### PR TITLE
Fix SUB_Remove deferred thinks

### DIFF
--- a/mp/src/game/server/subs.cpp
+++ b/mp/src/game/server/subs.cpp
@@ -86,20 +86,6 @@ void CBaseEntity::SUB_Remove( void )
 		DevWarning( 2, "SUB_Remove called on entity with health > 0\n");
 	}
 
-#if(0)
-#ifdef NEO
-	// NEO HACK (Rain): Hacky way to ensure Neo weapons don't remove themselves.
-	// There's probably some flag we could raise to prevent it from happening
-	// in a nicer way.
-	auto neoWep = dynamic_cast<CNEOBaseCombatWeapon*>(this);
-
-	if (neoWep)
-	{
-		return;
-	}
-#endif
-#endif
-
 	UTIL_Remove( this );
 }
 

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -281,6 +281,9 @@ CNEORules::CNEORules()
 
 CNEORules::~CNEORules()
 {
+#ifdef GAME_DLL
+	weaponstay.InstallChangeCallback(nullptr);
+#endif
 }
 
 #ifdef GAME_DLL

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -275,7 +275,6 @@ CNEORules::CNEORules()
 	ListenForGameEvent("round_start");
 
 #ifdef GAME_DLL
-	FnChangeCallback_t;
 	weaponstay.InstallChangeCallback(CvarChanged_WeaponStay);
 #endif
 }

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -21,6 +21,8 @@
 	#include "hl2mp_gameinterface.h"
 	#include "player_resource.h"
 	#include "inetchannelinfo.h"
+
+extern ConVar weaponstay;
 #endif
 
 ConVar mp_neo_loopback_warmup_round("mp_neo_loopback_warmup_round", "0", FCVAR_REPLICATED, "Allow loopback server to do warmup rounds.", true, 0.0f, true, 1.0f);
@@ -224,6 +226,22 @@ static inline void FireLegacyEvent_NeoRoundEnd()
 #endif
 }
 
+#ifdef GAME_DLL
+static void CvarChanged_WeaponStay(IConVar* convar, const char* pOldVal, float flOldVal)
+{
+	auto wep = gEntList.NextEntByClass((CNEOBaseCombatWeapon*)NULL);
+	while (wep)
+	{
+		// Don't schedule removal for guns currently held by someone
+		if (!wep->GetOwner())
+		{
+			wep->SetPickupTouch();
+		}
+		wep = gEntList.NextEntByClass(wep);
+	}
+}
+#endif
+
 CNEORules::CNEORules()
 {
 #ifdef GAME_DLL
@@ -255,6 +273,11 @@ CNEORules::CNEORules()
 	m_iGhosterPlayer = 0;
 
 	ListenForGameEvent("round_start");
+
+#ifdef GAME_DLL
+	FnChangeCallback_t;
+	weaponstay.InstallChangeCallback(CvarChanged_WeaponStay);
+#endif
 }
 
 CNEORules::~CNEORules()
@@ -958,11 +981,6 @@ void CNEORules::CreateStandardEntities(void)
 		CBaseEntity::Create("neo_gamerules", vec3_origin, vec3_angle);
 	Assert(pEnt);
 #endif
-}
-
-int CNEORules::WeaponShouldRespawn(CBaseCombatWeapon *pWeapon)
-{
-	return GR_NONE;
 }
 
 const char *CNEORules::GetGameDescription(void)

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -133,8 +133,6 @@ public:
 	virtual void Think( void ) OVERRIDE;
 	virtual void CreateStandardEntities( void ) OVERRIDE;
 
-	virtual int WeaponShouldRespawn(CBaseCombatWeapon* pWeapon) OVERRIDE;
-
 	virtual const char *GetGameDescription( void ) OVERRIDE;
 	virtual const CViewVectors* GetViewVectors() const OVERRIDE;
 

--- a/mp/src/game/shared/neo/weapons/weapon_ghost.h
+++ b/mp/src/game/shared/neo/weapons/weapon_ghost.h
@@ -45,6 +45,14 @@ public:
 	bool IsPosWithinViewDistance(const Vector &otherPlayerPos, float &dist);
 	float DistanceToPos(const Vector& otherPlayerPos);
 
+#if _DEBUG
+	virtual void SUB_Remove(void) override
+	{
+		DevWarning("SUB_Remove called on ghost!"); // this is probably a mistake if it ever happens
+		BaseClass::SUB_Remove();
+	}
+#endif
+
 #ifdef CLIENT_DLL
 	void PlayGhostSound(float volume = 1.0f);
 	void StopGhostSound(void);

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -202,18 +202,14 @@ public:
 	virtual bool CanBePickedUpByClass(int classId);
 	virtual bool CanDrop(void);
 
+	virtual void SetPickupTouch(void) override;
+
 #ifdef CLIENT_DLL
 	virtual bool Holster(CBaseCombatWeapon* pSwitchingTo);
 	virtual void ItemHolsterFrame() OVERRIDE;
 #endif
 
 	virtual bool Deploy(void);
-
-	// NEO HACK/FIXME (Rain):
-	// We override with empty implementation to avoid getting removed by
-	// some game logic somewhere. There's probably some flag we could set
-	// somewhere to achieve the same without having to do this.
-	virtual void SUB_Remove(void) { }
 
 	virtual float GetFireRate(void) OVERRIDE { Assert(false); return BaseClass::GetFireRate(); } // Should never call this base class; override in children.
 	virtual bool GetRoundChambered() const { return 0; }

--- a/mp/src/game/shared/neo/weapons/weapon_neobaseweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobaseweapon.h
@@ -81,12 +81,6 @@ public:
 
 	bool IsGhost(void) const { return (GetNeoWepBits() & NEO_WEP_GHOST) ? true : false; }
 
-	// NEO HACK/FIXME (Rain):
-	// We override with empty implementation to avoid getting removed by
-	// some game logic somewhere. There's probably some flag we could set
-	// somewhere to achieve the same without having to do this.
-	virtual void SUB_Remove(void) { }
-
 private:
 	INEOBaseWeapon(const INEOBaseWeapon &other);
 };


### PR DESCRIPTION
Fix #330 

Previously, we were overriding `SUB_Remove` for NT guns as a hack to prevent them from disappearing mid-round. This fix re-enables the correct `SUB_Remove` behaviour, and instead handles the deferred removals at the `SetPickupTouch` override, based on `mp_weaponstay` cvar's boolean value - with the exception of the ghost never being deleted from the world, regardless of the cvar's value.

We're defaulting to the more sensible `mp_weaponstay 1` behaviour to keep dropped guns in the world over parity, but the original NT behaviour can be restored by toggling this cvar to 0 instead.