### PR TITLE
Damage + hits + killer info on death/round end

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -178,7 +178,7 @@ static void __MsgFunc_DamageInfo(bf_read& msg)
 
 			static char infoLine[128];
 			DmgLineStr(infoLine, sizeof(infoLine), dmgerName, dmgerClass,
-				dmgTo, dmgFrom, hitsTo, hitsFrom, true);
+				dmgTo, dmgFrom, hitsTo, hitsFrom);
 			ConMsg("%s", infoLine);
 
 			totals.dealtTotalDmgs += dmgTo;

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -82,13 +82,15 @@ IMPLEMENT_CLIENTCLASS_DT(C_NEO_Player, DT_NEO_Player, CNEO_Player)
 
 	RecvPropArray(RecvPropVector(RECVINFO(m_rvFriendlyPlayerPositions[0])), m_rvFriendlyPlayerPositions),
 	RecvPropArray(RecvPropFloat(RECVINFO(m_rfAttackersScores[0])), m_rfAttackersScores),
+	RecvPropArray(RecvPropInt(RECVINFO(m_rfAttackersHits[0])), m_rfAttackersHits),
 
 	RecvPropInt(RECVINFO(m_NeoFlags)),
 END_RECV_TABLE()
 
 BEGIN_PREDICTION_DATA(C_NEO_Player)
 	DEFINE_PRED_FIELD(m_rvFriendlyPlayerPositions, FIELD_VECTOR, FTYPEDESC_INSENDTABLE),
-	DEFINE_PRED_FIELD(m_rfAttackersScores, FIELD_FLOAT, FTYPEDESC_INSENDTABLE),
+	DEFINE_PRED_ARRAY(m_rfAttackersScores, FIELD_FLOAT, MAX_PLAYERS + 1, FTYPEDESC_INSENDTABLE),
+	DEFINE_PRED_ARRAY(m_rfAttackersHits, FIELD_INTEGER, MAX_PLAYERS + 1, FTYPEDESC_INSENDTABLE),
 	DEFINE_PRED_FIELD(m_vecGhostMarkerPos, FIELD_VECTOR, FTYPEDESC_INSENDTABLE),
 
 	DEFINE_PRED_FIELD_TOL(m_flCamoAuxLastTime, FIELD_FLOAT, FTYPEDESC_INSENDTABLE, TD_MSECTOLERANCE),
@@ -990,6 +992,10 @@ void C_NEO_Player::Spawn( void )
 	for (int i = 0; i < m_rfAttackersScores.Count(); ++i)
 	{
 		m_rfAttackersScores.Set(i, 0.0f);
+	}
+	for (int i = 0; i < m_rfAttackersHits.Count(); ++i)
+	{
+		m_rfAttackersHits.Set(i, 0);
 	}
 
 	Weapon_SetZoom(false);

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -105,6 +105,96 @@ BEGIN_PREDICTION_DATA(C_NEO_Player)
 	DEFINE_PRED_FIELD(m_nVisionLastTick, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),
 END_PREDICTION_DATA()
 
