### PR TITLE
Replace hud_reloadscheme hack with EditablePanel + LoadControlSettings, indirectly fixes MOTD title + layout

### DIFF
--- a/mp/game/neo/scripts/HudLayout.res
+++ b/mp/game/neo/scripts/HudLayout.res
@@ -480,7 +480,7 @@
 	{
 		"ControlName"		"EditablePanel"
 		"fieldName" 		"HudChat"
-		"visible" 		"1"
+		"visible" 		"0"
 		"enabled" 		"1"
 		"xpos"			"10"
 		"ypos"			"275"

--- a/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
@@ -43,7 +43,7 @@ ConVar neo_cl_hud_debug_ammo_color_a("neo_cl_hud_debug_ammo_color_a", "255", FCV
 	"Alpha color value of the ammo, in range 0 - 255.", true, 0.0f, true, 255.0f);
 
 CNEOHud_Ammo::CNEOHud_Ammo(const char* pElementName, vgui::Panel* parent)
-	: CHudElement(pElementName), Panel(parent, pElementName)
+	: CHudElement(pElementName), EditablePanel(parent, pElementName)
 {
 	SetAutoDelete(true);
 
@@ -60,23 +60,9 @@ CNEOHud_Ammo::CNEOHud_Ammo(const char* pElementName, vgui::Panel* parent)
 		SetParent(g_pClientMode->GetViewport());
 	}
 
-	// NEO HACK (Rain): this is kind of awkward, we should get the handle on ApplySchemeSettings
-	vgui::IScheme* scheme = vgui::scheme()->GetIScheme(neoscheme);
-	if (!scheme) {
-		Assert(scheme);
-		Error("CNEOHud_Ammo: Failed to load neoscheme\n");
-	}
-
-	m_hSmallTextFont = scheme->GetFont("NHudOCRSmall");
-	m_hBulletFont = scheme->GetFont("NHudBullets");
-	m_hTextFont = scheme->GetFont("NHudOCR");
-
-	InvalidateLayout();
-
 	SetVisible(neo_cl_hud_ammo_enabled.GetBool());
 
 	SetHiddenBits(HIDEHUD_HEALTH | HIDEHUD_PLAYERDEAD | HIDEHUD_NEEDSUIT | HIDEHUD_WEAPONSELECTION);
-	engine->ClientCmd("hud_reloadscheme"); //NEO FIXME (Adam) this reloads the scheme of all elements, is there a way to do it just for this one?
 }
 
 void CNEOHud_Ammo::Paint()
@@ -93,6 +79,14 @@ void CNEOHud_Ammo::UpdateStateForNeoHudElementDraw()
 void CNEOHud_Ammo::ApplySchemeSettings(vgui::IScheme* pScheme)
 {
 	BaseClass::ApplySchemeSettings(pScheme);
+
+	LoadControlSettings("scripts/HudLayout.res");
+
+	m_hSmallTextFont = pScheme->GetFont("NHudOCRSmall");
+	m_hBulletFont = pScheme->GetFont("NHudBullets");
+	m_hTextFont = pScheme->GetFont("NHudOCR");
+
+	InvalidateLayout();
 
 	surface()->GetScreenSize(m_resX, m_resY);
 	SetBounds(0, 0, m_resX, m_resY);

--- a/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
@@ -86,8 +86,6 @@ void CNEOHud_Ammo::ApplySchemeSettings(vgui::IScheme* pScheme)
 	m_hBulletFont = pScheme->GetFont("NHudBullets");
 	m_hTextFont = pScheme->GetFont("NHudOCR");
 
-	InvalidateLayout();
-
 	surface()->GetScreenSize(m_resX, m_resY);
 	SetBounds(0, 0, m_resX, m_resY);
 	SetFgColor(COLOR_TRANSPARENT);

--- a/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
@@ -60,6 +60,9 @@ CNEOHud_Ammo::CNEOHud_Ammo(const char* pElementName, vgui::Panel* parent)
 		SetParent(g_pClientMode->GetViewport());
 	}
 
+	surface()->GetScreenSize(m_resX, m_resY);
+	SetBounds(0, 0, m_resX, m_resY);
+
 	SetVisible(neo_cl_hud_ammo_enabled.GetBool());
 
 	SetHiddenBits(HIDEHUD_HEALTH | HIDEHUD_PLAYERDEAD | HIDEHUD_NEEDSUIT | HIDEHUD_WEAPONSELECTION);

--- a/mp/src/game/client/neo/ui/neo_hud_ammo.h
+++ b/mp/src/game/client/neo/ui/neo_hud_ammo.h
@@ -6,13 +6,13 @@
 
 #include "neo_hud_childelement.h"
 #include "hudelement.h"
