### PR TITLE
Configurable FOV/Field of view, new convar: neo_fov

### DIFF
--- a/mp/src/game/client/c_baseplayer.h
+++ b/mp/src/game/client/c_baseplayer.h
@@ -158,6 +158,10 @@ public:
 	void ResetObserverMode();
 	bool IsBot( void ) const { return false; }
 
+#ifdef NEO
+	int ClientFOV() const;
+#endif
+
 	// Eye position..
 	virtual Vector		 EyePosition();
 	virtual const QAngle &EyeAngles();		// Direction of eyes

--- a/mp/src/game/client/hl2/hl2_clientmode.cpp
+++ b/mp/src/game/client/hl2/hl2_clientmode.cpp
@@ -14,7 +14,7 @@
 #include "tier0/memdbgon.h"
 
 // default FOV for HL2
-ConVar default_fov( "default_fov", "75", FCVAR_CHEAT );
+ConVar default_fov( "default_fov", "90", FCVAR_CHEAT );
 
 // The current client mode. Always ClientModeNormal in HL.
 IClientMode *g_pClientMode = NULL;

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -79,6 +79,7 @@ IMPLEMENT_CLIENTCLASS_DT(C_NEO_Player, DT_NEO_Player, CNEO_Player)
 
 	RecvPropTime(RECVINFO(m_flCamoAuxLastTime)),
 	RecvPropInt(RECVINFO(m_nVisionLastTick)),
+	RecvPropInt(RECVINFO(m_nNeoFOV)),
 
 	RecvPropArray(RecvPropVector(RECVINFO(m_rvFriendlyPlayerPositions[0])), m_rvFriendlyPlayerPositions),
 	RecvPropArray(RecvPropFloat(RECVINFO(m_rfAttackersScores[0])), m_rfAttackersScores),
@@ -101,6 +102,7 @@ BEGIN_PREDICTION_DATA(C_NEO_Player)
 	DEFINE_PRED_FIELD(m_bHasBeenAirborneForTooLongToSuperJump, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE),
 
 	DEFINE_PRED_FIELD(m_nVisionLastTick, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),
