### PR TITLE
Clear decals on round start

### DIFF
--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -669,6 +669,7 @@ void CNEORules::FireGameEvent(IGameEvent* event)
 	if (Q_strcmp(type, "round_start") == 0)
 	{
 #ifdef CLIENT_DLL
+		engine->ClientCmd("r_cleardecals");
 		engine->ClientCmd("classmenu");
 #endif
 		m_flNeoRoundStartTime = gpGlobals->curtime;


### PR DESCRIPTION
Execute client command for clients to clear all decals, is there a better way to do this?