### PR TITLE
Weapon firerates - Make it use the script instead and parity to OG:NT

### DIFF
--- a/mp/game/neo/scripts/weapon_knife.txt
+++ b/mp/game/neo/scripts/weapon_knife.txt
@@ -20,8 +20,9 @@ WeaponData
 	"weight"				"0"
 	"item_flags"			"0"
 
-	"damage"				"25"
-	"cycletime"				"0.534"
+	"Damage"			"15"
+        "Penetration"			"38.0"
+	"CycleTime"			"0.534"
 
 	ViewModelData
 	{

--- a/mp/game/neo/scripts/weapon_srs.txt
+++ b/mp/game/neo/scripts/weapon_srs.txt
@@ -13,7 +13,7 @@ WeaponData
 	"bucket_position"	"0"
 	"Damage"		"100"
 	"Penetration"		"65.0"
-	"CycleTime"		"0.7"		 // time between shots (this value is not used and instead hardcoded in the srs header file)
+	"CycleTime"		"1.0"
 	
 	"TPMuzzleFlashScale"	"0.25"
 

--- a/mp/game/neo/scripts/weapon_tachi.txt
+++ b/mp/game/neo/scripts/weapon_tachi.txt
@@ -27,7 +27,9 @@ WeaponData
 	// Combined as int = 37
 	"item_flags"		"37"
 	
-	"damage"			"17"
+	"Damage"			"17"
+	"Penetration"           "19.0"
+	"CycleTime"             "0.12"
 
 	"ViewModelOffset"
 	{

--- a/mp/src/game/shared/hl2mp/hl2mp_weapon_parse.cpp
+++ b/mp/src/game/shared/hl2mp/hl2mp_weapon_parse.cpp
@@ -81,7 +81,13 @@ void CHL2MPSWeaponInfo::Parse( KeyValues *pKeyValuesData, const char *szWeaponNa
 
 	// Get CycleTime AKA Fire-rate
 	m_flCycleTime = pKeyValuesData->GetFloat("CycleTime", 0.0f);
-	Assert(m_flCycleTime != 0.0f);
+#ifdef _DEBUG
+	const char *printName = pKeyValuesData->GetString("printname");
+	if (!V_strstr(printName, "#HL2"))
+	{
+		Assert(m_flCycleTime != 0.0f);
+	}
+#endif
 #endif
 }
 

--- a/mp/src/game/shared/hl2mp/hl2mp_weapon_parse.cpp
+++ b/mp/src/game/shared/hl2mp/hl2mp_weapon_parse.cpp
@@ -21,10 +21,7 @@ CHL2MPSWeaponInfo::CHL2MPSWeaponInfo()
 	m_iPlayerDamage = 0;
 
 #ifdef NEO
-	m_flVMFov = m_flVMAimFov = 0;
-
 	m_vecVMPosOffset = m_vecVMAimPosOffset = vec3_origin;
-
 	m_angVMAngOffset = m_angVMAimAngOffset = vec3_angle;
 #endif
 }
@@ -34,9 +31,17 @@ void CHL2MPSWeaponInfo::Parse( KeyValues *pKeyValuesData, const char *szWeaponNa
 {
 	BaseClass::Parse( pKeyValuesData, szWeaponName );
 
+#ifndef NEO
 	m_iPlayerDamage = pKeyValuesData->GetInt( "damage", 0 );
+#endif
 
 #ifdef NEO
+	m_iPlayerDamage = pKeyValuesData->GetInt("Damage", 0);
+	if (m_iPlayerDamage == 0)
+	{
+		m_iPlayerDamage = pKeyValuesData->GetInt("damage", 0);
+	}
+
 	KeyValues *pViewModel = pKeyValuesData->FindKey("ViewModelOffset");
 	if (pViewModel)
 	{
@@ -73,6 +78,10 @@ void CHL2MPSWeaponInfo::Parse( KeyValues *pKeyValuesData, const char *szWeaponNa
 		m_angVMAimAngOffset[YAW] = pAimOffset->GetFloat("yaw", 0);
 		m_angVMAimAngOffset[ROLL] = pAimOffset->GetFloat("roll", 0);
 	}
+
+	// Get CycleTime AKA Fire-rate
+	m_flCycleTime = pKeyValuesData->GetFloat("CycleTime", 0.0f);
+	Assert(m_flCycleTime != 0.0f);
 #endif
 }
 

--- a/mp/src/game/shared/hl2mp/hl2mp_weapon_parse.h
+++ b/mp/src/game/shared/hl2mp/hl2mp_weapon_parse.h
@@ -31,14 +31,15 @@ public:
 	int m_iPlayerDamage;
 
 #ifdef NEO
-	float m_flVMFov;
-
+	float m_flVMFov = 0.0f;
 	Vector m_vecVMPosOffset;
 	QAngle m_angVMAngOffset;
 
-	float m_flVMAimFov;
+	float m_flVMAimFov = 0.0f;
 	Vector m_vecVMAimPosOffset;
 	QAngle m_angVMAimAngOffset;
+
+	float m_flCycleTime = 0.0f;
 #endif
 };
 

--- a/mp/src/game/shared/neo/weapons/weapon_aa13.h
+++ b/mp/src/game/shared/neo/weapons/weapon_aa13.h
@@ -40,8 +40,6 @@ public:
 
 	Activity GetPrimaryAttackActivity(void) OVERRIDE;
 
-	virtual float GetFireRate() OVERRIDE { return 0.333f; }
-
 protected:
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }
 	virtual float GetMaxAccuracyPenalty() const OVERRIDE { return 1.5f; }

--- a/mp/src/game/shared/neo/weapons/weapon_jitte.h
+++ b/mp/src/game/shared/neo/weapons/weapon_jitte.h
@@ -53,8 +53,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void) OVERRIDE;
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.085f; }
-
 protected:
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }
 	virtual float GetMaxAccuracyPenalty() const OVERRIDE { return 0.5f; }

