### PR TITLE
Compass HUD visual closer to OG:NT Styling + HudLayout.res customization

### DIFF
--- a/mp/game/neo/scripts/HudLayout.res
+++ b/mp/game/neo/scripts/HudLayout.res
@@ -502,4 +502,12 @@
 		"visible"		"0"
 		"enabled"		"0"
 	}
+	NHudCompass
+	{
+		"fieldName"		"NHudCompass"
+		"visible"		"1"
+		"needle_visible"	"0"
+		"needle_colored"	"0"
+		"objective_visible"	"1"
+	}
 }

--- a/mp/src/game/client/neo/ui/neo_hud_childelement.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_childelement.cpp
@@ -49,12 +49,16 @@ CNEOHud_ChildElement::CNEOHud_ChildElement()
 	Assert(m_rounded_width > 0 && m_rounded_height > 0);
 }
 
-void CNEOHud_ChildElement::DrawNeoHudRoundedBox(const int x0, const int y0, const int x1, const int y1, Color color, bool topLeft, bool topRight, bool bottomLeft, bool bottomRight) const
+CNEOHud_ChildElement::XYHudPos CNEOHud_ChildElement::DrawNeoHudRoundedCommon(
+	const int x0, const int y0, const int x1, const int y1, Color color,
+	bool topLeft, bool topRight, bool bottomLeft, bool bottomRight) const
 {
-	const int x0w = x0 + m_rounded_width;
-	const int x1w = x1 - m_rounded_width;
-	const int y0h = y0 + m_rounded_height;
-	const int y1h = y1 - m_rounded_height;
+	const XYHudPos p{
+		.x0w = x0 + m_rounded_width,
+		.x1w = x1 - m_rounded_width,
+		.y0h = y0 + m_rounded_height,
+		.y1h = y1 - m_rounded_height,
+	};
 
 	surface()->DrawSetColor(color);
 
@@ -62,30 +66,52 @@ void CNEOHud_ChildElement::DrawNeoHudRoundedBox(const int x0, const int y0, cons
 	if (topLeft)
 	{
 		surface()->DrawSetTexture(m_hTex_Rounded_NW);
-		surface()->DrawTexturedRect(x0, y0, x0w, y0h);
+		surface()->DrawTexturedRect(x0, y0, p.x0w, p.y0h);
 	}
 	if (topRight)
 	{
 		surface()->DrawSetTexture(m_hTex_Rounded_NE);
-		surface()->DrawTexturedRect(x1w, y0, x1, y0h);
+		surface()->DrawTexturedRect(p.x1w, y0, x1, p.y0h);
 	}
 	if (bottomLeft)
 	{
 		surface()->DrawSetTexture(m_hTex_Rounded_SE);
-		surface()->DrawTexturedRect(x0, y1h, x0w, y1);
+		surface()->DrawTexturedRect(x0, p.y1h, p.x0w, y1);
 	}
 	if (bottomRight)
 	{
 		surface()->DrawSetTexture(m_hTex_Rounded_SW);
-		surface()->DrawTexturedRect(x1w, y1h, x1, y1);
+		surface()->DrawTexturedRect(p.x1w, p.y1h, x1, y1);
 	}
 
+	return p;
+}
+
+void CNEOHud_ChildElement::DrawNeoHudRoundedBox(const int x0, const int y0, const int x1, const int y1, Color color,
+	bool topLeft, bool topRight, bool bottomLeft, bool bottomRight) const
+{
+	const auto p = DrawNeoHudRoundedCommon(x0, y0, x1, y1, color, topLeft, topRight, bottomLeft, bottomRight);
+
 	// Large middle rectangle
-	surface()->DrawFilledRect(x0w, y0, x1w, y1);
+	surface()->DrawFilledRect(p.x0w, y0, p.x1w, y1);
 
 	// Small side rectangles
-	surface()->DrawFilledRect(x0, topLeft? y0h: y0, x0w, bottomLeft? y1h: y1);
-	surface()->DrawFilledRect(x1w, topRight? y0h: y0, x1, bottomRight? y1h: y1);
+	surface()->DrawFilledRect(x0, topLeft ? p.y0h : y0, p.x0w, bottomLeft ? p.y1h : y1);
+	surface()->DrawFilledRect(p.x1w, topRight ? p.y0h : y0, x1, bottomRight ? p.y1h : y1);
+}
+
+void CNEOHud_ChildElement::DrawNeoHudRoundedBoxFaded(const int x0, const int y0, const int x1, const int y1, Color color,
+	unsigned int alpha0, unsigned int alpha1, bool bHorizontal,
+	bool topLeft, bool topRight, bool bottomLeft, bool bottomRight) const
+{
+	const auto p = DrawNeoHudRoundedCommon(x0, y0, x1, y1, color, topLeft, topRight, bottomLeft, bottomRight);
+
+	// Large middle rectangle
+	surface()->DrawFilledRectFade(p.x0w, y0, p.x1w, y1, alpha0, alpha1, bHorizontal);
+
+	// Small side rectangles
+	surface()->DrawFilledRectFade(x0, topLeft ? p.y0h : y0, p.x0w, bottomLeft ? p.y1h : y1, alpha0, alpha0, bHorizontal);
+	surface()->DrawFilledRectFade(p.x1w, topRight ? p.y0h : y0, x1, bottomRight ? p.y1h : y1, alpha1, alpha1, bHorizontal);
 }
 
 int CNEOHud_ChildElement::GetMargin()

--- a/mp/src/game/client/neo/ui/neo_hud_childelement.h
+++ b/mp/src/game/client/neo/ui/neo_hud_childelement.h
@@ -32,7 +32,19 @@ public:
 	virtual ~CNEOHud_ChildElement() { }
 
 protected:
-	virtual void DrawNeoHudRoundedBox(const int x0, const int y0, const int x1, const int y1, Color colour = NEO_HUDBOX_COLOR, bool topLeft = TRUE, bool topRight = TRUE, bool bottomLeft = TRUE, bool bottomRight = TRUE) const;
+	virtual void DrawNeoHudRoundedBox(const int x0, const int y0, const int x1, const int y1, Color color = NEO_HUDBOX_COLOR,
+			bool topLeft = true, bool topRight = true, bool bottomLeft = true, bool bottomRight = true) const;
+	virtual void DrawNeoHudRoundedBoxFaded(const int x0, const int y0, const int x1, const int y1, Color color,
+		unsigned int alpha0, unsigned int alpha1, bool bHorizontal,
+		bool topLeft = true, bool topRight = true, bool bottomLeft = true, bool bottomRight = true) const;
+	struct XYHudPos {
+		int x0w;
+		int x1w;
+		int y0h;
+		int y1h;
+	};
+	XYHudPos DrawNeoHudRoundedCommon(const int x0, const int y0, const int x1, const int y1, Color color,
+		bool topLeft, bool topRight, bool bottomLeft, bool bottomRight) const;
 
 	virtual void UpdateStateForNeoHudElementDraw() = 0;
 	virtual void DrawNeoHudElement() = 0;

--- a/mp/src/game/client/neo/ui/neo_hud_compass.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.cpp
@@ -31,8 +31,10 @@ ConVar neo_cl_hud_compass_pos_x("neo_cl_hud_compass_pos_x", "2", FCVAR_USERINFO,
 	"HUD compass X offset divisor.", true, 1, false, 10);
 ConVar neo_cl_hud_compass_pos_y("neo_cl_hud_compass_pos_y", "80", FCVAR_USERINFO,
 	"HUD compass Y offset divisor.", true, 1, false, 10);
-ConVar neo_cl_hud_compass_needle("neo_cl_hud_compass_needle", "1", FCVAR_USERINFO,
+ConVar neo_cl_hud_compass_needle("neo_cl_hud_compass_needle", "0", FCVAR_USERINFO,
 	"Whether to show the HUD compass needle.", true, 0, true, 1);
+ConVar neo_cl_hud_compass_needle_colored("neo_cl_hud_compass_needle_colored", "0", FCVAR_USERINFO,
+	"Whether to color the HUD compass needle by their own team.", true, 0, true, 1);
 ConVar neo_cl_hud_compass_objective("neo_cl_hud_compass_objective", "1", FCVAR_USERINFO,
 	"Whether to show the HUD objective arrow.", true, 0, true, 1);
 
@@ -202,12 +204,12 @@ void CNEOHud_Compass::DrawCompass() const
 
 	const int resXHalf = m_resX / 2;
 	const int xBoxWidthHalf = xBoxWidth / 2;
-	const int margin = neo_cl_hud_ammo_enabled.GetInt();
+	const int margin = 1; //neo_cl_hud_compass_pos_y.GetInt();
 
-	surface()->DrawSetColor(Color(116, 116, 116, 200));
-	surface()->DrawFilledRect(
+	DrawNeoHudRoundedBox(
 		resXHalf - xBoxWidthHalf, m_resY - yBoxHeight - margin,
-		resXHalf + xBoxWidthHalf, m_resY - margin);
+		resXHalf + xBoxWidthHalf, m_resY - margin,
+		Color(116, 116, 116, 200));
 
 	const auto fadeColor = Color(150, 150, 150, 175);
 	surface()->DrawSetColor(fadeColor);
@@ -227,11 +229,21 @@ void CNEOHud_Compass::DrawCompass() const
 	// Draw the compass "needle"
 	if (neo_cl_hud_compass_needle.GetBool())
 	{
-#define COMPASS_NEEDLE_COLOR_GREEN Color(25, 255, 25, 150)
-#define COMPASS_NEEDLE_COLOR_BLUE Color(25, 25, 255, 150)
-#define COMPASS_NEEDLE_COLOR_WHITE Color(255, 255, 255, 150)
-		surface()->DrawSetColor((player->GetTeamNumber() == TEAM_JINRAI) ?
-			COMPASS_NEEDLE_COLOR_GREEN : ((player->GetTeamNumber() == TEAM_NSF) ? COMPASS_NEEDLE_COLOR_BLUE : COMPASS_NEEDLE_COLOR_WHITE));
+		static const Color COMPASS_NEEDLE_COLOR_GREEN{25, 255, 25, 150};
+		static const Color COMPASS_NEEDLE_COLOR_BLUE{25, 25, 255, 150};
+		static const Color COMPASS_NEEDLE_COLOR_WHITE{255, 255, 255, 150};
+		Color needleColor = COMPASS_NEEDLE_COLOR_WHITE;
+		if (neo_cl_hud_compass_needle_colored.GetBool())
+		{
+			const int playerTeam = player->GetTeamNumber();
+			switch (playerTeam)
+			{
+			break; case TEAM_JINRAI: needleColor = COMPASS_NEEDLE_COLOR_GREEN;
+			break; case TEAM_NSF: needleColor = COMPASS_NEEDLE_COLOR_BLUE;
+			break; default: break;
+			}
+		}
+		surface()->DrawSetColor(needleColor);
 		surface()->DrawFilledRect(resXHalf - 1, m_resY - yBoxHeight - margin, resXHalf + 1, m_resY - margin);
 	}
 

--- a/mp/src/game/client/neo/ui/neo_hud_compass.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.cpp
@@ -70,7 +70,6 @@ CNEOHud_Compass::CNEOHud_Compass(const char *pElementName, vgui::Panel *parent)
 	COMPILE_TIME_ASSERT(sizeof(m_wszCompassUnicode) == UNICODE_NEO_COMPASS_SIZE_BYTES);
 	Assert(g_pVGuiLocalize);
 	g_pVGuiLocalize->ConvertANSIToUnicode("\0", m_wszCompassUnicode, UNICODE_NEO_COMPASS_SIZE_BYTES);
-	engine->ClientCmd("hud_reloadscheme");
 }
 
 void CNEOHud_Compass::Paint()
@@ -168,6 +167,7 @@ void CNEOHud_Compass::ApplySchemeSettings(vgui::IScheme *pScheme)
 	BaseClass::ApplySchemeSettings(pScheme);
 
 	m_hFont = pScheme->GetFont("NHudOCRSmall");
+	m_savedXBoxWidth = 0;
 
 	surface()->GetScreenSize(m_resX, m_resY);
 	SetBounds(0, 0, m_resX, m_resY);
@@ -183,9 +183,14 @@ void CNEOHud_Compass::DrawCompass() const
 	int fontWidth, fontHeight;
 	surface()->GetTextSize(m_hFont, m_wszCompassUnicode, fontWidth, fontHeight);
 
-	// These are the constant res based scalings of the compass box dimensions.
-	const int xBoxWidth = m_resX * 0.25 * 0.9;
-	const int yBoxHeight = fontHeight; // m_resY *(0.1 / 1.5) *(1.0 / 3);
+	if (m_savedXBoxWidth == 0)
+	{
+		// Using the fontHeight for padding works out
+		m_savedXBoxWidth = fontWidth + fontHeight;
+	}
+	// These are the compass box dimension, just based on the font's dimensions
+	const int xBoxWidth = m_savedXBoxWidth;
+	const int yBoxHeight = fontHeight;
 
 	const int resXHalf = m_resX / 2;
 	const int xBoxWidthHalf = xBoxWidth / 2;
@@ -251,15 +256,16 @@ void CNEOHud_Compass::DrawCompass() const
 		}
 	}
 
