### PR TITLE
Implement round limit, early win, match point indicator, and sudden death

### DIFF
--- a/mp/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -117,6 +117,7 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	float roundTimeLeft = NEORules()->GetRoundRemainingTime();
 	const NeoRoundStatus roundStatus = NEORules()->GetRoundStatus();
 	const bool inSuddenDeath = NEORules()->RoundIsInSuddenDeath();
+	const bool inMatchPoint = NEORules()->RoundIsMatchPoint();
 
 	// Exactly zero means there's no time limit, so we don't need to draw anything.
 	if (roundTimeLeft == 0)
@@ -145,6 +146,10 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	if (inSuddenDeath)
 	{
 		prefixStr = "(Sudden death) ";
+	}
+	else if (inMatchPoint)
+	{
+		prefixStr = "(Match point) ";
 	}
 
 	V_sprintf_safe(m_szStatusANSI, "%s%02d:%02d", prefixStr, minutes, secsRemainder);

--- a/mp/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -116,6 +116,7 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 {
 	float roundTimeLeft = NEORules()->GetRoundRemainingTime();
 	const NeoRoundStatus roundStatus = NEORules()->GetRoundStatus();
+	const bool inSuddenDeath = NEORules()->RoundIsInSuddenDeath();
 
 	// Exactly zero means there's no time limit, so we don't need to draw anything.
 	if (roundTimeLeft == 0)
@@ -140,8 +141,13 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	const int secsTotal = RoundFloatToInt(roundTimeLeft);
 	const int secsRemainder = secsTotal % 60;
 	const int minutes = (secsTotal - secsRemainder) / 60;
+	const char *prefixStr = (roundStatus == NeoRoundStatus::Warmup) ? "(Warmup) " : "";
+	if (inSuddenDeath)
+	{
+		prefixStr = "(Sudden death) ";
+	}
 
-	V_sprintf_safe(m_szStatusANSI, "%s%02d:%02d", (roundStatus == NeoRoundStatus::Warmup) ? "(Warmup) " : "", minutes, secsRemainder);
+	V_sprintf_safe(m_szStatusANSI, "%s%02d:%02d", prefixStr, minutes, secsRemainder);
 	memset(m_wszStatusUnicode, 0, sizeof(m_wszStatusUnicode)); // NOTE (nullsystem): Clear it or get junk after warmup ends
 	g_pVGuiLocalize->ConvertANSIToUnicode(m_szStatusANSI, m_wszStatusUnicode, sizeof(m_wszStatusUnicode));
 }

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -7,6 +7,7 @@
 
 #ifdef CLIENT_DLL
 	#include "c_neo_player.h"
+	#include "c_team.h"
 #else
 	#include "neo_player.h"
 	#include "team.h"
@@ -120,6 +121,9 @@ static NEOViewVectors g_NEOViewVectors(
 
 
 ConVar neo_score_limit("neo_score_limit", "7", FCVAR_REPLICATED, "Neo score limit.", true, 0.0f, true, 99.0f);
+ConVar neo_round_limit("neo_round_limit", "0", FCVAR_REPLICATED, "Max amount of rounds, 0 for no limit.", true, 0.0f, false, 0.0f);
+ConVar neo_round_sudden_death("neo_round_sudden_death", "1", FCVAR_REPLICATED, "If neo_round_limit is not 0 and round is past "
+	"neo_round_limit, go into sudden death where match won't end until a team won.", true, 0.0f, true, 1.0f);
 
 ConVar neo_round_timelimit("neo_round_timelimit", "2.75", FCVAR_REPLICATED, "Neo round timelimit, in minutes.",
 	true, 0.0f, false, 600.0f);
@@ -392,6 +396,7 @@ void CNEORules::ChangeLevel(void)
 
 	BaseClass::ChangeLevel();
 }
+
 #endif
 
 bool CNEORules::CheckGameOver(void)
@@ -452,32 +457,6 @@ void CNEORules::Think(void)
 		}
 
 		return;
-	}
-
-	if (neo_score_limit.GetInt() != 0)
-	{
-#ifdef DEBUG
-		float neoScoreLimitMin = -1.0f;
-		AssertOnce(neo_score_limit.GetMin(neoScoreLimitMin));
-		AssertOnce(neoScoreLimitMin >= 0);
-#endif
-		COMPILE_TIME_ASSERT((TEAM_JINRAI < TEAM_NSF) && (TEAM_JINRAI == (TEAM_NSF - 1)));
-		for (int team = TEAM_JINRAI; team <= TEAM_NSF; ++team)
-		{
-			auto pTeam = GetGlobalTeam(team);
-			if (!pTeam)
-			{
-				continue;
-			}
-
-			if (pTeam->GetRoundsWon() >= neo_score_limit.GetInt())
-			{
-				UTIL_CenterPrintAll(team == TEAM_JINRAI ? "JINRAI WINS THE MATCH\n" : "NSF WINS THE MATCH\n");
-				SetRoundStatus(NeoRoundStatus::PostRound);
-				GoToIntermission();
-				return;
-			}
-		}
 	}
 #endif
 