+static void __MsgFunc_DamageInfo(bf_read& msg)
+{
+	const int killerIdx = msg.ReadShort();
+
+	auto *localPlayer = C_NEO_Player::GetLocalNEOPlayer();
+	if (!localPlayer)
+	{
+		return;
+	}
+
+	// Print damage stats into the console
+	// Print to console
+	struct AttackersTotals
+	{
+		float dealtTotalDmgs;
+		int dealtTotalHits;
+		float takenTotalDmgs;
+		int takenTotalHits;
+	};
+	AttackersTotals totals;
+	totals.dealtTotalDmgs = 0.0f;
+	totals.dealtTotalHits = 0;
+	totals.takenTotalDmgs = 0.0f;
+	totals.takenTotalHits = 0;
+
+	const int thisIdx = localPlayer->entindex();
+
+	// Can't rely on Msg as it can print out of order, so do it in chunks
+	static char killByLine[512];
+
+	static const char* BORDER = "==========================\n";
+	bool setKillByLine = false;
+	if (killerIdx > 0)
+	{
+		auto* neoAttacker = dynamic_cast<C_NEO_Player*>(UTIL_PlayerByIndex(killerIdx));
+		if (neoAttacker && neoAttacker->entindex() != thisIdx)
+		{
+			KillerLineStr(killByLine, sizeof(killByLine), neoAttacker, localPlayer);
+			setKillByLine = true;
+		}
+	}
+
+	ConMsg("%sDamage infos (Round %d):\n%s\n", BORDER, NEORules()->roundNumber(), setKillByLine ? killByLine : "");
+	
+	for (int pIdx = 1; pIdx <= gpGlobals->maxClients; ++pIdx)
+	{
+		if (pIdx == thisIdx)
+		{
+			continue;
+		}
+
+		auto* neoAttacker = dynamic_cast<C_NEO_Player*>(UTIL_PlayerByIndex(pIdx));
+		if (!neoAttacker || neoAttacker->IsHLTV())
+		{
+			continue;
+		}
+
+		const char* dmgerName = neoAttacker->GetPlayerName();
+		if (!dmgerName)
+		{
+			continue;
+		}
+
+		const float dmgTo = min(neoAttacker->GetAttackersScores(thisIdx), 100.0f);
+		const float dmgFrom = min(localPlayer->GetAttackersScores(pIdx), 100.0f);
+		if (dmgTo > 0.0f || dmgFrom > 0.0f)
+		{
+			const int hitsTo = neoAttacker->GetAttackerHits(thisIdx);
+			const int hitsFrom = localPlayer->GetAttackerHits(pIdx);
+			const char* dmgerClass = GetNeoClassName(neoAttacker->GetClass());
+
+			static char infoLine[128];
+			DmgLineStr(infoLine, sizeof(infoLine), dmgerName, dmgerClass,
+				dmgTo, dmgFrom, hitsTo, hitsFrom, true);
+			ConMsg("%s", infoLine);
+
+			totals.dealtTotalDmgs += dmgTo;
+			totals.takenTotalDmgs += dmgFrom;
+			totals.dealtTotalHits += hitsTo;
+			totals.takenTotalHits += hitsFrom;
+		}
+	}
+
+	ConMsg("\nTOTAL: Dealt: %.0f in %d hits | Taken: %.0f in %d hits\n%s\n",
+		totals.dealtTotalDmgs, totals.dealtTotalHits,
+		totals.takenTotalDmgs, totals.takenTotalHits,
+		BORDER);
+}
+static bool g_hasHookDamageInfo = false;
+
 ConVar cl_drawhud_quickinfo("cl_drawhud_quickinfo", "0", 0,
 	"Whether to display HL2 style ammo/health info near crosshair.",
 	true, 0.0f, true, 1.0f);
@@ -323,6 +413,12 @@ C_NEO_Player::C_NEO_Player()
 
 	m_pPlayerAnimState = CreatePlayerAnimState(this, CreateAnimStateHelpers(this),
 		NEO_ANIMSTATE_LEGANIM_TYPE, NEO_ANIMSTATE_USES_AIMSEQUENCES);
+
+	if (!g_hasHookDamageInfo)
+	{
+		usermessages->HookMessage("DamageInfo", __MsgFunc_DamageInfo);
+		g_hasHookDamageInfo = true;
+	}
 }
 
 C_NEO_Player::~C_NEO_Player()
@@ -402,6 +498,11 @@ void C_NEO_Player::ZeroFriendlyPlayerLocArray()
 float C_NEO_Player::GetAttackersScores(const int attackerIdx) const
 {
 	return m_rfAttackersScores.Get(attackerIdx);
+}
+
+int C_NEO_Player::GetAttackerHits(const int attackerIdx) const
+{
+	return m_rfAttackersHits.Get(attackerIdx);
 }
 
 int C_NEO_Player::DrawModel( int flags )

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -181,6 +181,7 @@ public:
 
 	CNetworkArray(Vector, m_rvFriendlyPlayerPositions, MAX_PLAYERS);
 	CNetworkArray(float, m_rfAttackersScores, (MAX_PLAYERS + 1));
