### PR TITLE
Change ghost cap distance calculation to match OG NT.

### DIFF
--- a/mp/src/game/shared/neo/neo_ghost_cap_point.cpp
+++ b/mp/src/game/shared/neo/neo_ghost_cap_point.cpp
@@ -215,13 +215,13 @@ void CNEOGhostCapturePoint::Think_CheckMyRadius(void)
 		}
 
 		const Vector dir = player->GetAbsOrigin() - GetAbsOrigin();
-		const float distance = dir.Length2D();
+		const float distance = dir.Length();
 
 		Assert(distance >= 0);
 
 		// Has the ghost carrier reached inside our radius?
 		// NEO TODO (Rain): newbie UI helpers for approaching wrong team cap
-		if (distance >= (m_flCapzoneRadius / 2.0f))
+		if (distance > m_flCapzoneRadius)
 		{
 			continue;
 		}


### PR DESCRIPTION
For parity the distance is calculated in 3D instead of 2D, and the cap zone radius is not halved. Also, a distance less than or equal to the radius should be a cap, not just less than (this caused some annoying off by a frame issues in one of my old plugins 😅).

Fixes #269.