+	DEFINE_PRED_FIELD(m_nNeoFOV, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),
 END_PREDICTION_DATA()
 
 ConVar cl_drawhud_quickinfo("cl_drawhud_quickinfo", "0", 0,
@@ -310,6 +312,7 @@ C_NEO_Player::C_NEO_Player()
 
 	m_flCamoAuxLastTime = 0;
 	m_nVisionLastTick = 0;
+	m_nNeoFOV = DEFAULT_FOV;
 	m_flLastAirborneJumpOkTime = 0;
 	m_flLastSuperJumpTime = 0;
 
@@ -1267,18 +1270,19 @@ void C_NEO_Player::Weapon_SetZoom(const bool bZoomIn)
 #endif
 #endif
 
+	const int fov = GetDefaultFOV();
 	if (bZoomIn)
 	{
 		m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
 
 		const int zoomAmount = 30;
-		SetFOV((CBaseEntity*)this, GetDefaultFOV() - zoomAmount, zoomSpeedSecs);
+		SetFOV((CBaseEntity*)this, fov - zoomAmount, zoomSpeedSecs);
 	}
 	else
 	{
 		m_Local.m_iHideHUD |= HIDEHUD_CROSSHAIR;
 
-		SetFOV((CBaseEntity*)this, GetDefaultFOV(), zoomSpeedSecs);
+		SetFOV((CBaseEntity*)this, fov, zoomSpeedSecs);
 	}
 
 	m_bInAim = bZoomIn;

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -79,7 +79,6 @@ IMPLEMENT_CLIENTCLASS_DT(C_NEO_Player, DT_NEO_Player, CNEO_Player)
 
 	RecvPropTime(RECVINFO(m_flCamoAuxLastTime)),
 	RecvPropInt(RECVINFO(m_nVisionLastTick)),
-	RecvPropInt(RECVINFO(m_nNeoFOV)),
 
 	RecvPropArray(RecvPropVector(RECVINFO(m_rvFriendlyPlayerPositions[0])), m_rvFriendlyPlayerPositions),
 	RecvPropArray(RecvPropFloat(RECVINFO(m_rfAttackersScores[0])), m_rfAttackersScores),
@@ -102,7 +101,6 @@ BEGIN_PREDICTION_DATA(C_NEO_Player)
 	DEFINE_PRED_FIELD(m_bHasBeenAirborneForTooLongToSuperJump, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE),
 
 	DEFINE_PRED_FIELD(m_nVisionLastTick, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),
-	DEFINE_PRED_FIELD(m_nNeoFOV, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),
 END_PREDICTION_DATA()
 
 ConVar cl_drawhud_quickinfo("cl_drawhud_quickinfo", "0", 0,
@@ -312,7 +310,6 @@ C_NEO_Player::C_NEO_Player()
 
 	m_flCamoAuxLastTime = 0;
 	m_nVisionLastTick = 0;
-	m_nNeoFOV = DEFAULT_FOV;
 	m_flLastAirborneJumpOkTime = 0;
 	m_flLastSuperJumpTime = 0;
 

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -189,7 +189,6 @@ public:
 
 	CNetworkVar(float, m_flCamoAuxLastTime);
 	CNetworkVar(int, m_nVisionLastTick);
-	CNetworkVar(int, m_nNeoFOV);
 
 	CNetworkVector(m_vecGhostMarkerPos);
 

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -189,6 +189,7 @@ public:
 
 	CNetworkVar(float, m_flCamoAuxLastTime);
 	CNetworkVar(int, m_nVisionLastTick);
+	CNetworkVar(int, m_nNeoFOV);
 
 	CNetworkVector(m_vecGhostMarkerPos);
 

--- a/mp/src/game/client/view.cpp
+++ b/mp/src/game/client/view.cpp
@@ -848,7 +848,7 @@ void CViewRender::SetUpViews()
 
 	//Adjust the viewmodel's FOV to move with any FOV offsets on the viewer's end
 #ifdef SDK2013CE
-#ifdef NEO // Decouple viewmodel FOV from view FOV.
+#ifdef NEO // Viewmodel FOV determined by multiplier from default FOV off its own FOV
 	float fovMultiplier = view.fov / static_cast<float>(DEFAULT_FOV);
 	view.fovViewmodel = g_pClientMode->GetViewModelFOV() * fovMultiplier;
 #else

--- a/mp/src/game/client/view.cpp
+++ b/mp/src/game/client/view.cpp
@@ -840,14 +840,16 @@ void CViewRender::SetUpViews()
 		}
 	}
 
+#ifndef NEO
 	//Find the offset our current FOV is from the default value
 	float fDefaultFov = default_fov.GetFloat();
 	float flFOVOffset = fDefaultFov - view.fov;
+#endif
 
 	//Adjust the viewmodel's FOV to move with any FOV offsets on the viewer's end
 #ifdef SDK2013CE
 #ifdef NEO // Decouple viewmodel FOV from view FOV.
-	float fovMultiplier = view.fov / fDefaultFov;
+	float fovMultiplier = view.fov / static_cast<float>(DEFAULT_FOV);
 	view.fovViewmodel = g_pClientMode->GetViewModelFOV() * fovMultiplier;
 #else
 	view.fovViewmodel = fabs(g_pClientMode->GetViewModelFOV() - flFOVOffset);
