### PR TITLE
Srs Bolting

### DIFF
--- a/mp/game/neo/scripts/weapon_srs.txt
+++ b/mp/game/neo/scripts/weapon_srs.txt
@@ -13,7 +13,7 @@ WeaponData
 	"bucket_position"	"0"
 	"Damage"		"100"
 	"Penetration"		"65.0"
-	"CycleTime"		"1.0"		 // time between shots
+	"CycleTime"		"0.7"		 // time between shots (this value is not used and instead hardcoded in the srs header file)
 	
 	"TPMuzzleFlashScale"	"0.25"
 

--- a/mp/src/game/shared/neo/neo_player_shared.cpp
+++ b/mp/src/game/shared/neo/neo_player_shared.cpp
@@ -31,7 +31,7 @@ ConVar neo_recon_superjump_intensity("neo_recon_superjump_intensity", "250", FCV
 
 bool IsAllowedToZoom(CNEOBaseCombatWeapon *pWep)
 {
-	if (!pWep || pWep->m_bInReload)
+	if (!pWep || pWep->m_bInReload || pWep->GetRoundBeingChambered())
 	{
 		return false;
 	}

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -216,8 +216,8 @@ public:
 	virtual void SUB_Remove(void) { }
 
 	virtual float GetFireRate(void) OVERRIDE { Assert(false); return BaseClass::GetFireRate(); } // Should never call this base class; override in children.
-	virtual bool GetRoundChambered() const { Assert(false); return 0; }
-	virtual bool GetRoundBeingChambered() const { Assert(false); return 0; }
+	virtual bool GetRoundChambered() const { return 0; }
+	virtual bool GetRoundBeingChambered() const { return 0; }
 
 protected:
 	virtual float GetAccuracyPenalty() const { Assert(false); return 0; } // Should never call this base class; implement in children.

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -216,6 +216,8 @@ public:
 	virtual void SUB_Remove(void) { }
 
 	virtual float GetFireRate(void) OVERRIDE { Assert(false); return BaseClass::GetFireRate(); } // Should never call this base class; override in children.
+	virtual bool GetRoundChambered() const { Assert(false); return 0; }
+	virtual bool GetRoundBeingChambered() const { Assert(false); return 0; }
 
 protected:
 	virtual float GetAccuracyPenalty() const { Assert(false); return 0; } // Should never call this base class; implement in children.
@@ -228,6 +230,8 @@ protected:
 	CNetworkVar(float, m_flAccuracyPenalty);
 
 	CNetworkVar(int, m_nNumShotsFired);
+	CNetworkVar(bool, m_bRoundChambered);
+	CNetworkVar(bool, m_bRoundBeingChambered);
 
 private:
 	bool m_bReadyToAimIn;

--- a/mp/src/game/shared/neo/weapons/weapon_srs.h
+++ b/mp/src/game/shared/neo/weapons/weapon_srs.h
@@ -36,8 +36,10 @@ public:
 	void	ItemPostFrame(void);
 	void	ItemPreFrame(void);
 	void	ItemBusyFrame(void);
-	virtual void	PrimaryAttack(void) OVERRIDE { if (!ShootingIsPrevented()) { BaseClass::PrimaryAttack(); } }
+	void	PrimaryAttack(void) OVERRIDE;
 	virtual void	SecondaryAttack(void) OVERRIDE { if (!ShootingIsPrevented()) { BaseClass::SecondaryAttack(); } }
+	virtual bool	Reload(void) OVERRIDE { if (auto owner = ToBasePlayer(GetOwner())) { if (!(owner->m_nButtons & IN_ATTACK)) { return BaseClass::Reload(); } return false; } return false; }
+	virtual void	FinishReload(void) OVERRIDE { m_bRoundChambered = true; BaseClass::FinishReload(); }
 	void	AddViewKick(void);
 	void	DryFire(void);
 
@@ -53,11 +55,14 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 1.0f; }
+	virtual float GetFireRate(void) OVERRIDE { return 0.4f; }
+	float m_flChamberFinishTime = maxfloat16bits;
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }
 	virtual float GetMaxAccuracyPenalty() const OVERRIDE { return 1.5f; }
+	virtual bool GetRoundChambered() const { return m_bRoundChambered.Get(); }
+	virtual bool GetRoundBeingChambered() const { return m_bRoundBeingChambered.Get(); }
 
 private:
 	CWeaponSRS(const CWeaponSRS &other);


### PR DESCRIPTION
Adds bolting the srs, prevents bolting and reloading when looking through scope and fire button is held, bolting animation supersedes running animation, weapons dropped before being bolted do not have a round in the chamber and have to be chambered on pickup