+	CNetworkArray(int, m_rfAttackersHits, (MAX_PLAYERS + 1));
 
 	bool m_bShowClassMenu, m_bShowTeamMenu;
 	CNetworkVar(bool, m_bHasBeenAirborneForTooLongToSuperJump);

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -161,6 +161,7 @@ public:
 	bool IsInAim() const { return m_bInAim; }
 
 	float GetAttackersScores(const int attackerIdx) const;
+	int GetAttackerHits(const int attackerIdx) const;
 
 private:
 	void CheckThermOpticButtons();

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1617,7 +1617,7 @@ int CNEO_Player::SetDmgListStr(char* infoStr, const int infoStrMax, const int pl
 			const int hitsFrom = GetAttackerHits(pIdx);
 			static char infoLine[SHOWMENU_STRLIMIT];
 			const int infoLineLen = DmgLineStr(infoLine, sizeof(infoLine),
-					dmgerName, dmgerClass, dmgTo, dmgFrom, hitsTo, hitsFrom, true);
+					dmgerName, dmgerClass, dmgTo, dmgFrom, hitsTo, hitsFrom);
 			if ((infoStrLen + infoLineLen) >= FILLSTR_END)
 			{
 				// Truncate for this page

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1566,12 +1566,12 @@ int CNEO_Player::SetDmgListStr(char* infoStr, const int infoStrMax, const int pl
 	Assert(infoStrSize != NULL);
 	Assert(showMenu != NULL);
 	*showMenu = false;
-	static const int TITLE_LEN = 16;
+	static const int TITLE_LEN = 30;
 	static const int POSTFIX_LEN = 15 + 12;
 	static const int TOTALLINE_LEN = 64; // Rough-approximate
 	static const int INFO_MAX_LEN = SHOWMENU_STRLIMIT - TITLE_LEN - POSTFIX_LEN - TOTALLINE_LEN - 2;
 	memset(infoStr, 0, infoStrMax);
-	Q_strncpy(infoStr, "Damage infos:\n \n", infoStrMax);
+	Q_snprintf(infoStr, infoStrMax, "Damage infos (Round %d):\n \n", NEORules()->roundNumber());
 	int infoStrLen = TITLE_LEN;
 	const int thisIdx = entindex();
 	int nextPage = 0;
@@ -1599,12 +1599,27 @@ int CNEO_Player::SetDmgListStr(char* infoStr, const int infoStrMax, const int pl
 #endif
 		{
 			*showMenu = true;
+			const char* dmgerClass = GetNeoClassName(neoAttacker->GetClass());
 			const int hitsTo = neoAttacker->GetAttackerHits(thisIdx);
 			const int hitsFrom = GetAttackerHits(pIdx);
 			static char infoLine[SHOWMENU_STRLIMIT];
 			memset(infoLine, 0, sizeof(infoLine));
-			Q_snprintf(infoLine, sizeof(infoLine), "%s: Dealt: %.0f in %d hits | Taken: %.0f in %d hits\n",
-					dmgerName, dmgTo, hitsTo, dmgFrom, hitsFrom);
+			if (dmgTo > 0.0f && dmgFrom > 0.0f)
+			{
+				Q_snprintf(infoLine, sizeof(infoLine), "%s [%s]: Dealt: %.0f in %d hits | Taken: %.0f in %d hits\n",
+					dmgerName, dmgerClass,
+					dmgTo, hitsTo, dmgFrom, hitsFrom);
+			}
+			else if (dmgTo > 0.0f)
+			{
+				Q_snprintf(infoLine, sizeof(infoLine), "%s [%s]: Dealt: %.0f in %d hits\n",
+					dmgerName, dmgerClass, dmgTo, hitsTo);
+			}
+			else if (dmgFrom > 0.0f)
+			{
+				Q_snprintf(infoLine, sizeof(infoLine), "%s [%s]: Taken: %.0f in %d hits\n",
+					dmgerName, dmgerClass, dmgFrom, hitsFrom);
+			}
 			const int infoLineLen = Q_strlen(infoLine);
 			if ((infoStrLen + infoLineLen) >= INFO_MAX_LEN)
 			{

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -184,6 +184,7 @@ public:
 		int takenTotalHits;
 	};
 	AttackersTotals GetAttackersTotals() const;
+	void StartShowDmgStats();
 
 	IMPLEMENT_NETWORK_VAR_FOR_DERIVED(m_EyeAngleOffset);
 
@@ -201,7 +202,7 @@ private:
 	bool IsAllowedToSuperJump(void);
 
 	void ShowDmgInfo(char *infoStr, int infoStrSize);
-	int SetDmgListStr(char *infoStr, const int infoStrMax, const int playerIdxStart, int *infoStrSize) const;
+	int SetDmgListStr(char *infoStr, const int infoStrMax, const int playerIdxStart, int *infoStrSize, bool *showMenu) const;
 
 public:
 	CNetworkVar(int, m_iNeoClass);

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -174,6 +174,16 @@ public:
 	int ShouldTransmit( const CCheckTransmitInfo *pInfo) OVERRIDE;
 
 	float GetAttackersScores(const int attackerIdx) const;
+	int GetAttackerHits(const int attackerIdx) const;
+
+	struct AttackersTotals
+	{
+		float dealtTotalDmgs;
+		int dealtTotalHits;
+		float takenTotalDmgs;
+		int takenTotalHits;
+	};
+	AttackersTotals GetAttackersTotals() const;
 
 	IMPLEMENT_NETWORK_VAR_FOR_DERIVED(m_EyeAngleOffset);
 
@@ -223,6 +233,7 @@ public:
 
 	CNetworkArray(Vector, m_rvFriendlyPlayerPositions, MAX_PLAYERS);
 	CNetworkArray(float, m_rfAttackersScores, (MAX_PLAYERS + 1));
+	CNetworkArray(int, m_rfAttackersHits, (MAX_PLAYERS + 1));
 
 	CNetworkVar(unsigned char, m_NeoFlags);
 

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -184,7 +184,7 @@ public:
 		int takenTotalHits;
 	};
 	AttackersTotals GetAttackersTotals() const;
-	void StartShowDmgStats();
+	void StartShowDmgStats(const CTakeDamageInfo *info);
 
 	IMPLEMENT_NETWORK_VAR_FOR_DERIVED(m_EyeAngleOffset);
 
@@ -202,7 +202,9 @@ private:
 	bool IsAllowedToSuperJump(void);
 
 	void ShowDmgInfo(char *infoStr, int infoStrSize);
-	int SetDmgListStr(char *infoStr, const int infoStrMax, const int playerIdxStart, int *infoStrSize, bool *showMenu) const;
+	int SetDmgListStr(char *infoStr, const int infoStrMax, const int playerIdxStart,
+		int *infoStrSize, bool *showMenu,
+		const CTakeDamageInfo *info) const;
 
 public:
 	CNetworkVar(int, m_iNeoClass);

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -190,6 +190,9 @@ private:
 
 	bool IsAllowedToSuperJump(void);
 
+	void ShowDmgInfo(char *infoStr, int infoStrSize);
+	int SetDmgListStr(char *infoStr, const int infoStrMax, const int playerIdxStart, int *infoStrSize) const;
+
 public:
 	CNetworkVar(int, m_iNeoClass);
 	CNetworkVar(int, m_iNeoSkin);
@@ -232,6 +235,9 @@ private:
 
 	float m_flLastAirborneJumpOkTime;
 	float m_flLastSuperJumpTime;
+
+	int m_iDmgMenuCurPage;
+	int m_iDmgMenuNextPage;
 
 	INEOPlayerAnimState* m_pPlayerAnimState;
 

--- a/mp/src/game/shared/hl2/hl2_usermessages.cpp
+++ b/mp/src/game/shared/hl2/hl2_usermessages.cpp
@@ -47,6 +47,10 @@ void RegisterUserMessages( void )
 	usermessages->Register( "UpdateJalopyRadar", -1 );
 	usermessages->Register( "RoundResult", -1 );
 
+#ifdef NEO
+	usermessages->Register( "DamageInfo", -1 );
+#endif
+
 #ifndef _X360
 	// NVNT register haptic user messages
 	RegisterHapticMessages();

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -1468,7 +1468,7 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 			// Any human player still alive, show them damage stats in round end
 			if (!player->IsBot() && !player->IsHLTV() && player->IsAlive())
 			{
-				player->StartShowDmgStats();
+				player->StartShowDmgStats(NULL);
 			}
 		}
 	}

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -1281,6 +1281,24 @@ bool CNEORules::ClientConnected(edict_t *pEntity, const char *pszName, const cha
 	return canJoin;
 #endif
 }
+
+bool CNEORules::ClientCommand(CBaseEntity* pEdict, const CCommand& args)
+{
+	if (auto* neoPlayer = dynamic_cast<CNEO_Player*>(pEdict))
+	{
+		if (neoPlayer->ClientCommand(args))
+		{
+			return true;
+		}
+	}
+
+	if (BaseClass::ClientCommand(pEdict, args))
+	{
+		return true;
+	}
+
+	return false;
+}
 #endif
 
 void CNEORules::ClientSettingsChanged(CBasePlayer *pPlayer)

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -1465,6 +1465,11 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 				player->m_iXP.GetForModify() += xpAward;
 			}
 