@@ -860,11 +862,13 @@ void CViewRender::SetUpViews()
 	{
 		// Let the headtracking read the status of the HMD, etc.
 		// This call can go almost anywhere, but it needs to know the player FOV for sniper weapon zoom, etc
+#ifndef NEO
 		if ( flFOVOffset == 0.0f )
 		{
 			g_ClientVirtualReality.ProcessCurrentTrackingState ( 0.0f );
 		}
 		else
+#endif
 		{
 			g_ClientVirtualReality.ProcessCurrentTrackingState ( view.fov );
 		}

--- a/mp/src/game/client/view.cpp
+++ b/mp/src/game/client/view.cpp
@@ -71,6 +71,10 @@ bool ToolFramework_SetupEngineMicrophone( Vector &origin, QAngle &angles );
 extern ConVar default_fov;
 extern bool g_bRenderingScreenshot;
 
+#ifdef NEO
+extern ConVar neo_fov;
+#endif
+
 #if !defined( _X360 )
 #define SAVEGAME_SCREENSHOT_WIDTH	180
 #define SAVEGAME_SCREENSHOT_HEIGHT	100
@@ -752,7 +756,11 @@ void CViewRender::SetUpViews()
 	//  closest point of approach seems to be view center to top of crouched box
 	view.zNear			    = GetZNear();
 	view.zNearViewmodel	    = 1;
+#ifndef NEO
 	view.fov = default_fov.GetFloat();
+#else
+	view.fov = neo_fov.GetFloat();
+#endif
 
 	view.m_bOrtho			= false;
     view.m_bViewToProjectionOverride = false;
@@ -839,7 +847,8 @@ void CViewRender::SetUpViews()
 	//Adjust the viewmodel's FOV to move with any FOV offsets on the viewer's end
 #ifdef SDK2013CE
 #ifdef NEO // Decouple viewmodel FOV from view FOV.
-	view.fovViewmodel = g_pClientMode->GetViewModelFOV();
+	float fovMultiplier = view.fov / fDefaultFov;
+	view.fovViewmodel = g_pClientMode->GetViewModelFOV() * fovMultiplier;
 #else
 	view.fovViewmodel = fabs(g_pClientMode->GetViewModelFOV() - flFOVOffset);
 #endif

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -64,6 +64,7 @@ SendPropBool(SENDINFO(m_bDroppedAnything)),
 
 SendPropTime(SENDINFO(m_flCamoAuxLastTime)),
 SendPropInt(SENDINFO(m_nVisionLastTick)),
+SendPropInt(SENDINFO(m_nNeoFOV)),
 
 SendPropString(SENDINFO(m_pszTestMessage)),
 
@@ -105,6 +106,7 @@ DEFINE_FIELD(m_rvFriendlyPlayerPositions, FIELD_CUSTOM),
 DEFINE_FIELD(m_rfAttackersScores, FIELD_CUSTOM),
 
 DEFINE_FIELD(m_NeoFlags, FIELD_CHARACTER),
+DEFINE_FIELD(m_nNeoFOV, FIELD_INTEGER),
 END_DATADESC()
 
 CBaseEntity *g_pLastJinraiSpawn, *g_pLastNSFSpawn;
@@ -385,6 +387,7 @@ CNEO_Player::CNEO_Player()
 	m_nVisionLastTick = 0;
 	m_flLastAirborneJumpOkTime = 0;
 	m_flLastSuperJumpTime = 0;
+	m_nNeoFOV = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(edict()), "neo_fov"));
 
 	m_bFirstDeathTick = true;
 	m_bPreviouslyReloading = false;
@@ -493,6 +496,7 @@ void CNEO_Player::Spawn(void)
 	m_bInVision = false;
 	m_nVisionLastTick = 0;
 	m_bInLean = NEO_LEAN_NONE;
+	m_nNeoFOV = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(edict()), "neo_fov"));
 
 	for (int i = 0; i < m_rfAttackersScores.Count(); ++i)
 	{
@@ -1142,15 +1146,27 @@ void CNEO_Player::Weapon_SetZoom(const bool bZoomIn)
 	const float zoomSpeedSecs = 0.25f;
 
 	ShowCrosshair(bZoomIn);
+
+	int checkFov = DEFAULT_FOV;
+	if (!(GetFlags() & FL_FAKECLIENT))
+	{
+		checkFov = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(edict()), "neo_fov"));
+	}
+
+	if (checkFov != m_nNeoFOV)
+	{
+		m_nNeoFOV = checkFov;
+	}
 	
