### PR TITLE
Revert accidental code deletion - Ghost marker should be red on enemy

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -763,6 +763,7 @@ void C_NEO_Player::PreThink( void )
 
 					ghostMarker->SetScreenPosition(ghostMarkerX, ghostMarkerY);
 					ghostMarker->SetGhostingTeam(NEORules()->ghosterTeam());
+					ghostMarker->SetClientCurrentTeam(GetTeamNumber());
 					ghostMarker->SetGhostDistance(distance);
 				}
 				else

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
@@ -124,7 +124,7 @@ void CNEOHud_GhostBeacons::DrawNeoHudElement()
 		{
 			auto enemyPos = enemyToShow->GetAbsOrigin();
 			float distance;
-			if(ghost->IsPosWithinViewDistance(enemyPos, distance) && !enemyToShow->IsDormant())
+			if(enemyToShow->IsAlive() && ghost->IsPosWithinViewDistance(enemyPos, distance) && !enemyToShow->IsDormant())
 			{
 				DrawPlayer(enemyPos);
 			}

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
@@ -31,6 +31,7 @@ CNEOHud_GhostMarker::CNEOHud_GhostMarker(const char* pElemName, vgui::Panel* par
 	m_flDistMeters = 0;
 
 	m_iGhostingTeam = TEAM_UNASSIGNED;
+	m_iClientTeam = TEAM_UNASSIGNED;
 	m_iPosX = m_iPosY = 0;
 
 	{
@@ -113,9 +114,22 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 	const int offset_X = m_iPosX - ((m_iMarkerTexWidth * 0.5f) * scale);
 	const int offset_Y = m_iPosY - ((m_iMarkerTexHeight * 0.5f) * scale);
 
-	auto color = m_iGhostingTeam == TEAM_JINRAI ? COLOR_JINRAI : (m_iGhostingTeam == TEAM_NSF ? COLOR_NSF : COLOR_GREY);
+	Color ghostColor = COLOR_GREY;
+	if (m_iGhostingTeam == TEAM_JINRAI || m_iGhostingTeam == TEAM_NSF)
+	{
+		if ((m_iClientTeam == TEAM_JINRAI || m_iClientTeam == TEAM_NSF) && (m_iClientTeam != m_iGhostingTeam))
+		{
+			// If viewing from playing player, but opposite of ghosting team, show red
+			ghostColor = COLOR_RED;
+		}
+		else
+		{
+			// Otherwise show ghosting team color (if friendly or spec)
+			ghostColor = (m_iGhostingTeam == TEAM_JINRAI) ? COLOR_JINRAI : COLOR_NSF;
+		}
+	}
 
-	surface()->DrawSetColor(color);
+	surface()->DrawSetColor(ghostColor);
 	surface()->DrawSetTexture(m_hTex);
 	surface()->DrawTexturedRect(
 		offset_X,
@@ -135,6 +149,11 @@ void CNEOHud_GhostMarker::Paint()
 void CNEOHud_GhostMarker::SetGhostingTeam(int team)
 {
 	m_iGhostingTeam = team;
+}
+
+void CNEOHud_GhostMarker::SetClientCurrentTeam(int team)
+{
+	m_iClientTeam = team;
 }
 
 void CNEOHud_GhostMarker::SetScreenPosition(int x, int y)

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_marker.h
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_marker.h
@@ -20,6 +20,7 @@ public:
 	virtual void Paint();
 
 	void SetGhostingTeam(int team);
+	void SetClientCurrentTeam(int team);
 	void SetScreenPosition(int x, int y);
 	void SetGhostDistance(float distance);
 
@@ -32,6 +33,7 @@ private:
 	int m_iMarkerTexWidth, m_iMarkerTexHeight;
 	int m_iPosX, m_iPosY;
 	int m_iGhostingTeam;
+	int m_iClientTeam;
 
 	char m_szMarkerText[12 + 1];
 	wchar_t m_wszMarkerTextUnicode[12 + 1];


### PR DESCRIPTION
Dunno why this part of the code got deleted during the hud/positioning change