@@ -1313,6 +1292,17 @@ void CNEORules::ClientSettingsChanged(CBasePlayer *pPlayer)
 #endif
 }
 
+bool CNEORules::RoundIsInSuddenDeath() const
+{
+	auto teamJinrai = GetGlobalTeam(TEAM_JINRAI);
+	auto teamNSF = GetGlobalTeam(TEAM_NSF);
+	if (teamJinrai && teamNSF)
+	{
+		return (neo_round_limit.GetInt() != 0 && (m_iRoundNumber > neo_round_limit.GetInt()) && teamJinrai->GetRoundsWon() == teamNSF->GetRoundsWon());
+	}
+	return false;
+}
+
 ConVar snd_victory_volume("snd_victory_volume", "0.33", FCVAR_ARCHIVE | FCVAR_DONTRECORD | FCVAR_USERINFO, "Loudness of the victory jingle (0-1).", true, 0.0, true, 1.0);
 
 #ifdef GAME_DLL
@@ -1350,23 +1340,57 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 
 	char victoryMsg[128];
 	bool gotMatchWinner = false;
+	bool isSuddenDeath = false;
 
-	if (!bForceMapReset && neo_score_limit.GetInt() != 0)
+	if (!bForceMapReset)
 	{
-#ifdef DEBUG
-		float neoScoreLimitMin = -1.0f;
-		AssertOnce(neo_score_limit.GetMin(neoScoreLimitMin));
-		AssertOnce(neoScoreLimitMin >= 0);
-#endif
-		if (winningTeam->GetRoundsWon() >= neo_score_limit.GetInt())
+		if (neo_score_limit.GetInt() != 0)
 		{
-			V_sprintf_safe(victoryMsg, "Team %s wins the match!\n", (team == TEAM_JINRAI ? "Jinrai" : "NSF"));
-			m_flNeoNextRoundStartTime = FLT_MAX;
-			gotMatchWinner = true;
+#ifdef DEBUG
+			float neoScoreLimitMin = -1.0f;
+			AssertOnce(neo_score_limit.GetMin(neoScoreLimitMin));
+			AssertOnce(neoScoreLimitMin >= 0);
+#endif
+			if (winningTeam->GetRoundsWon() >= neo_score_limit.GetInt())
+			{
+				V_sprintf_safe(victoryMsg, "Team %s wins the match!\n", (team == TEAM_JINRAI ? "Jinrai" : "NSF"));
+				m_flNeoNextRoundStartTime = FLT_MAX;
+				gotMatchWinner = true;
+			}
+		}
+
+		// If a hard round limit is set, end the game and show the team
+		// that won with the most score, sudden death, or tie out
+		if (neo_round_limit.GetInt() != 0 && (m_iRoundNumber >= neo_round_limit.GetInt()))
+		{
+			auto teamJinrai = GetGlobalTeam(TEAM_JINRAI);
+			auto teamNSF = GetGlobalTeam(TEAM_NSF);
+			if (teamJinrai && teamNSF)
+			{
+				if (teamJinrai->GetRoundsWon() == teamNSF->GetRoundsWon())
+				{
+					// Sudden death - Don't end the match until we get a winning team
+					if (neo_round_sudden_death.GetBool())
+					{
+						V_sprintf_safe(victoryMsg, "Next round: Sudden death!\n");
+						isSuddenDeath = true;
+					}
+					else
+					{
+						V_sprintf_safe(victoryMsg, "The match is tied!\n");
+						gotMatchWinner = true;
+					}
+				}
+				else
+				{
+					V_sprintf_safe(victoryMsg, "Team %s wins the match!\n", ((teamJinrai->GetRoundsWon() > teamNSF->GetRoundsWon()) ? "Jinrai" : "NSF"));
+					gotMatchWinner = true;
+				}
+			}
 		}
 	}
 
-	if (!gotMatchWinner)
+	if (!gotMatchWinner && !isSuddenDeath)
 	{
 		if (iWinReason == NEO_VICTORY_GHOST_CAPTURE)
 		{

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -149,6 +149,8 @@ public:
 	;
 #endif
 
+	bool RoundIsInSuddenDeath() const;
+
 	virtual int DefaultFOV(void) OVERRIDE;
 
 	float GetRemainingPreRoundFreezeTime(const bool clampToZero) const;

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -150,6 +150,7 @@ public:
 #endif
 
 	bool RoundIsInSuddenDeath() const;
+	bool RoundIsMatchPoint() const;
 
 	virtual int DefaultFOV(void) OVERRIDE;
 


### PR DESCRIPTION
* `neo_round_limit` - Default 0/off, if set, maximum amount of round can be played per match
* `neo_round_sudden_death` - Default 1/on, if set, going over `neo_round_limit` if `neo_round_limit` is not 0 will cause the next round on sudden death on ties until a winner happens
* Added an indicator on round that is sudden death
* This also removed some block of code which I think is unused now