### PR TITLE
Grenades shouldn't collide with players

### DIFF
--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -379,7 +379,8 @@ bool CNEORules::ShouldCollide(int collisionGroup0, int collisionGroup1)
 	}
 
 	if ((collisionGroup0 == COLLISION_GROUP_PLAYER || collisionGroup0 == COLLISION_GROUP_PLAYER_MOVEMENT) &&
-		((collisionGroup1 == COLLISION_GROUP_WEAPON) || (collisionGroup1 == COLLISION_GROUP_PLAYER || collisionGroup1 == COLLISION_GROUP_PLAYER_MOVEMENT)))
+		(collisionGroup1 == COLLISION_GROUP_PROJECTILE || collisionGroup1 == COLLISION_GROUP_WEAPON ||
+		 collisionGroup1 == COLLISION_GROUP_PLAYER || collisionGroup1 == COLLISION_GROUP_PLAYER_MOVEMENT))
 	{
 		return false;
 	}


### PR DESCRIPTION
* Projectiles = grenades, so smokes and frags
* fixes #289