### PR TITLE
Removed cannot find neopath messages on windows application shutdown

### DIFF
--- a/mp/src/game/shared/neo/neo_mount_original.h
+++ b/mp/src/game/shared/neo/neo_mount_original.h
@@ -345,10 +345,10 @@ some Neotokyo assets may not load correctly!\n", szThisCaller);
 // Helper override when you don't have a constructed neoPath at hand.
 void FixIncompatibleNeoAssets(IFileSystem* filesystem, bool restoreInstead)
 {
-	const char* szThisCaller = "FixIncompatibleNeoAssets";
 	char neoPath[MAX_PATH];
 	bool originalNtPathOk = false;
 #ifdef LINUX
+	const char* szThisCaller = "FixIncompatibleNeoAssets";
 	const bool callerIsClientDll = false; // always server here. should refactor this stuff later.
 
 	// The NeotokyoSource root asset folder should exist (or be symlinked) to one of these paths,
@@ -436,50 +436,11 @@ void FixIncompatibleNeoAssets(IFileSystem* filesystem, bool restoreInstead)
         }
 	}
 #else
-
-	const char* noNeoPathId = "0";
-	Q_strncpy(neoPath, CommandLine()->ParmValue(NEO_PATH_PARM_CMD, noNeoPathId), sizeof(neoPath));
-
-	// There was no NEO_PATH_PARM_CMD provided
-	if (!*neoPath || FStrEq(neoPath, noNeoPathId))
-	{
-		// User has Steam running, use it to deduce the NT path.
-		if (SteamAPI_IsSteamRunning())
-		{
-			originalNtPathOk = IsNeoGameInfoPathOK(neoPath, sizeof(neoPath));
-		}
-		else
-		{
-			// We don't have Steam running, and there is no NEO_PATH_PARM_CMD specified.
-			// This is a failure state on Windows.
-			originalNtPathOk = false;
-		}
-	}
-	/// There is a NEO_PATH_PARM_CMD
-	else
-	{
-		// Make sure the path is valid
-		if (filesystem->IsDirectory(neoPath))
-		{
-			// Make sure there's actually a GameInfo.txt in the path, otherwise we will crash on mount.
-			// We make the assumption that any GameInfo.txt found will be valid format.
-			char gameInfoPath[MAX_PATH];
-			V_strcpy_safe(gameInfoPath, neoPath);
-			V_AppendSlash(gameInfoPath, sizeof(gameInfoPath));
-			V_strcat(gameInfoPath, "GameInfo.txt", sizeof(gameInfoPath));
-
-			originalNtPathOk = filesystem->FileExists(gameInfoPath);
-		}
-
-		// NEO TODO (Rain): check reg entries:
-		//	HKEY_LOCAL_MACHINE\SOFTWARE\Valve\Steam (32bit) and HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Valve\Steam (64bit)
-		// for a Steam installation as fallback on client systems.
-	}
-
+	originalNtPathOk = IsNeoGameInfoPathOK(neoPath, sizeof(neoPath));
 #endif
 	if (!originalNtPathOk)
 	{
-		Error("%s: Failed to retrieve Neo path\n", szThisCaller);
+		// Error("%s: Failed to retrieve Neo path\n", szThisCaller);
 	}
 	else
 	{


### PR DESCRIPTION
Fix the silly "cannot find neopath" error message when closing the game on windows