+			// Any human player still alive, show them damage stats in round end
+			if (!player->IsBot() && !player->IsHLTV() && player->IsAlive())
+			{
+				player->StartShowDmgStats();
+			}
 		}
 	}
 

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -111,6 +111,8 @@ public:
 
 	virtual bool ClientConnected(edict_t *pEntity, const char *pszName, const char *pszAddress, char *reject, int maxrejectlen) OVERRIDE;
 
+	virtual bool ClientCommand(CBaseEntity* pEdict, const CCommand& args) OVERRIDE;
+
 	virtual void SetWinningTeam(int team, int iWinReason, bool bForceMapReset = true, bool bSwitchTeams = false, bool bDontAddScore = false, bool bFinal = false) OVERRIDE;
 
 	virtual void ChangeLevel(void) OVERRIDE;

--- a/mp/src/game/shared/neo/neo_player_shared.cpp
+++ b/mp/src/game/shared/neo/neo_player_shared.cpp
@@ -130,28 +130,24 @@ bool ClientWantsLeanToggle(const CNEO_Player* player)
 
 int DmgLineStr(char* infoLine, const int infoLineMax,
 	const char* dmgerName, const char* dmgerClass,
-	const float dmgTo, const float dmgFrom, const int hitsTo, const int hitsFrom,
-	const bool newline)
+	const float dmgTo, const float dmgFrom, const int hitsTo, const int hitsFrom)
 {
 	memset(infoLine, 0, infoLineMax);
 	if (dmgTo > 0.0f && dmgFrom > 0.0f)
 	{
-		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Dealt: %.0f in %d hits | Taken: %.0f in %d hits%s",
+		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Dealt: %.0f in %d hits | Taken: %.0f in %d hits\n",
 			dmgerName, dmgerClass,
-			dmgTo, hitsTo, dmgFrom, hitsFrom,
-			newline ? "\n" : "");
+			dmgTo, hitsTo, dmgFrom, hitsFrom);
 	}
 	else if (dmgTo > 0.0f)
 	{
-		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Dealt: %.0f in %d hits%s",
-			dmgerName, dmgerClass, dmgTo, hitsTo,
-			newline ? "\n" : "");
+		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Dealt: %.0f in %d hits\n",
+			dmgerName, dmgerClass, dmgTo, hitsTo);
 	}
 	else if (dmgFrom > 0.0f)
 	{
-		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Taken: %.0f in %d hits%s",
-			dmgerName, dmgerClass, dmgFrom, hitsFrom,
-			newline ? "\n" : "");
+		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Taken: %.0f in %d hits\n",
+			dmgerName, dmgerClass, dmgFrom, hitsFrom);
 	}
 	return Q_strlen(infoLine);
 }

