### PR TITLE
Fix dead player observing & bot team join logic parity

### DIFF
--- a/mp/src/game/client/c_baseplayer.cpp
+++ b/mp/src/game/client/c_baseplayer.cpp
@@ -714,11 +714,14 @@ bool C_BasePlayer::IsValidObserverTarget(CBaseEntity* target)
 	{
 		switch (mp_forcecamera.GetInt())
 		{
-		case OBS_ALLOW_ALL:	break;
-		case OBS_ALLOW_TEAM:	if (GetTeamNumber() != target->GetTeamNumber())
-			return false;
+		case OBS_ALLOW_ALL:
 			break;
-		case OBS_ALLOW_NONE:	return false;
+		case OBS_ALLOW_TEAM:
+			if (GetTeamNumber() != target->GetTeamNumber())
+				return false;
+			break;
+		case OBS_ALLOW_NONE:
+			return false;
 		}
 	}
 

--- a/mp/src/game/client/c_baseplayer.cpp
+++ b/mp/src/game/client/c_baseplayer.cpp
@@ -620,6 +620,7 @@ void C_BasePlayer::SetObserverMode ( int iNewMode )
 	}
 }
 
+#ifdef NEO
 int C_BasePlayer::GetNextObserverSearchStartPoint(bool bReverse)
 {
 	int iDir = bReverse ? -1 : 1;
@@ -723,6 +724,7 @@ bool C_BasePlayer::IsValidObserverTarget(CBaseEntity* target)
 
 	return true;	// passed all test
 }
+#endif
 
 int C_BasePlayer::GetObserverMode() const 
 { 

--- a/mp/src/game/client/c_baseplayer.h
+++ b/mp/src/game/client/c_baseplayer.h
@@ -150,6 +150,12 @@ public:
 	virtual CBaseEntity	*GetObserverTarget() const;
 	void			SetObserverTarget( EHANDLE hObserverTarget );
 
+#ifdef NEO
+	virtual int				GetNextObserverSearchStartPoint(bool bReverse); // Where we should start looping the player list in a FindNextObserverTarget call
+	virtual CBaseEntity* FindNextObserverTarget(bool bReverse); // returns next/prev player to follow or nullptr
+	virtual bool			IsValidObserverTarget(CBaseEntity* target); // true, if player is allowed to see this target
+#endif
+
 	bool			AudioStateIsUnderwater( Vector vecMainViewOrigin );
 
 	bool IsObserver() const;
@@ -454,7 +460,12 @@ protected:
 							float& zNear, float& zFar, float& fov );
 	virtual void		CalcObserverView( Vector& eyeOrigin, QAngle& eyeAngles, float& fov );
 	virtual Vector		GetChaseCamViewOffset( CBaseEntity *target );
-	void				CalcChaseCamView( Vector& eyeOrigin, QAngle& eyeAngles, float& fov );
+
+#ifdef NEO
+	virtual
+#endif
+		void				CalcChaseCamView( Vector& eyeOrigin, QAngle& eyeAngles, float& fov );
+
 	virtual void		CalcInEyeCamView( Vector& eyeOrigin, QAngle& eyeAngles, float& fov );
 
 	virtual float		GetDeathCamInterpolationTime();

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -88,6 +88,8 @@ IMPLEMENT_CLIENTCLASS_DT(C_NEO_Player, DT_NEO_Player, CNEO_Player)
 	RecvPropString(RECVINFO(m_szNeoName)),
 	RecvPropInt(RECVINFO(m_szNameDupePos)),
 	RecvPropBool(RECVINFO(m_bClientWantNeoName)),
+
+	RecvPropTime(RECVINFO(m_flDeathTime)),
 END_RECV_TABLE()
 
 BEGIN_PREDICTION_DATA(C_NEO_Player)
@@ -1361,6 +1363,53 @@ float C_NEO_Player::GetSprintSpeed(void) const
 	default:
 		return NEO_BASE_SPRINT_SPEED * GetBackwardsMovementPenaltyScale();
 	}
