### PR TITLE
Idle/Warmup auto respawn with menu

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -47,6 +47,8 @@
 
 #include "neo_playeranimstate.h"
 
+#include "c_user_message_register.h"
+
 // Don't alias here
 #if defined( CNEO_Player )
 #undef CNEO_Player	
@@ -189,7 +191,13 @@ static void __MsgFunc_DamageInfo(bf_read& msg)
 		totals.takenTotalDmgs, totals.takenTotalHits,
 		BORDER);
 }
-static bool g_hasHookDamageInfo = false;
+USER_MESSAGE_REGISTER(DamageInfo);
+
+static void __MsgFunc_IdleRespawnShowMenu(bf_read &)
+{
+	engine->ClientCmd("classmenu");
+}
+USER_MESSAGE_REGISTER(IdleRespawnShowMenu);
 
 ConVar cl_drawhud_quickinfo("cl_drawhud_quickinfo", "0", 0,
 	"Whether to display HL2 style ammo/health info near crosshair.",
@@ -412,11 +420,6 @@ C_NEO_Player::C_NEO_Player()
 
 	memset(m_szNeoNameWDupeIdx, 0, sizeof(m_szNeoNameWDupeIdx));
 	m_szNameDupePos = 0;
-	if (!g_hasHookDamageInfo)
-	{
-		usermessages->HookMessage("DamageInfo", __MsgFunc_DamageInfo);
-		g_hasHookDamageInfo = true;
-	}
 }
 
 C_NEO_Player::~C_NEO_Player()

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -195,7 +195,12 @@ USER_MESSAGE_REGISTER(DamageInfo);
 
 static void __MsgFunc_IdleRespawnShowMenu(bf_read &)
 {
-	engine->ClientCmd("classmenu");
+	if (auto *localPlayer = C_NEO_Player::GetLocalNEOPlayer())
+	{
+		localPlayer->m_bShowTeamMenu = false;
+		localPlayer->m_bShowClassMenu = true;
+		localPlayer->m_bIsClassMenuOpen = false;
+	}
 }
 USER_MESSAGE_REGISTER(IdleRespawnShowMenu);
 
@@ -220,6 +225,11 @@ public:
 			Assert(false);
 			Warning("Couldn't find weapon loadout panel\n");
 			return;
+		}
+
+		if (panel->IsVisible() && panel->IsEnabled())
+		{
+			return;	// Prevent cursor stuck
 		}
 
 		panel->SetProportional(false); // Fixes wrong menu size when in windowed mode, regardless of whether proportional is set to false in the res file (NEOWTF)
@@ -283,6 +293,12 @@ public:
 			Warning("Couldn't find class panel\n");
 			return;
 		}
+
+		if (panel->IsVisible() && panel->IsEnabled())
+		{
+			return;	// Prevent cursor stuck
+		}
+
 		panel->SetProportional(false);
 		panel->ApplySchemeSettings(vgui::scheme()->GetIScheme(panel->GetScheme()));
 
@@ -329,6 +345,11 @@ public:
 			Assert(false);
 			Warning("Couldn't find team panel\n");
 			return;
+		}
+
+		if (panel->IsVisible() && panel->IsEnabled())
+		{
+			return;	// Prevent cursor stuck
 		}
 
 		panel->SetProportional(false);

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -214,7 +214,6 @@ public:
 
 	unsigned char m_NeoFlags;
 
-protected:
 	bool m_bIsClassMenuOpen, m_bIsTeamMenuOpen;
 
 private:

--- a/mp/src/game/server/neo/neo_client.cpp
+++ b/mp/src/game/server/neo/neo_client.cpp
@@ -314,7 +314,7 @@ void ClientGamePrecache( void )
 }
 
 // called by ClientKill and DeadThink
-void respawn( CBaseEntity *pEdict, bool fCopyCorpse )
+bool RespawnWithRet( CBaseEntity *pEdict, bool fCopyCorpse )
 {
 	CNEO_Player *pPlayer = ToNEOPlayer( pEdict );
 
@@ -326,6 +326,7 @@ void respawn( CBaseEntity *pEdict, bool fCopyCorpse )
 			{
 				// respawn player
 				pPlayer->Spawn();
+				return true;
 			}
 		}
 		else
@@ -333,6 +334,12 @@ void respawn( CBaseEntity *pEdict, bool fCopyCorpse )
 			pPlayer->SetNextThink( gpGlobals->curtime + 0.1f );
 		}
 	}
+	return false;
+}
+
+void respawn(CBaseEntity *pEdict, bool fCopyCorpse)
+{
+	RespawnWithRet(pEdict, fCopyCorpse);
 }
 
 ConVar sv_neo_bot_think("sv_neo_bot_think",

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -138,7 +138,10 @@ void CNEO_Player::RequestSetClass(int newClass)
 		return;
 	}
 
-	if (IsDead() || sv_neo_can_change_classes_anytime.GetBool() || (!m_bDroppedAnything && NEORules()->GetRemainingPreRoundFreezeTime(false) > 0))
+	const NeoRoundStatus status = NEORules()->GetRoundStatus();
+	if (IsDead() || sv_neo_can_change_classes_anytime.GetBool() ||
+		(!m_bDroppedAnything && NEORules()->GetRemainingPreRoundFreezeTime(false) > 0) ||
+		(status == NeoRoundStatus::Idle || status == NeoRoundStatus::Warmup))
 	{
 		m_iNeoClass = newClass;
 		m_iNextSpawnClassChoice = -1;
@@ -2563,7 +2566,9 @@ void CNEO_Player::GiveDefaultItems(void)
 
 void CNEO_Player::GiveLoadoutWeapon(void)
 {
-	if (IsObserver() || IsDead() || m_bDroppedAnything || ((NEORules()->GetRemainingPreRoundFreezeTime(false)) < 0))
+	const NeoRoundStatus status = NEORules()->GetRoundStatus();
+	if (!(status == NeoRoundStatus::Idle || status == NeoRoundStatus::Warmup) && 
+		(IsObserver() || IsDead() || m_bDroppedAnything || ((NEORules()->GetRemainingPreRoundFreezeTime(false)) < 0)))
 	{
 		return;
 	}

--- a/mp/src/game/shared/hl2/hl2_usermessages.cpp
+++ b/mp/src/game/shared/hl2/hl2_usermessages.cpp
@@ -49,6 +49,7 @@ void RegisterUserMessages( void )
 
 #ifdef NEO
 	usermessages->Register( "DamageInfo", -1 );
+	usermessages->Register( "IdleRespawnShowMenu", -1 );
 #endif
 
 #ifndef _X360


### PR DESCRIPTION
* Player now auto-respawns on Idle/Warmup rounds, with menu open after spawning
* Fixes: https://github.com/NeotokyoRebuild/neo/issues/288
* Add a guard on the menus to prevent cursor getting stuck
* Utilise `USER_MESSAGE_REGISTER`