--- a/mp/src/game/shared/neo/neo_player_shared.cpp
+++ b/mp/src/game/shared/neo/neo_player_shared.cpp
@@ -127,3 +127,46 @@ bool ClientWantsLeanToggle(const CNEO_Player* player)
 	return 1 == atoi(engine->GetClientConVarValue(engine->IndexOfEdict(player->edict()), "neo_lean_toggle"));
 #endif
 }
+
+int DmgLineStr(char* infoLine, const int infoLineMax,
+	const char* dmgerName, const char* dmgerClass,
+	const float dmgTo, const float dmgFrom, const int hitsTo, const int hitsFrom,
+	const bool newline)
+{
+	memset(infoLine, 0, infoLineMax);
+	if (dmgTo > 0.0f && dmgFrom > 0.0f)
+	{
+		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Dealt: %.0f in %d hits | Taken: %.0f in %d hits%s",
+			dmgerName, dmgerClass,
+			dmgTo, hitsTo, dmgFrom, hitsFrom,
+			newline ? "\n" : "");
+	}
+	else if (dmgTo > 0.0f)
+	{
+		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Dealt: %.0f in %d hits%s",
+			dmgerName, dmgerClass, dmgTo, hitsTo,
+			newline ? "\n" : "");
+	}
+	else if (dmgFrom > 0.0f)
+	{
+		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Taken: %.0f in %d hits%s",
+			dmgerName, dmgerClass, dmgFrom, hitsFrom,
+			newline ? "\n" : "");
+	}
+	return Q_strlen(infoLine);
+}
+
+void KillerLineStr(char* killByLine, const int killByLineMax,
+	CNEO_Player* neoAttacker, const CNEO_Player* neoVictim)
+{
+	const char* dmgerName = neoAttacker->GetPlayerName();
+	const char* dmgerClass = GetNeoClassName(neoAttacker->GetClass());
+	const int dmgerHP = neoAttacker->GetHealth();
+	auto* dmgerWep = neoAttacker->GetActiveWeapon();
+	const char* dmgerWepName = dmgerWep ? dmgerWep->GetPrintName() : "";
+	const float distance = METERS_PER_INCH * neoAttacker->GetAbsOrigin().DistTo(neoVictim->GetAbsOrigin());
+
+	memset(killByLine, 0, killByLineMax);
+	Q_snprintf(killByLine, killByLineMax, "Killed by: %s [%s | %d hp] with %s at %.0f m\n",
+		dmgerName, dmgerClass, dmgerHP, dmgerWepName, distance);
+}