+}
+
+void C_NEO_Player::CalcChaseCamView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov)
+{
+	if (!HandleDeathSpecCamSwitch(eyeOrigin, eyeAngles, fov))
+	{
+		BaseClass::CalcChaseCamView(eyeOrigin, eyeAngles, fov);
+	}
+}
+
+void C_NEO_Player::CalcInEyeCamView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov)
+{
+	if (!HandleDeathSpecCamSwitch(eyeOrigin, eyeAngles, fov))
+	{
+		BaseClass::CalcInEyeCamView(eyeOrigin, eyeAngles, fov);
+	}
+}
+
+bool C_NEO_Player::HandleDeathSpecCamSwitch(Vector& eyeOrigin, QAngle& eyeAngles, float& fov)
+{
+	fov = GetFOV(); // jic the caller relies on us initializing this
+
+	auto target = GetObserverTarget();
+	if (!target || !target->IsAlive())
+	{
+		if (target && !target->IsAlive())
+		{
+			auto playerTarget = ToBasePlayer(target);
+			if (playerTarget)
+			{
+				const auto dtDeath = gpGlobals->curtime - playerTarget->GetDeathTime();
+				constexpr auto specDeathCamTime = 3;
+				if (dtDeath > specDeathCamTime)
+				{
+					auto nextTarget = FindNextObserverTarget(false);
+					if (nextTarget && nextTarget != target)
+					{
+						SetObserverTarget(nextTarget);
+					}
+				}
+			}
+		}
+		VectorCopy(EyePosition(), eyeOrigin);
+		VectorCopy(EyeAngles(), eyeAngles);
+		return true;
+	}
+	return false;
 }
 
 float C_NEO_Player::GetActiveWeaponSpeedScale() const

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1384,26 +1384,13 @@ void C_NEO_Player::CalcInEyeCamView(Vector& eyeOrigin, QAngle& eyeAngles, float&
 bool C_NEO_Player::HandleDeathSpecCamSwitch(Vector& eyeOrigin, QAngle& eyeAngles, float& fov)
 {
 	fov = GetFOV(); // jic the caller relies on us initializing this
-
 	auto target = GetObserverTarget();
-	if (!target || !target->IsAlive())
+	if (!IsValidObserverTarget(target))
 	{
-		if (target && !target->IsAlive())
+		auto nextTarget = FindNextObserverTarget(false);
+		if (nextTarget && nextTarget != target)
 		{
-			auto playerTarget = ToBasePlayer(target);
-			if (playerTarget)
-			{
-				const auto dtDeath = gpGlobals->curtime - playerTarget->GetDeathTime();
-				constexpr auto specDeathCamTime = 3;
-				if (dtDeath > specDeathCamTime)
-				{
-					auto nextTarget = FindNextObserverTarget(false);
-					if (nextTarget && nextTarget != target)
-					{
-						SetObserverTarget(nextTarget);
-					}
-				}
-			}
+			SetObserverTarget(nextTarget);
 		}
 		VectorCopy(EyePosition(), eyeOrigin);
 		VectorCopy(EyeAngles(), eyeAngles);

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -90,6 +90,9 @@ public:
 	virtual const Vector GetPlayerMins(void) const OVERRIDE;
 	virtual const Vector GetPlayerMaxs(void) const OVERRIDE;
 
+	virtual void CalcChaseCamView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov) override;
+	virtual void CalcInEyeCamView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov) override;
+
 	// Implementing in header in hopes of compiler picking up the inlined base method
 	virtual float GetModelScale() const
 	{
@@ -124,6 +127,8 @@ public:
 private:
 	float GetActiveWeaponSpeedScale() const;
 	float GetBackwardsMovementPenaltyScale() const { return ((m_nButtons & IN_BACK) ? NEO_SLOW_MODIFIER : 1.0); }
+
+	bool HandleDeathSpecCamSwitch(Vector& eyeOrigin, QAngle& eyeAngles, float& fov);
 
 public:
 	bool ShouldDrawHL2StyleQuickHud( void );

--- a/mp/src/game/server/neo/neo_client.cpp
+++ b/mp/src/game/server/neo/neo_client.cpp
@@ -343,6 +343,8 @@ ConVar sv_neo_bot_think("sv_neo_bot_think",
 #endif
 	FCVAR_NONE, "Run think on debug bots.", true, 0.0, true, 1.0);
 
+ConVar bot_next_team("bot_next_team", "-1", FCVAR_NONE, "Which team the next bot should join. -1: Choose the playing team with less players in it. -2: Random playing team. Any other value: The corresponding team index.");
+
 void GameStartFrame( void )
 {
 	VPROF("GameStartFrame()");

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -2371,7 +2371,9 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 			iTeam = RandomInt(TEAM_JINRAI, TEAM_NSF);
 			break;
 		default:
-			iTeam = joinMode.GetInt();
+			const auto lastGameTeam = GetNumberOfTeams() - LAST_SHARED_TEAM;
+			Assert(FIRST_GAME_TEAM <= lastGameTeam);
+			iTeam = Clamp(joinMode.GetInt(), FIRST_GAME_TEAM, lastGameTeam);
 		}
 	}
 	// Limit team join spam, unless this is a newly joined player

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -2356,11 +2356,13 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 		case JoinMode::TeamWithLessPlayers:
 			numJin = GetGlobalTeam(TEAM_JINRAI) ? GetGlobalTeam(TEAM_JINRAI)->GetNumPlayers() : 0;
 			numNsf = GetGlobalTeam(TEAM_NSF) ? GetGlobalTeam(TEAM_NSF)->GetNumPlayers() : 0;
-			if (numJin < numNsf) {
+			if (numJin < numNsf)
+			{
 				iTeam = TEAM_JINRAI;
 				break;
 			}
-			else if (numNsf < numJin) {
+			else if (numNsf < numJin)
+			{
 				iTeam = TEAM_NSF;
 				break;
 			}

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -75,6 +75,8 @@ SendPropInt(SENDINFO(m_NeoFlags), 4, SPROP_UNSIGNED),
 SendPropString(SENDINFO(m_szNeoName)),
 SendPropInt(SENDINFO(m_szNameDupePos)),
 SendPropBool(SENDINFO(m_bClientWantNeoName)),
+
+SendPropTime(SENDINFO(m_flDeathTime)),
 END_SEND_TABLE()
 
 BEGIN_DATADESC(CNEO_Player)

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -2711,15 +2711,18 @@ bool CBasePlayer::IsValidObserverTarget(CBaseEntity * target)
 	}
 		
 	// check forcecamera settings for active players
-	if ( GetTeamNumber() != TEAM_SPECTATOR )
+	if (GetTeamNumber() != TEAM_SPECTATOR)
 	{
-		switch ( mp_forcecamera.GetInt() )	
+		switch (mp_forcecamera.GetInt())
 		{
-			case OBS_ALLOW_ALL	:	break;
-			case OBS_ALLOW_TEAM :	if ( GetTeamNumber() != target->GetTeamNumber() )
-										 return false;
-									break;
-			case OBS_ALLOW_NONE :	return false;
+		case OBS_ALLOW_ALL:
+			break;
+		case OBS_ALLOW_TEAM:
+			if (GetTeamNumber() != target->GetTeamNumber())
+				return false;
+			break;
+		case OBS_ALLOW_NONE:
+			return false;
 		}
 	}
 	


### PR DESCRIPTION
Fix #336 

If spectating a player who has died, and it's been `>=DEATH_ANIMATION_TIME` since their death, look up the next valid target and switch to them.

---

Also sneaking in a `bot_next_team` server cvar, because it was useful for testing this. Set `bot_next_team` to a team index to force the next bot created by `bot_add` to join that specific team. Default value is `-1`, which instead makes the bot join the player team with less players. There's also `-2`, which makes bot join a player team completely at random. Anecdotally, this actually fixes a parity issue with bots - before this change, they were joining player teams completely randomly, but OG NT bots follow the `-1` value behaviour (which is the default now).

---

This PR duplicates some of the base `CBasePlayer` methods for client side access, to be called from the `C_NEO_Player::Calc<...>View` overrides. The client's also now receiving the `m_flDeathTime` prop for calculating the death deltatime client side for observing purposes.

---

### Steps to repro:
* Launch a CTG map
* Spawn some bots in both teams
* Join a team
* End the warmup with `mp_restartgame 1` if needed
* Set `mp_forcecamera 0`
* Suicide and start spectating other players
* Use `ent_fire !picker sethealth 0` to kill the current spec target and see what happens
  * If it targets the wrong client whilst in 1st person spec, go to chase cam for a second to update the picker target

### What happens before this patch:
* Can observe a dead player observing some third player

### What happens after this patch:
* Observing a dead client will automatically find the next valid obs target after `DEATH_ANIMATION_TIME` (3 seconds) since their death