### PR TITLE
Fix buggy viewmodel ADS change transition on dedicated servers

### DIFF
--- a/mp/src/game/client/hl2mp/clientmode_hl2mpnormal.h
+++ b/mp/src/game/client/hl2mp/clientmode_hl2mpnormal.h
@@ -41,6 +41,7 @@ public:
 #ifdef NEO
 	virtual float	GetViewModelFOV(void);
 	float m_flStartAimingChange;
+	float m_flVMFOV = 0.0f;
 	bool m_bViewAim;
 #endif
 };

--- a/mp/src/game/shared/neo/neo_predicted_viewmodel.h
+++ b/mp/src/game/shared/neo/neo_predicted_viewmodel.h
@@ -59,6 +59,8 @@ private:
 	float m_flLastLeanTime;
 	float m_flStartAimingChange;
 	bool m_bViewAim;
+	Vector m_vOffset;
+	QAngle m_angOffset;
 };
 
 #endif // NEO_PREDICTED_VIEWMODEL_H


### PR DESCRIPTION
* Seems to be the prediction system colliding it, so instead if out prediction and keep a record of the variables.
* It's kind of based on C_BasePlayer::GetFOV if-ing out prediction system. Although the start-end-time based can be kept.
* This also refactor the percentage usage to use clamp + lerp instead of basically doing the same thing as that.
* Make sure it doesn't affect loopback negatively
* Contrary to the original issue, it's replicated on both Windows + Linux
* fixes #284
* EDIT 1: Original reporter @xedmain confirmed on the fix