--- a/mp/src/game/shared/neo/neo_player_shared.h
+++ b/mp/src/game/shared/neo/neo_player_shared.h
@@ -274,8 +274,7 @@ bool ClientWantsAimHold(const CNEO_Player* player);
 
 int DmgLineStr(char* infoLine, const int infoLineMax,
 	const char* dmgerName, const char* dmgerClass,
-	const float dmgTo, const float dmgFrom, const int hitsTo, const int hitsFrom,
-	const bool newline);
+	const float dmgTo, const float dmgFrom, const int hitsTo, const int hitsFrom);
 
 void KillerLineStr(char* killByLine, const int killByLineMax,
 	CNEO_Player* neoAttacker, const CNEO_Player* neoVictim);

--- a/mp/src/game/shared/neo/neo_player_shared.h
+++ b/mp/src/game/shared/neo/neo_player_shared.h
@@ -272,4 +272,12 @@ enum NeoWeponAimToggleE {
 
 bool ClientWantsAimHold(const CNEO_Player* player);
 
+int DmgLineStr(char* infoLine, const int infoLineMax,
+	const char* dmgerName, const char* dmgerClass,
+	const float dmgTo, const float dmgFrom, const int hitsTo, const int hitsFrom,
+	const bool newline);
+
+void KillerLineStr(char* killByLine, const int killByLineMax,
+	CNEO_Player* neoAttacker, const CNEO_Player* neoVictim);
+
 #endif // NEO_PLAYER_SHARED_H


### PR DESCRIPTION
* Shows damage, hits, and killer info at round end or death
* Shows in both the (server process, client shown) left-side menu and (client process + shown) console
* If it overflows in left-side menu (because it has 512bytes size limit), it'll appear in multiple pages
* If killed instead of round end/self-killed, then it'll also show up killer's information