### PR TITLE
Warn if -tickrate is set

### DIFF
--- a/mp/src/game/server/gameinterface.cpp
+++ b/mp/src/game/server/gameinterface.cpp
@@ -858,10 +858,7 @@ float CServerGameDLL::GetTickInterval( void ) const
 	{
 #ifdef NEO
 		const int tickrateAsInt = CommandLine()->ParmValue("-tickrate", 0);
-		if (tickrateAsInt != 66)
-		{
-			Warning("WARNING: Server is only recommended to run at ~66 tickrate. Current tickrate: %d\n", tickrateAsInt);
-		}
+		Warning("WARNING: Setting -tickrate is not recommended. Server is only recommended to run at the default ~66.67 tickrate. Current tickrate: %d\n", tickrateAsInt);
 		const float tickrate = static_cast<float>(tickrateAsInt);
 #else
 		float tickrate = CommandLine()->ParmValue("-tickrate", 0);

--- a/mp/src/game/server/gameinterface.cpp
+++ b/mp/src/game/server/gameinterface.cpp
@@ -856,7 +856,16 @@ float CServerGameDLL::GetTickInterval( void ) const
 	// override if tick rate specified in command line
 	if ( CommandLine()->CheckParm( "-tickrate" ) )
 	{
-		float tickrate = CommandLine()->ParmValue( "-tickrate", 0 );
+#ifdef NEO
+		const int tickrateAsInt = CommandLine()->ParmValue("-tickrate", 0);
+		if (tickrateAsInt != 66)
+		{
+			Warning("WARNING: Server is only recommended to run at ~66 tickrate. Current tickrate: %d\n", tickrateAsInt);
+		}
+		const float tickrate = static_cast<float>(tickrateAsInt);
+#else
+		float tickrate = CommandLine()->ParmValue("-tickrate", 0);
+#endif
 		if ( tickrate > 10 )
 			tickinterval = 1.0f / tickrate;
 	}


### PR DESCRIPTION
If set to EX: 120, then the server will warn/log:
`WARNING: Setting -tickrate is not recommended. Server is only recommended to run at the default ~66.67 tickrate. Current tickrate: 120`