--- a/mp/src/game/shared/neo/weapons/weapon_jittes.h
+++ b/mp/src/game/shared/neo/weapons/weapon_jittes.h
@@ -53,7 +53,6 @@ public:
 
 	virtual Activity GetPrimaryAttackActivity(void) OVERRIDE;
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.085f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_knife.h
+++ b/mp/src/game/shared/neo/weapons/weapon_knife.h
@@ -52,7 +52,6 @@ public:
 
 	virtual Activity GetPrimaryAttackActivity() final { return ACT_VM_HITCENTER; }
 	virtual Activity GetSecondaryAttackActivity() final { return ACT_VM_HITCENTER2; }
-	virtual float GetFireRate() final { return 0.534f; }
 	virtual float GetSpeedScale() const final { return 1.0; }
 	virtual NEO_WEP_BITS_UNDERLYING_TYPE GetNeoWepBits() const { return NEO_WEP_KNIFE; }
 

--- a/mp/src/game/shared/neo/weapons/weapon_kyla.h
+++ b/mp/src/game/shared/neo/weapons/weapon_kyla.h
@@ -33,7 +33,6 @@ public:
 
 	virtual float GetSpeedScale(void) const { return 1.0; }
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.35f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_m41.h
+++ b/mp/src/game/shared/neo/weapons/weapon_m41.h
@@ -50,7 +50,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.1f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_m41l.h
+++ b/mp/src/game/shared/neo/weapons/weapon_m41l.h
@@ -50,7 +50,6 @@ public:
 
 	virtual Activity	GetPrimaryAttackActivity(void) OVERRIDE;
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.1f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_m41s.h
+++ b/mp/src/game/shared/neo/weapons/weapon_m41s.h
@@ -50,7 +50,6 @@ public:
 
 	virtual Activity	GetPrimaryAttackActivity(void) OVERRIDE;
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.1f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_milso.h
+++ b/mp/src/game/shared/neo/weapons/weapon_milso.h
@@ -51,7 +51,6 @@ public:
 
 	virtual float GetSpeedScale(void) const { return 1.0; }
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.2f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_mpn.h
+++ b/mp/src/game/shared/neo/weapons/weapon_mpn.h
@@ -53,7 +53,6 @@ public:
 
 	virtual Activity GetPrimaryAttackActivity(void) OVERRIDE;
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.065f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.025f; }

--- a/mp/src/game/shared/neo/weapons/weapon_mpns.h
+++ b/mp/src/game/shared/neo/weapons/weapon_mpns.h
@@ -53,7 +53,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.065f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.025f; }

--- a/mp/src/game/shared/neo/weapons/weapon_mx.h
+++ b/mp/src/game/shared/neo/weapons/weapon_mx.h
@@ -53,7 +53,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.095f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_mxs.h
+++ b/mp/src/game/shared/neo/weapons/weapon_mxs.h
@@ -53,7 +53,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.1f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -232,6 +232,11 @@ bool CNEOBaseCombatWeapon::Deploy(void)
 	return ret;
 }
 