+	const int fov = GetDefaultFOV();
 	if (bZoomIn)
 	{
 		const int zoomAmount = 30;
-		SetFOV((CBaseEntity*)this, GetDefaultFOV() - zoomAmount, zoomSpeedSecs);
+		SetFOV((CBaseEntity*)this, fov - zoomAmount, zoomSpeedSecs);
 	}
 	else
 	{
-		SetFOV((CBaseEntity*)this, GetDefaultFOV(), zoomSpeedSecs);
+		SetFOV((CBaseEntity*)this, fov, zoomSpeedSecs);
 	}
 
 	m_bInAim = bZoomIn;

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -64,7 +64,6 @@ SendPropBool(SENDINFO(m_bDroppedAnything)),
 
 SendPropTime(SENDINFO(m_flCamoAuxLastTime)),
 SendPropInt(SENDINFO(m_nVisionLastTick)),
-SendPropInt(SENDINFO(m_nNeoFOV)),
 
 SendPropString(SENDINFO(m_pszTestMessage)),
 
@@ -106,7 +105,6 @@ DEFINE_FIELD(m_rvFriendlyPlayerPositions, FIELD_CUSTOM),
 DEFINE_FIELD(m_rfAttackersScores, FIELD_CUSTOM),
 
 DEFINE_FIELD(m_NeoFlags, FIELD_CHARACTER),
-DEFINE_FIELD(m_nNeoFOV, FIELD_INTEGER),
 END_DATADESC()
 
 CBaseEntity *g_pLastJinraiSpawn, *g_pLastNSFSpawn;
@@ -387,7 +385,6 @@ CNEO_Player::CNEO_Player()
 	m_nVisionLastTick = 0;
 	m_flLastAirborneJumpOkTime = 0;
 	m_flLastSuperJumpTime = 0;
-	m_nNeoFOV = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(edict()), "neo_fov"));
 
 	m_bFirstDeathTick = true;
 	m_bPreviouslyReloading = false;
@@ -496,7 +493,6 @@ void CNEO_Player::Spawn(void)
 	m_bInVision = false;
 	m_nVisionLastTick = 0;
 	m_bInLean = NEO_LEAN_NONE;
-	m_nNeoFOV = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(edict()), "neo_fov"));
 
 	for (int i = 0; i < m_rfAttackersScores.Count(); ++i)
 	{
@@ -1146,17 +1142,6 @@ void CNEO_Player::Weapon_SetZoom(const bool bZoomIn)
 	const float zoomSpeedSecs = 0.25f;
 
 	ShowCrosshair(bZoomIn);
-
-	int checkFov = DEFAULT_FOV;
-	if (!(GetFlags() & FL_FAKECLIENT))
-	{
-		checkFov = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(edict()), "neo_fov"));
-	}
-
-	if (checkFov != m_nNeoFOV)
-	{
-		m_nNeoFOV = checkFov;
-	}
 	
 	const int fov = GetDefaultFOV();
 	if (bZoomIn)

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -463,6 +463,11 @@ void CNEO_Player::UpdateNetworkedFriendlyLocations()
 	}
 }
 
