### PR TITLE
Decouple viewmodel FOV, left/right toggle, draw toggle, fix viewmodel

### DIFF
--- a/mp/src/game/client/c_baseviewmodel.cpp
+++ b/mp/src/game/client/c_baseviewmodel.cpp
@@ -35,7 +35,7 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
-#ifdef CSTRIKE_DLL
+#if defined(NEO) || defined(CSTRIKE_DLL)
 	ConVar cl_righthand( "cl_righthand", "1", FCVAR_ARCHIVE, "Use right-handed view models." );
 #endif
 
@@ -197,7 +197,7 @@ bool C_BaseViewModel::Interpolate( float currentTime )
 
 bool C_BaseViewModel::ShouldFlipViewModel()
 {
-#ifdef CSTRIKE_DLL
+#if defined(NEO) || defined(CSTRIKE_DLL)
 	// If cl_righthand is set, then we want them all right-handed.
 	CBaseCombatWeapon *pWeapon = m_hWeapon.Get();
 	if ( pWeapon )

--- a/mp/src/game/client/hl2mp/clientmode_hl2mpnormal.cpp
+++ b/mp/src/game/client/hl2mp/clientmode_hl2mpnormal.cpp
@@ -19,6 +19,7 @@
 #ifdef NEO
 	#include "neo/ui/neo_scoreboard.h"
 	#include "neo/ui/neo_hud_elements.h"
+	extern ConVar v_viewmodel_fov;
 #else
 	#include "hl2mpclientscoreboard.h"
 #endif
@@ -226,7 +227,7 @@ float ClientModeHL2MPNormal::GetViewModelFOV()
 				}
 			}
 
-			static float flCurrentFov = pWepInfo->m_flVMFov;
+			float flCurrentFov = v_viewmodel_fov.GetFloat();
 			const bool playerAiming = pOwner->IsInAim();
 			const float currentTime = gpGlobals->curtime;
 			if (m_bViewAim && !playerAiming)

--- a/mp/src/game/client/view.cpp
+++ b/mp/src/game/client/view.cpp
@@ -111,7 +111,7 @@ extern ConVar cl_forwardspeed;
 static ConVar v_centermove( "v_centermove", "0.15");
 static ConVar v_centerspeed( "v_centerspeed","500" );
 
-#ifdef TF_CLIENT_DLL
+#if defined(NEO) || defined(TF_CLIENT_DLL)
 // 54 degrees approximates a 35mm camera - we determined that this makes the viewmodels
 // and motions look the most natural.
 ConVar v_viewmodel_fov( "viewmodel_fov", "54", FCVAR_ARCHIVE, "Sets the field-of-view for the viewmodel.", true, 0.1, true, 179.9 );
@@ -848,9 +848,8 @@ void CViewRender::SetUpViews()
 
 	//Adjust the viewmodel's FOV to move with any FOV offsets on the viewer's end
 #ifdef SDK2013CE
-#ifdef NEO // Viewmodel FOV determined by multiplier from default FOV off its own FOV
-	float fovMultiplier = view.fov / static_cast<float>(DEFAULT_FOV);
-	view.fovViewmodel = g_pClientMode->GetViewModelFOV() * fovMultiplier;
+#ifdef NEO // NEO NOTE: Viewmodel FOV and (neo_fov) FOV are decoupled
+	view.fovViewmodel = g_pClientMode->GetViewModelFOV();
 #else
 	view.fovViewmodel = fabs(g_pClientMode->GetViewModelFOV() - flFOVOffset);
 #endif

--- a/mp/src/game/client/viewrender.cpp
+++ b/mp/src/game/client/viewrender.cpp
@@ -110,7 +110,7 @@ static ConVar r_drawopaqueworld( "r_drawopaqueworld", "1", FCVAR_CHEAT );
 static ConVar r_drawtranslucentworld( "r_drawtranslucentworld", "1", FCVAR_CHEAT );
 static ConVar r_3dsky( "r_3dsky","1", 0, "Enable the rendering of 3d sky boxes" );
 static ConVar r_skybox( "r_skybox","1", FCVAR_CHEAT, "Enable the rendering of sky boxes" );
-#ifdef TF_CLIENT_DLL
+#if defined(NEO) || defined(TF_CLIENT_DLL)
 ConVar r_drawviewmodel( "r_drawviewmodel","1", FCVAR_ARCHIVE );
 #else
 ConVar r_drawviewmodel( "r_drawviewmodel","1", FCVAR_CHEAT );


### PR DESCRIPTION
* `neo_viewmodel_fov_offset` is a new ConVar to offset NT's viewmodel and can be set
* `cl_righthand` is now available and can be set
* `r_drawviewmodel` is now available and can be set
* Fixes: https://github.com/NeotokyoRebuild/neo/issues/282
* Fix the lerp section that's no longer needed and caused viewmodel shaking.
* Might fix viewmodel going random