+float CNEOBaseCombatWeapon::GetFireRate()
+{
+	return GetHL2MPWpnData().m_flCycleTime;
+}
+
 #ifdef CLIENT_DLL
 bool CNEOBaseCombatWeapon::Holster(CBaseCombatWeapon* pSwitchingTo)
 {

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -211,7 +211,7 @@ public:
 
 	virtual bool Deploy(void);
 
-	virtual float GetFireRate() final;
+	virtual float GetFireRate() override final;
 	virtual bool GetRoundChambered() const { return 0; }
 	virtual bool GetRoundBeingChambered() const { return 0; }
 

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -211,7 +211,7 @@ public:
 
 	virtual bool Deploy(void);
 
-	virtual float GetFireRate(void) OVERRIDE { Assert(false); return BaseClass::GetFireRate(); } // Should never call this base class; override in children.
+	virtual float GetFireRate() final;
 	virtual bool GetRoundChambered() const { return 0; }
 	virtual bool GetRoundBeingChambered() const { return 0; }
 

--- a/mp/src/game/shared/neo/weapons/weapon_pz.h
+++ b/mp/src/game/shared/neo/weapons/weapon_pz.h
@@ -53,8 +53,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.085f; }
-
 	bool CanBePickedUpByClass(int classId) OVERRIDE;
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_smac.h
+++ b/mp/src/game/shared/neo/weapons/weapon_smac.h
@@ -53,7 +53,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.085f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_srm.h
+++ b/mp/src/game/shared/neo/weapons/weapon_srm.h
@@ -53,7 +53,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.08f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_srms.h
+++ b/mp/src/game/shared/neo/weapons/weapon_srms.h
@@ -53,7 +53,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.08f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_srs.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_srs.cpp
@@ -98,7 +98,7 @@ void CWeaponSRS::ItemPreFrame()
 			pOwner->Weapon_SetZoom(false);
 		}
 		m_bRoundBeingChambered = true;
-		m_flChamberFinishTime = gpGlobals->curtime + 1.3f;
+		m_flChamberFinishTime = gpGlobals->curtime + GetFireRate();
 		WeaponSound(SPECIAL1);
 		SendWeaponAnim(ACT_VM_PULLBACK);
 	}

--- a/mp/src/game/shared/neo/weapons/weapon_srs.h
+++ b/mp/src/game/shared/neo/weapons/weapon_srs.h
@@ -55,7 +55,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.4f; }
 	float m_flChamberFinishTime = maxfloat16bits;
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_supa7.h
+++ b/mp/src/game/shared/neo/weapons/weapon_supa7.h
@@ -59,8 +59,6 @@ public:
 	
 	void Drop(const Vector& vecVelocity) OVERRIDE;
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.7f; }
-
 	void ClearDelayedInputs(void);
 
 protected:

--- a/mp/src/game/shared/neo/weapons/weapon_tachi.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_tachi.cpp
@@ -116,15 +116,7 @@ void CWeaponTachi::UpdatePenaltyTime( void )
 	}
 	else
 	{
-		if ((IsAutomatic() && (!(pOwner->m_afButtonLast & IN_ATTACK))) &&
-			(gpGlobals->curtime - m_flLastAttackTime > TACHI_SEMIAUTO_FIRERATE))
-		{
-			m_flSoonestAttack = gpGlobals->curtime + TACHI_SEMIAUTO_FIRERATE;
-		}
-		else
-		{
-			m_flSoonestAttack = gpGlobals->curtime + GetFireRate();
-		}
+		m_flSoonestAttack = gpGlobals->curtime + GetFireRate();
 	}
 
 	if (m_flSoonestAttack > gpGlobals->curtime)

--- a/mp/src/game/shared/neo/weapons/weapon_tachi.h
+++ b/mp/src/game/shared/neo/weapons/weapon_tachi.h
@@ -22,9 +22,6 @@
 
 class CWeaponTachi : public CNEOBaseCombatWeapon
 {
-#define TACHI_SEMIAUTO_FIRERATE 0.2f
-#define TACHI_MAGDUMP_FIRERATE 0.1f
-
 	DECLARE_CLASS(CWeaponTachi, CNEOBaseCombatWeapon);
 public:
 	DECLARE_NETWORKCLASS(); 
@@ -66,8 +63,6 @@ public:
 	{
 		return (m_bIsPrimaryFireMode == false);
 	}
-
-	virtual float GetFireRate(void) OVERRIDE { return (m_bIsPrimaryFireMode ? TACHI_SEMIAUTO_FIRERATE : TACHI_MAGDUMP_FIRERATE); }
 
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_zr68c.h
+++ b/mp/src/game/shared/neo/weapons/weapon_zr68c.h
@@ -53,7 +53,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.1f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_zr68l.h
+++ b/mp/src/game/shared/neo/weapons/weapon_zr68l.h
@@ -53,7 +53,6 @@ public:
 
 	Activity	GetPrimaryAttackActivity(void);
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.5f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }

--- a/mp/src/game/shared/neo/weapons/weapon_zr68s.h
+++ b/mp/src/game/shared/neo/weapons/weapon_zr68s.h
@@ -54,7 +54,6 @@ public:
 
 	virtual Activity	GetPrimaryAttackActivity(void) OVERRIDE;
 
-	virtual float GetFireRate(void) OVERRIDE { return 0.1f; }
 protected:
 	virtual float GetFastestDryRefireTime() const OVERRIDE { return 0.2f; }
 	virtual float GetAccuracyPenalty() const OVERRIDE { return 0.2f; }


### PR DESCRIPTION
* Instead of fixed in weapons header files, read from the scripts instead
* The existing script generally already have OG:NT firerates apart from a few
* Also fix the weapons to OG:NT script values, apart from knife
* fixes #323 fixes #108