### PR TITLE
Observer on demand

### DIFF
--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1116,6 +1116,10 @@ void CNEO_Player::PostThink(void)
 
 void CNEO_Player::PlayerDeathThink()
 {
+	if (m_nButtons & ~IN_SCORE)
+	{
+		m_bEnterObserver = true;
+	}
 	BaseClass::PlayerDeathThink();
 }
 
@@ -1599,10 +1603,10 @@ void CNEO_Player::Event_Killed( const CTakeDamageInfo &info )
 
 	BaseClass::Event_Killed(info);
 
-	m_bEnterObserver = true;
+	//m_bEnterObserver = true;
 	StartObserverMode(OBS_MODE_CHASE);
 	RemoveAllWeapons();
-	ShowViewPortPanel(PANEL_SPECGUI, true);
+	//ShowViewPortPanel(PANEL_SPECGUI, true);
 }
 
 int CNEO_Player::GetDeadModel()

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1603,10 +1603,7 @@ void CNEO_Player::Event_Killed( const CTakeDamageInfo &info )
 
 	BaseClass::Event_Killed(info);
 
-	//m_bEnterObserver = true;
-	StartObserverMode(OBS_MODE_CHASE);
 	RemoveAllWeapons();
-	//ShowViewPortPanel(PANEL_SPECGUI, true);
 }
 
 int CNEO_Player::GetDeadModel()

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -2152,6 +2152,7 @@ void CBasePlayer::PlayerDeathThink(void)
 		fAnyButtonDown &= ~IN_DUCK;
 	}
 
+#ifndef NEO
 	// wait for all buttons released
 	if (m_lifeState == LIFE_DEAD)
 	{
@@ -2162,10 +2163,10 @@ void CBasePlayer::PlayerDeathThink(void)
 		{
 			m_lifeState = LIFE_RESPAWNABLE;
 		}
-		
+
 		return;
 	}
-
+#endif
 // if the player has been dead for one second longer than allowed by forcerespawn, 
 // forcerespawn isn't on. Send the player off to an intermission camera until they 
 // choose to respawn.


### PR DESCRIPTION
disables some hl2dm code in player death think that meant code to check if player should respawn or enter observer mode was never reached. Also now listening for player input before entering observer mode, can enter observer mode no earlier then after the death animation time is over (about 3 seconds)