### PR TITLE
Removed utility on exhaust, re-added auto weapon switching

### DIFF
--- a/mp/game/neo/scripts/weapon_grenade.txt
+++ b/mp/game/neo/scripts/weapon_grenade.txt
@@ -17,7 +17,7 @@ WeaponData
 
 	"primary_ammo"			"AMMO_GRENADE"
 	"secondary_ammo"		"None"
-	"autoswitchfrom"        "0"
+	"autoswitchfrom"        "1"
 
 	"weight"			"1"
 	"item_flags"			"18"	// ITEM_FLAG_NOAUTORELOAD | ITEM_FLAG_EXHAUSTIBLE

--- a/mp/game/neo/scripts/weapon_knife.txt
+++ b/mp/game/neo/scripts/weapon_knife.txt
@@ -14,6 +14,8 @@ WeaponData
 	"clip_size"				"-1"
 	"primary_ammo"			"None"
 	"secondary_ammo"		"None"
+	"MeleeWeapon"			"1"
+	"autoswitchto"			"1"
 
 	"weight"				"0"
 	"item_flags"			"0"

--- a/mp/game/neo/scripts/weapon_remotedet.txt
+++ b/mp/game/neo/scripts/weapon_remotedet.txt
@@ -18,6 +18,7 @@ WeaponData
 	"clip_size"		"1"
 	"primary_ammo"		"AMMO_DETPACK"
 	"secondary_ammo"	"None"
+	"autoswitchfrom"        "1"
 
 	"weight"		"1"
 	"item_flags"		"0"

--- a/mp/game/neo/scripts/weapon_smokegrenade.txt
+++ b/mp/game/neo/scripts/weapon_smokegrenade.txt
@@ -16,6 +16,7 @@ WeaponData
 
 	"primary_ammo"			"AMMO_SMOKEGRENADE"
 	"secondary_ammo"		"None"
+	"autoswitchfrom"        "1"
 
 	"weight"			"1"
 	"item_flags"			"18"	// ITEM_FLAG_NOAUTORELOAD | ITEM_FLAG_EXHAUSTIBLE

--- a/mp/src/game/shared/basecombatcharacter_shared.cpp
+++ b/mp/src/game/shared/basecombatcharacter_shared.cpp
@@ -24,6 +24,13 @@ bool CBaseCombatCharacter::SwitchToNextBestWeapon(CBaseCombatWeapon *pCurrent)
 	
 	if ( ( pNewWeapon != NULL ) && ( pNewWeapon != pCurrent ) )
 	{
+#ifndef CLIENT_DLL
+		// If current weapon is exhaustible, remove it
+		if ((pCurrent->GetWeaponFlags() & ITEM_FLAG_EXHAUSTIBLE) != false) {
+			UTIL_Remove(pCurrent);
+		}
+#endif // !CLIENT_DLL
+
 		return Weapon_Switch( pNewWeapon );
 	}
 


### PR DESCRIPTION
Grenades, smoke grenades and det-packs are now removed from the players inventory once they run out of ammunition, allowing for more of these items to be picked up either off of the ground or through the give weapon_x command