+void CNEO_Player::SetDefaultFOV(const int fov)
+{
+	m_iDefaultFOV.Set(fov);
+}
+
 void CNEO_Player::Precache( void )
 {
 	BaseClass::Precache();

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -116,6 +116,8 @@ public:
 
 	void UpdateNetworkedFriendlyLocations(void);
 
+	void SetDefaultFOV(const int fov);
+
 	void Weapon_AimToggle(CBaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType);
 	void Weapon_AimToggle(CNEOBaseCombatWeapon* pWep, const NeoWeponAimToggleE toggleType);
 

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -214,7 +214,6 @@ public:
 
 	CNetworkVar(float, m_flCamoAuxLastTime);
 	CNetworkVar(int, m_nVisionLastTick);
-	CNetworkVar(int, m_nNeoFOV);
 
 	CNetworkArray(Vector, m_rvFriendlyPlayerPositions, MAX_PLAYERS);
 	CNetworkArray(float, m_rfAttackersScores, (MAX_PLAYERS + 1));

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -214,6 +214,7 @@ public:
 
 	CNetworkVar(float, m_flCamoAuxLastTime);
 	CNetworkVar(int, m_nVisionLastTick);
+	CNetworkVar(int, m_nNeoFOV);
 
 	CNetworkArray(Vector, m_rvFriendlyPlayerPositions, MAX_PLAYERS);
 	CNetworkArray(float, m_rfAttackersScores, (MAX_PLAYERS + 1));

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -84,7 +84,6 @@
 
 #ifdef NEO
 #include "neo_player.h"
-extern int ClientFOV(const CBasePlayer* player);
 #endif
 
 ConVar autoaim_max_dist( "autoaim_max_dist", "2160" ); // 2160 = 180 feet
@@ -597,7 +596,7 @@ CBasePlayer::CBasePlayer( )
 #ifndef NEO
 	m_iDefaultFOV = g_pGameRules->DefaultFOV();
 #else
-	m_iDefaultFOV = ClientFOV(this);
+	m_iDefaultFOV = ClientFOV();
 #endif
 
 	m_hZoomOwner = NULL;
@@ -8636,7 +8635,8 @@ void CBasePlayer::SetDefaultFOV( int FOV )
 #ifndef NEO
 	m_iDefaultFOV = ( FOV == 0 ) ? g_pGameRules->DefaultFOV() : FOV;
 #else
-	m_iDefaultFOV = ClientFOV(this);
+	(void)FOV;	// Unused - Override to take from ClientFOV instead
+	m_iDefaultFOV = ClientFOV();
 #endif
 }
 

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -84,6 +84,7 @@
 
 #ifdef NEO
 #include "neo_player.h"
+extern int ClientFOV(const CBasePlayer* player);
 #endif
 
 ConVar autoaim_max_dist( "autoaim_max_dist", "2160" ); // 2160 = 180 feet
@@ -593,7 +594,11 @@ CBasePlayer::CBasePlayer( )
 	m_qangLockViewangles.Init();
 
 	// Setup our default FOV
+#ifndef NEO
 	m_iDefaultFOV = g_pGameRules->DefaultFOV();
+#else
+	m_iDefaultFOV = ClientFOV(this);
+#endif
 
 	m_hZoomOwner = NULL;
 
@@ -8628,7 +8633,11 @@ float CBasePlayer::GetFOVDistanceAdjustFactorForNetworking()
 //-----------------------------------------------------------------------------
 void CBasePlayer::SetDefaultFOV( int FOV )
 {
+#ifndef NEO
 	m_iDefaultFOV = ( FOV == 0 ) ? g_pGameRules->DefaultFOV() : FOV;
+#else
+	m_iDefaultFOV = ClientFOV(this);
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/mp/src/game/server/player.h
+++ b/mp/src/game/server/player.h
@@ -956,9 +956,7 @@ protected:
 
 	CNetworkVar( int, m_iObserverMode );	// if in spectator mode != 0
 	CNetworkVar( int,	m_iFOV );			// field of view
-public:
 	CNetworkVar( int,	m_iDefaultFOV );	// default field of view
-protected:
 	CNetworkVar( int,	m_iFOVStart );		// What our FOV started at
 	CNetworkVar( float,	m_flFOVTime );		// Time our FOV change started
 	

--- a/mp/src/game/server/player.h
+++ b/mp/src/game/server/player.h
@@ -739,6 +739,10 @@ public:
 	int		GetLockViewanglesTickNumber() const { return m_iLockViewanglesTickNumber; }
 	QAngle	GetLockViewanglesData() const { return m_qangLockViewangles; }
 
+#ifdef NEO
+	int ClientFOV() const;
+#endif
+
 	int		GetFOV( void );														// Get the current FOV value
 	int		GetDefaultFOV( void ) const;										// Default FOV if not specified otherwise
 	int		GetFOVForNetworking( void );										// Get the current FOV used for network computations

--- a/mp/src/game/server/player.h
+++ b/mp/src/game/server/player.h
@@ -952,7 +952,9 @@ protected:
 
 	CNetworkVar( int, m_iObserverMode );	// if in spectator mode != 0
 	CNetworkVar( int,	m_iFOV );			// field of view
+public:
 	CNetworkVar( int,	m_iDefaultFOV );	// default field of view
+protected:
 	CNetworkVar( int,	m_iFOVStart );		// What our FOV started at
 	CNetworkVar( float,	m_flFOVTime );		// Time our FOV change started
 	

--- a/mp/src/game/shared/baseplayer_shared.cpp
+++ b/mp/src/game/shared/baseplayer_shared.cpp
@@ -100,6 +100,10 @@
 ConVar mp_usehwmmodels( "mp_usehwmmodels", "0", NULL, "Enable the use of the hw morph models. (-1 = never, 1 = always, 0 = based upon GPU)" ); // -1 = never, 0 = if hasfastvertextextures, 1 = always
 #endif
 
+#ifdef NEO
+ConVar neo_fov("neo_fov", "90", FCVAR_USERINFO, "Set the normal FOV.", true, 60.0f, true, (float)(MAX_FOV));
+#endif
+
 bool UseHWMorphModels()
 {
 // #ifdef CLIENT_DLL 
@@ -1889,6 +1893,26 @@ void CBasePlayer::SharedSpawn()
 #endif
 }
 
+#ifdef NEO
+int ClientFOV(const CBasePlayer* player)
+{
+	int fov = DEFAULT_FOV;
+	int type = 0;
+#ifdef CLIENT_DLL
+	//fov = neo_fov.GetFloat();
+	fov = player->m_iDefaultFOV;
+	type = 1;
+#else
+	if (player && !(player->GetFlags() & FL_FAKECLIENT))
+	{
+		fov = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(player->edict()), "neo_fov"));
+	}
+	type = 2;
+#endif
+	return fov;
+}
+#endif
+
 
 //-----------------------------------------------------------------------------
 // Purpose: 
