### PR TITLE
Team switching - Make it available as server convar, change defaults

### DIFF
--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -115,6 +115,8 @@ extern ConVar neo_sv_ignore_wep_xp_limit;
 
 ConVar sv_neo_can_change_classes_anytime("sv_neo_can_change_classes_anytime", "0", FCVAR_CHEAT | FCVAR_REPLICATED, "Can players change classes at any moment, even mid-round?",
 	true, 0.0f, true, 1.0f);
+ConVar sv_neo_change_suicide_player("sv_neo_change_suicide_player", "1", FCVAR_REPLICATED, "Kill the player if they change the team and they're alive.", true, 0.0f, true, 1.0f);
+ConVar sv_neo_change_threshold_interval("sv_neo_change_threshold_interval", "0.25", FCVAR_REPLICATED, "The interval threshold limit in seconds before the player is allowed to change team.", true, 0.0f, true, 1000.0f);
 
 void CNEO_Player::RequestSetClass(int newClass)
 {
@@ -1935,10 +1937,6 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 		return false;
 	}
 
-	// NEO TODO (Rain): add server cvars
-#define TEAM_CHANGE_SUICIDE true
-#define TEAM_CHANGE_INTERVAL 5.0f
-
 	const bool justJoined = (GetTeamNumber() == TEAM_UNASSIGNED);
 
 	// Player bots should initially join a player team.
@@ -1978,7 +1976,7 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 			return false;
 		}
 
-		if (TEAM_CHANGE_SUICIDE)
+		if (sv_neo_change_suicide_player.GetBool())
 		{
 			// Unassigned implies we just joined.
 			if (!justJoined && !IsDead())
@@ -2001,7 +1999,7 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 	}
 	else if (iTeam == TEAM_JINRAI || iTeam == TEAM_NSF)
 	{
-		if (TEAM_CHANGE_SUICIDE && !justJoined && GetTeamNumber() != TEAM_SPECTATOR && !IsDead())
+		if (sv_neo_change_suicide_player.GetBool() && !justJoined && GetTeamNumber() != TEAM_SPECTATOR && !IsDead())
 		{
 			SoftSuicide();
 		}
@@ -2022,7 +2020,7 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 		return false;
 	}
 
-	m_flNextTeamChangeTime = gpGlobals->curtime + TEAM_CHANGE_INTERVAL;
+	m_flNextTeamChangeTime = gpGlobals->curtime + sv_neo_change_threshold_interval.GetFloat();
 	
 	RemoveAllItems(true);
 	ShowCrosshair(false);


### PR DESCRIPTION
* Now available as server convars:
    * `sv_neo_change_suicide_player` - Default to 0/false
    * `sv_neo_change_threshold_interval` - Default of 0.25 seconds, down from previous 5 seconds
* Default `sv_neo_change_suicide_player` to false which was previously true. This also adds a functionality to prevent player change on player being alive.