### PR TITLE
Return mouse back to camera on closing VGUI dialog

### DIFF
--- a/mp/src/game/client/neo/game_controls/neo_classmenu.cpp
+++ b/mp/src/game/client/neo/game_controls/neo_classmenu.cpp
@@ -153,6 +153,12 @@ void CNeoClassMenu::CommandCompletion()
 	SetCursorAlwaysVisible(false);
 }
 
+void CNeoClassMenu::OnClose()
+{
+	CommandCompletion();
+	BaseClass::OnClose();
+}
+
 void CNeoClassMenu::OnCommand(const char *command)
 {
 	BaseClass::OnCommand(command);

--- a/mp/src/game/client/neo/game_controls/neo_classmenu.h
+++ b/mp/src/game/client/neo/game_controls/neo_classmenu.h
@@ -63,6 +63,7 @@ public:
     }
 
 protected:
+    virtual void OnClose() override;
     void OnCommand(const char *command);
     void ChangeMenu(const char *menuName);
     void OnKeyCodeReleased(vgui::KeyCode code);

--- a/mp/src/game/client/neo/game_controls/neo_loadoutmenu.cpp
+++ b/mp/src/game/client/neo/game_controls/neo_loadoutmenu.cpp
@@ -229,6 +229,12 @@ extern ConCommand loadoutmenu;
 
 extern ConVar neo_sv_ignore_wep_xp_limit;
 
+void CNeoLoadoutMenu::OnClose()
+{
+	CommandCompletion();
+	BaseClass::OnClose();
+}
+
 void CNeoLoadoutMenu::OnCommand(const char* command)
 {
 	BaseClass::OnCommand(command);

--- a/mp/src/game/client/neo/game_controls/neo_loadoutmenu.h
+++ b/mp/src/game/client/neo/game_controls/neo_loadoutmenu.h
@@ -45,6 +45,7 @@ public:
 	}
 
 protected:
+	virtual void OnClose() override;
 	void OnCommand(const char *command);
 	void ChangeMenu(const char* menuName);
 	void OnKeyCodeReleased(vgui::KeyCode code);

--- a/mp/src/game/client/neo/game_controls/neo_teammenu.cpp
+++ b/mp/src/game/client/neo/game_controls/neo_teammenu.cpp
@@ -142,6 +142,12 @@ void CNeoTeamMenu::FindButtons()
 	m_pCancel_Button = FindControl<Button>(CONTROL_CANCEL_BUTTON);
 }
 
+void CNeoTeamMenu::OnClose()
+{
+	CommandCompletion();
+	BaseClass::OnClose();
+}
+
 void CNeoTeamMenu::CommandCompletion()
 {	
 	SetControlEnabled(CONTROL_JINRAI_BUTTON, false);

--- a/mp/src/game/client/neo/game_controls/neo_teammenu.h
+++ b/mp/src/game/client/neo/game_controls/neo_teammenu.h
@@ -104,6 +104,7 @@ protected:
     bool m_bTeamMenu;
 
 protected:
+	virtual void OnClose() override;
 	void CommandCompletion();
 
 private:


### PR DESCRIPTION
* Affected teammenu and classmenu, loadoutmenu didn't seemed to, but also edited it just for consistency
* Reproducable with Alt-F4, although that's the default keybind for closing the window on Windows + major DEs on Linux. But using non-default keybind/other DE/WM easily reproduce it.
* fixes #371