@@ -1908,7 +1932,11 @@ int CBasePlayer::GetDefaultFOV( void ) const
 	}
 #endif
 
+#ifndef NEO
 	int iFOV = ( m_iDefaultFOV == 0 ) ? g_pGameRules->DefaultFOV() : m_iDefaultFOV;
+#else
+	int iFOV = ClientFOV(this);
+#endif
 	if ( iFOV > MAX_FOV )
 		iFOV = MAX_FOV;
 

--- a/mp/src/game/shared/baseplayer_shared.cpp
+++ b/mp/src/game/shared/baseplayer_shared.cpp
@@ -1894,20 +1894,18 @@ void CBasePlayer::SharedSpawn()
 }
 
 #ifdef NEO
-int ClientFOV(const CBasePlayer* player)
+int CBasePlayer::ClientFOV() const
 {
 	int fov = DEFAULT_FOV;
-	int type = 0;
 #ifdef CLIENT_DLL
-	//fov = neo_fov.GetFloat();
-	fov = player->m_iDefaultFOV;
-	type = 1;
+	// neo_fov.GetFloat() doesn't work, so utilize m_iDefaultFOV
+	fov = m_iDefaultFOV;
 #else
-	if (player && !(player->GetFlags() & FL_FAKECLIENT))
+	if (!(GetFlags() & FL_FAKECLIENT))
 	{
-		fov = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(player->edict()), "neo_fov"));
+		// NOTE (nullsystem): Think this only called once in a while so not too bad
+		fov = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(edict()), "neo_fov"));
 	}
-	type = 2;
 #endif
 	return fov;
 }
@@ -1935,7 +1933,7 @@ int CBasePlayer::GetDefaultFOV( void ) const
 #ifndef NEO
 	int iFOV = ( m_iDefaultFOV == 0 ) ? g_pGameRules->DefaultFOV() : m_iDefaultFOV;
 #else
-	int iFOV = ClientFOV(this);
+	int iFOV = ClientFOV();
 #endif
 	if ( iFOV > MAX_FOV )
 		iFOV = MAX_FOV;

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -22,6 +22,8 @@
 	#include "inetchannelinfo.h"
 #endif
 