-#include <vgui_controls/Panel.h>
+#include <vgui_controls/EditablePanel.h>
 
 class CNeoHudElements;
 
-class CNEOHud_Ammo : public CNEOHud_ChildElement, public CHudElement, public vgui::Panel
+class CNEOHud_Ammo : public CNEOHud_ChildElement, public CHudElement, public vgui::EditablePanel
 {
-	DECLARE_CLASS_SIMPLE(CNEOHud_Ammo, Panel);
+	DECLARE_CLASS_SIMPLE(CNEOHud_Ammo, EditablePanel);
 
 public:
 	CNEOHud_Ammo(const char* pElementName, vgui::Panel* parent);
@@ -31,9 +31,9 @@ private:
 	void DrawAmmo() const;
 
 private:
-	vgui::HFont m_hSmallTextFont;
-	vgui::HFont m_hTextFont;
-	vgui::HFont m_hBulletFont;
+	vgui::HFont m_hSmallTextFont = 0;
+	vgui::HFont m_hTextFont = 0;
+	vgui::HFont m_hBulletFont = 0;
 
 	int m_resX, m_resY;
 	int m_smallFontWidth, m_smallFontHeight;

--- a/mp/src/game/client/neo/ui/neo_hud_compass.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.cpp
@@ -43,7 +43,7 @@ ConVar neo_cl_hud_debug_compass_color_a("neo_cl_hud_debug_compass_color_a", "255
 NEO_HUD_ELEMENT_DECLARE_FREQ_CVAR(Compass, 0.00695)
 
 CNEOHud_Compass::CNEOHud_Compass(const char *pElementName, vgui::Panel *parent)
-	: CHudElement(pElementName), Panel(parent, pElementName)
+	: CHudElement(pElementName), EditablePanel(parent, pElementName)
 {
 	SetAutoDelete(true);
 
@@ -165,6 +165,8 @@ void CNEOHud_Compass::DrawNeoHudElement(void)
 void CNEOHud_Compass::ApplySchemeSettings(vgui::IScheme *pScheme)
 {
 	BaseClass::ApplySchemeSettings(pScheme);
+
+	LoadControlSettings("scripts/HudLayout.res");
 
 	m_hFont = pScheme->GetFont("NHudOCRSmall");
 	m_savedXBoxWidth = 0;

--- a/mp/src/game/client/neo/ui/neo_hud_compass.h
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.h
@@ -6,16 +6,16 @@
 
 #include "neo_hud_childelement.h"
 #include "hudelement.h"
-#include <vgui_controls/Panel.h>
+#include <vgui_controls/EditablePanel.h>
 
 class CNeoHudElements;
 
 static constexpr size_t UNICODE_NEO_COMPASS_VIS_AROUND = 33; // How many characters should be visible around each side of the needle position
 static constexpr size_t UNICODE_NEO_COMPASS_STR_LENGTH = ((UNICODE_NEO_COMPASS_VIS_AROUND * 2) + 2);
 
-class CNEOHud_Compass : public CNEOHud_ChildElement, public CHudElement, public vgui::Panel
+class CNEOHud_Compass : public CNEOHud_ChildElement, public CHudElement, public vgui::EditablePanel
 {
-	DECLARE_CLASS_SIMPLE(CNEOHud_Compass, Panel);
+	DECLARE_CLASS_SIMPLE(CNEOHud_Compass, EditablePanel);
 
 public:
 	CNEOHud_Compass(const char *pElementName, vgui::Panel *parent = NULL);

--- a/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
@@ -81,8 +81,6 @@ void CNEOHud_HTA::ApplySchemeSettings(vgui::IScheme* pScheme)
 	m_hFont = pScheme->GetFont("NHudOCRSmall");
 	m_hFontBuildInfo = pScheme->GetFont("Default");
 
-	InvalidateLayout();
-
 	surface()->GetScreenSize(m_resX, m_resY);
 	SetBounds(0, 0, m_resX, m_resY);
 }

--- a/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
@@ -27,7 +27,7 @@ ConVar neo_cl_hud_hta_enabled("neo_cl_hud_hta_enabled", "1", FCVAR_USERINFO,
 	"Whether the HUD Health/ThermOptic/AUX module is enabled or not.", true, 0, true, 1);
 
 CNEOHud_HTA::CNEOHud_HTA(const char* pElementName, vgui::Panel* parent)
-	: CHudElement(pElementName), Panel(parent, pElementName)
+	: CHudElement(pElementName), EditablePanel(parent, pElementName)
 {
 	SetAutoDelete(true);
 
@@ -47,27 +47,14 @@ CNEOHud_HTA::CNEOHud_HTA(const char* pElementName, vgui::Panel* parent)
 	surface()->GetScreenSize(m_resX, m_resY);
 	SetBounds(0, 0, m_resX, m_resY);
 
-	// NEO HACK (Rain): this is kind of awkward, we should get the handle on ApplySchemeSettings
-	vgui::IScheme* scheme = vgui::scheme()->GetIScheme(neoscheme);
-	if (!scheme) {
-		Assert(scheme);
-		Error("CNEOHud_Ammo: Failed to load neoscheme\n");
-	}
-
-	m_hFont = scheme->GetFont("NHudOCRSmall");
-	m_hFontBuildInfo = scheme->GetFont("Default");
-
 	if (!g_pVGuiLocalize->ConvertANSIToUnicode(GIT_HASH, m_wszBuildInfo, sizeof(m_wszBuildInfo)))
 	{
 		m_wszBuildInfo[0] = L'\0';
 	}
 
-	InvalidateLayout();
-
 	SetVisible(neo_cl_hud_hta_enabled.GetBool());
 
 	SetHiddenBits(HIDEHUD_HEALTH | HIDEHUD_PLAYERDEAD | HIDEHUD_NEEDSUIT | HIDEHUD_WEAPONSELECTION);
-	engine->ClientCmd("hud_reloadscheme"); //NEO FIXME this reloads the scheme of all elements, is there a way to do it just for this one?
 }
 
 void CNEOHud_HTA::Paint()
@@ -88,6 +75,13 @@ void CNEOHud_HTA::UpdateStateForNeoHudElementDraw()
 void CNEOHud_HTA::ApplySchemeSettings(vgui::IScheme* pScheme)
 {
 	BaseClass::ApplySchemeSettings(pScheme);
+
+	LoadControlSettings("scripts/HudLayout.res");
+
+	m_hFont = pScheme->GetFont("NHudOCRSmall");
+	m_hFontBuildInfo = pScheme->GetFont("Default");
+
+	InvalidateLayout();
 
 	surface()->GetScreenSize(m_resX, m_resY);
 	SetBounds(0, 0, m_resX, m_resY);

--- a/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.h
+++ b/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.h
@@ -6,13 +6,13 @@
 
 #include "neo_hud_childelement.h"
 #include "hudelement.h"
-#include <vgui_controls/Panel.h>
+#include <vgui_controls/EditablePanel.h>
 
 class CNeoHudElements;
 
-class CNEOHud_HTA : public CNEOHud_ChildElement, public CHudElement, public vgui::Panel
+class CNEOHud_HTA : public CNEOHud_ChildElement, public CHudElement, public vgui::EditablePanel
 {
-	DECLARE_CLASS_SIMPLE(CNEOHud_HTA, Panel);
+	DECLARE_CLASS_SIMPLE(CNEOHud_HTA, EditablePanel);
 public:
 	CNEOHud_HTA(const char* pElementName, vgui::Panel* parent);
 
@@ -31,7 +31,8 @@ private:
 	void DrawHTA() const;
 
 private:
-	vgui::HFont m_hFont, m_hFontBuildInfo;
+	vgui::HFont m_hFont = 0;
+	vgui::HFont m_hFontBuildInfo = 0;
 
 	int m_resX, m_resY;
 


### PR DESCRIPTION
* Both ammo and health-aux huds had a hack which forces hud_reloadscheme to be called on initialization. However this has visibly caused an issue with the MOTD which in Valve's code resets the data and look a bit odd. This also enforced reload on all huds which is unnecessary.
* The proper way to load those HudLayout.res settings is instead to have those inherit EditablePanel which most importantly provides a method `LoadControlSettings` to properly load those settings instead.
* This also refactor the font applying to ApplySchemeSettings
* Minor edit in HudLayout.res chat box is intentional otherwise there's a permanent background with using this EditablePanel change.
* fixes #367

## Testing
* What to change around:
    * Change/add around values in: `scripts/HudLayout.res`. Minimal example to differentiate from defaults. Compass +20 instead of +3, Ammo read bg, Health bar RGB, 255-0-255:
        ```
        NHudCompass
        {
                "fieldName"             "NHudCompass"
                "y_bottom_pos"          "20"
        }
        NHudWeapon
        {
                "fieldName"             "NHudWeapon"
                "box_color_r"           "254"
        }
        NHudHealth
        {
                "fieldName"             "NHudHealth"
                "health_color_g"        "0"
        }
        ```
* What needed to be checked:
    * First time loading in, make sure HudLayout.res setting is applied
    * `hud_reloadscheme` works as usual
    * N-times loading in, HudLayout.res setting is applied
    * Without PR #366 the MOTD retains its layout and server title. It doesn't display something in the central area but that's part of that PR's change. With PR #366 it should look functional.