### PR TITLE
Scoped weapon zoom at parity

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1414,9 +1414,15 @@ void C_NEO_Player::Weapon_SetZoom(const bool bZoomIn)
 	if (bZoomIn)
 	{
 		m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
-
-		const int zoomAmount = 30;
-		SetFOV((CBaseEntity*)this, fov - zoomAmount, zoomSpeedSecs);
+		auto neoWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
+		if (neoWep && neoWep->GetNeoWepBits() & NEO_WEP_SCOPEDWEAPON)
+		{
+			SetFOV((CBaseEntity*)this, 16, zoomSpeedSecs);
+		}
+		else {
+			const int zoomAmount = 30;
+			SetFOV((CBaseEntity*)this, fov - zoomAmount, zoomSpeedSecs);
+		}
 	}
 	else
 	{

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1414,6 +1414,7 @@ void C_NEO_Player::Weapon_SetZoom(const bool bZoomIn)
 	if (bZoomIn)
 	{
 		m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
+		const int zoomAmount = 30;
 		auto neoWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
 		if (neoWep)
 		{
@@ -1422,12 +1423,10 @@ void C_NEO_Player::Weapon_SetZoom(const bool bZoomIn)
 			else if (neoWep->GetNeoWepBits() & NEO_WEP_ZR68_L)
 				SetFOV((CBaseEntity*)this, 26, zoomSpeedSecs);
 			else {
-				const int zoomAmount = 30;
 				SetFOV((CBaseEntity*)this, fov - zoomAmount, zoomSpeedSecs);
 			}
 		}
 		else {
-			const int zoomAmount = 30;
 			SetFOV((CBaseEntity*)this, fov - zoomAmount, zoomSpeedSecs);
 		}
 	}

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1415,9 +1415,16 @@ void C_NEO_Player::Weapon_SetZoom(const bool bZoomIn)
 	{
 		m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
 		auto neoWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
-		if (neoWep && neoWep->GetNeoWepBits() & NEO_WEP_SCOPEDWEAPON)
+		if (neoWep)
 		{
-			SetFOV((CBaseEntity*)this, 16, zoomSpeedSecs);
+			if (neoWep->GetNeoWepBits() & NEO_WEP_SRS)
+				SetFOV((CBaseEntity*)this, 16, zoomSpeedSecs);
+			else if (neoWep->GetNeoWepBits() & NEO_WEP_ZR68_L)
+				SetFOV((CBaseEntity*)this, 26, zoomSpeedSecs);
+			else {
+				const int zoomAmount = 30;
+				SetFOV((CBaseEntity*)this, fov - zoomAmount, zoomSpeedSecs);
+			}
 		}
 		else {
 			const int zoomAmount = 30;

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1250,6 +1250,7 @@ void CNEO_Player::Weapon_SetZoom(const bool bZoomIn)
 	const int fov = GetDefaultFOV();
 	if (bZoomIn)
 	{
+		const int zoomAmount = 30;
 		auto neoWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
 		if (neoWep)
 		{
@@ -1258,12 +1259,10 @@ void CNEO_Player::Weapon_SetZoom(const bool bZoomIn)
 			else if (neoWep->GetNeoWepBits() & NEO_WEP_ZR68_L)
 				SetFOV((CBaseEntity*)this, 26, NEO_ZOOM_SPEED);
 			else {
-				const int zoomAmount = 30;
 				SetFOV((CBaseEntity*)this, fov - zoomAmount, NEO_ZOOM_SPEED);
 			}
 		}
 		else {
-			const int zoomAmount = 30;
 			SetFOV((CBaseEntity*)this, fov - zoomAmount, NEO_ZOOM_SPEED);
 		}
 	}

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1250,8 +1250,15 @@ void CNEO_Player::Weapon_SetZoom(const bool bZoomIn)
 	const int fov = GetDefaultFOV();
 	if (bZoomIn)
 	{
-		const int zoomAmount = 30;
-		SetFOV((CBaseEntity*)this, fov - zoomAmount, NEO_ZOOM_SPEED);
+		auto neoWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
+		if (neoWep && neoWep->GetNeoWepBits() & NEO_WEP_SCOPEDWEAPON)
+		{
+			SetFOV((CBaseEntity*)this, 16, NEO_ZOOM_SPEED);
+		}
+		else {
+			const int zoomAmount = 30;
+			SetFOV((CBaseEntity*)this, fov - zoomAmount, NEO_ZOOM_SPEED);
+		}
 	}
 	else
 	{

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1251,9 +1251,16 @@ void CNEO_Player::Weapon_SetZoom(const bool bZoomIn)
 	if (bZoomIn)
 	{
 		auto neoWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
-		if (neoWep && neoWep->GetNeoWepBits() & NEO_WEP_SCOPEDWEAPON)
+		if (neoWep)
 		{
-			SetFOV((CBaseEntity*)this, 16, NEO_ZOOM_SPEED);
+			if (neoWep->GetNeoWepBits() & NEO_WEP_SRS)
+				SetFOV((CBaseEntity*)this, 16, NEO_ZOOM_SPEED);
+			else if (neoWep->GetNeoWepBits() & NEO_WEP_ZR68_L)
+				SetFOV((CBaseEntity*)this, 26, NEO_ZOOM_SPEED);
+			else {
+				const int zoomAmount = 30;
+				SetFOV((CBaseEntity*)this, fov - zoomAmount, NEO_ZOOM_SPEED);
+			}
 		}
 		else {
 			const int zoomAmount = 30;


### PR DESCRIPTION
Scoped weapon zoom now decoupled from neo_fov and should always show the same amount of stuff as og tokyo at 4:3. 