+extern int ClientFOV(const CBasePlayer* player);
+
 ConVar mp_neo_loopback_warmup_round("mp_neo_loopback_warmup_round", "0", FCVAR_REPLICATED, "Allow loopback server to do warmup rounds.", true, 0.0f, true, 1.0f);
 ConVar mp_neo_warmup_round_time("mp_neo_warmup_round_time", "45", FCVAR_REPLICATED, "The warmup round time, in seconds.", true, 0.0f, false, 0.0f);
 ConVar mp_neo_preround_freeze_time("mp_neo_preround_freeze_time", "10", FCVAR_REPLICATED, "The pre-round freeze time, in seconds.", true, 0.0, false, 0);
@@ -349,6 +351,15 @@ void CNEORules::ClientSpawned(edict_t* pPlayer)
 		player->m_bShowClassMenu = true;
 	}
 #endif
+#endif
+}
+
+int CNEORules::DefaultFOV(void)
+{
+#ifdef CLIENT_DLL
+	return ClientFOV(C_NEO_Player::GetLocalNEOPlayer());
+#else
+	return 90;
 #endif
 }
 
@@ -1296,6 +1307,7 @@ void CNEORules::ClientSettingsChanged(CBasePlayer *pPlayer)
 	{
 		pNEOPlayer->SetPlayerTeamModel();
 	}
+	pNEOPlayer->m_iDefaultFOV = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(pNEOPlayer->edict()), "neo_fov"));
 
 	// We're skipping calling the base CHL2MPRules method here
 	CTeamplayRules::ClientSettingsChanged(pPlayer);

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -1305,7 +1305,7 @@ void CNEORules::ClientSettingsChanged(CBasePlayer *pPlayer)
 	{
 		pNEOPlayer->SetPlayerTeamModel();
 	}
-	pNEOPlayer->m_iDefaultFOV = atoi(engine->GetClientConVarValue(engine->IndexOfEdict(pNEOPlayer->edict()), "neo_fov"));
+	pNEOPlayer->SetDefaultFOV(pNEOPlayer->ClientFOV());
 
 	// We're skipping calling the base CHL2MPRules method here
 	CTeamplayRules::ClientSettingsChanged(pPlayer);

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -22,8 +22,6 @@
 	#include "inetchannelinfo.h"
 #endif
 
-extern int ClientFOV(const CBasePlayer* player);
-
 ConVar mp_neo_loopback_warmup_round("mp_neo_loopback_warmup_round", "0", FCVAR_REPLICATED, "Allow loopback server to do warmup rounds.", true, 0.0f, true, 1.0f);
 ConVar mp_neo_warmup_round_time("mp_neo_warmup_round_time", "45", FCVAR_REPLICATED, "The warmup round time, in seconds.", true, 0.0f, false, 0.0f);
 ConVar mp_neo_preround_freeze_time("mp_neo_preround_freeze_time", "10", FCVAR_REPLICATED, "The pre-round freeze time, in seconds.", true, 0.0, false, 0);
@@ -357,7 +355,7 @@ void CNEORules::ClientSpawned(edict_t* pPlayer)
 int CNEORules::DefaultFOV(void)
 {
 #ifdef CLIENT_DLL
-	return ClientFOV(C_NEO_Player::GetLocalNEOPlayer());
+	return C_NEO_Player::GetLocalNEOPlayer()->ClientFOV();
 #else
 	return 90;
 #endif

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -149,6 +149,8 @@ public:
 	;
 #endif
 
+	virtual int DefaultFOV(void) OVERRIDE;
+
 	float GetRemainingPreRoundFreezeTime(const bool clampToZero) const;
 
 	float GetMapRemainingTime();

--- a/mp/src/game/shared/shareddefs.h
+++ b/mp/src/game/shared/shareddefs.h
@@ -262,7 +262,12 @@ enum CastVote
 
 #define MAX_PLACE_NAME_LENGTH		18
 
+#ifdef NEO
+#define MAX_FOV						110
+#define DEFAULT_FOV					90
+#else
 #define MAX_FOV						90
+#endif
 
 //===================================================================================================================
 // Team Defines


### PR DESCRIPTION
* Most importantly, weapon switching shouldn't use pre-set fov default, because somehow convar isn't updated (client variable) even though it's updated (server and console recognizes)?????
* New convar: `neo_fov`, default 90, range 60-110