### PR TITLE
Weapon Handling in multiplayer work-around

### DIFF
--- a/mp/src/game/shared/baseentity_shared.cpp
+++ b/mp/src/game/shared/baseentity_shared.cpp
@@ -1766,7 +1766,7 @@ void CBaseEntity::FireBullets( const FireBulletsInfo_t &info )
 		}
 		else
 		{
-#ifndef NEO
+#ifdef NEO
 			// Don't run the biasing code for the player at the moment.
 			vecDir = Manipulator.ApplySpread( info.m_vecSpread );
 #else


### PR DESCRIPTION
Disabling some client biasing code to make fully automatic weapons usable when playing with ping