### PR TITLE
Fix missing HudLayout.res defines (HudMenu/HudRadio) - Fixes attacker info missing

### DIFF
--- a/mp/game/neo/scripts/HudLayout.res
+++ b/mp/game/neo/scripts/HudLayout.res
@@ -448,6 +448,34 @@
 		"TextColor"	"255 255 255 192"
 
 	}
+
+	HudMenu
+	{
+		"fieldName" "HudMenu"
+		"visible" "1"
+		"enabled" "1"
+		"wide"	 "640"
+		"tall"	 "480"
+		"zpos"	"1"
+		"TextFont"	"Default"
+		"ItemFont"	"Default"
+		"ItemFontPulsing"	"Default"
+	}
+
+	HudRadio
+	{
+		"fieldName"	"HudRadio"
+		"TextFont"	"Default"
+		"visible"	"1"
+		"xpos"	"10"
+		"ypos"	"c"
+		"wide"	"Default"
+		"tall"	"Default"
+		"text_ygap"	"2"
+		"TextColor"	"255 255 255 192"
+		"PaintBackgroundType"	"0"
+	}
+
 	"HudChat"
 	{
 		"ControlName"		"EditablePanel"


### PR DESCRIPTION
The HudLayout.res wasn't updated for the asset change, causing HudMenu to have empty texts which caused the attacker info to look like nothing.