+	static const Color FADE_END_COLOR(116, 116, 116, 255);
 	DrawNeoHudRoundedBoxFaded(
 		resXHalf - xBoxWidthHalf, m_resY - yBoxHeight - margin,
 		resXHalf, m_resY - margin,
-		NEO_HUDBOX_COLOR, 255, 0, true,
+		FADE_END_COLOR, 255, 0, true,
 		true, false, true, false);
 	DrawNeoHudRoundedBoxFaded(
 		resXHalf, m_resY - yBoxHeight - margin,
 		resXHalf + xBoxWidthHalf, m_resY - margin,
-		NEO_HUDBOX_COLOR, 0, 255, true,
+		FADE_END_COLOR, 0, 255, true,
 		false, true, false, true);
 }
 

--- a/mp/src/game/client/neo/ui/neo_hud_compass.h
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.h
@@ -37,6 +37,7 @@ private:
 	vgui::HFont m_hFont;
 
 	int m_resX, m_resY;
+	mutable int m_savedXBoxWidth = 0;
 
 	wchar_t m_wszCompassUnicode[UNICODE_NEO_COMPASS_STR_LENGTH];
 

--- a/mp/src/game/client/neo/ui/neo_hud_compass.h
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.h
@@ -40,6 +40,12 @@ private:
 
 	wchar_t m_wszCompassUnicode[UNICODE_NEO_COMPASS_STR_LENGTH];
 
+	CPanelAnimationVarAliasType(bool, m_showCompass, "visible", "1", "bool");
+	CPanelAnimationVarAliasType(int, m_yFromBottomPos, "y_bottom_pos", "3", "proportional_ypos");
+	CPanelAnimationVarAliasType(bool, m_needleVisible, "needle_visible", "0", "bool");
+	CPanelAnimationVarAliasType(bool, m_needleColored, "needle_colored", "0", "bool");
+	CPanelAnimationVarAliasType(bool, m_objectiveVisible, "objective_visible", "1", "bool");
+
 private:
 	CNEOHud_Compass(const CNEOHud_Compass &other);
 };

--- a/mp/src/game/client/neo/ui/neo_hud_compass.h
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.h
@@ -10,7 +10,8 @@
 
 class CNeoHudElements;
 
-#define UNICODE_NEO_COMPASS_STR_LENGTH 50
+static constexpr size_t UNICODE_NEO_COMPASS_VIS_AROUND = 33; // How many characters should be visible around each side of the needle position
+static constexpr size_t UNICODE_NEO_COMPASS_STR_LENGTH = ((UNICODE_NEO_COMPASS_VIS_AROUND * 2) + 2);
 
 class CNEOHud_Compass : public CNEOHud_ChildElement, public CHudElement, public vgui::Panel
 {

--- a/mp/src/game/client/neo/ui/neo_hud_elements.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_elements.cpp
@@ -21,7 +21,7 @@
 #include "tier0/memdbgon.h"
 
 #define UI_ELEMENT_NAME_AMMO "NHudWeapon"
-#define UI_ELEMENT_NAME_COMPASS "neo_compass"
+#define UI_ELEMENT_NAME_COMPASS "NHudCompass"
 #define UI_ELEMENT_NAME_HTA "NHudHealth"
 #define UI_ELEMENT_NAME_IFF "neo_iff"
 #define UI_ELEMENT_GAME_EVENT "CNEOHud_GameEvent"
@@ -266,7 +266,7 @@ void CNeoHudElements::InitAmmo()
 void CNeoHudElements::InitCompass()
 {
 	Assert(!m_pCompass);
-	m_pCompass = new CNEOHud_Compass(UI_ELEMENT_NAME_COMPASS, this);
+	m_pCompass = new CNEOHud_Compass(UI_ELEMENT_NAME_COMPASS, NULL);
 }
 
 void CNeoHudElements::InitFriendlyMarker()


### PR DESCRIPTION
* Styling closer to OG:NT, rounded corners, faded text, compass length, and NSWE direction adjusted to OG:NT's NSWE directions
* Changed hud customisation, now can be done via `HudLayout.res` (currently OG:NT's HudLayout.res takes precedent)
* Fixes: https://github.com/NeotokyoRebuild/neo/issues/50