### PR TITLE
Fadeout after death + first person head ragdoll death cam

### DIFF
--- a/mp/src/game/client/c_baseplayer.cpp
+++ b/mp/src/game/client/c_baseplayer.cpp
@@ -2375,6 +2375,14 @@ void C_BasePlayer::PhysicsSimulate( void )
 		//VectorCopy ( pl.v_angle, ctx->cmd.viewangles );
 	}
 #ifdef NEO
+	else if (GetObserverMode() == OBS_MODE_DEATHCAM)
+	{
+		ctx->cmd.forwardmove = 0;
+		ctx->cmd.sidemove = 0;
+		ctx->cmd.upmove = 0;
+		ctx->cmd.impulse = 0;
+		ctx->cmd.buttons &= ~(IN_ATTACK | IN_ATTACK2 | IN_ATTACK3 | IN_JUMP | IN_ALT1 | IN_ALT2 | IN_ZOOM);
+	}
 	else if (static_cast<C_NEO_Player*>(this)->GetNeoFlags() & NEO_FL_FREEZETIME)
 	{
 		ctx->cmd.forwardmove = 0;

--- a/mp/src/game/client/c_baseplayer.cpp
+++ b/mp/src/game/client/c_baseplayer.cpp
@@ -60,6 +60,7 @@
 #ifdef NEO
 #include "c_neo_player.h"
 #include "weapon_tachi.h"
+#include "ivieweffects.h"
 #endif
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -616,6 +617,12 @@ void C_BasePlayer::SetObserverMode ( int iNewMode )
 		{
 			// On a change of viewing mode or target, we may want to reset both head and torso to point at the new target.
 			g_ClientVirtualReality.AlignTorsoAndViewToWeapon();
+#ifdef NEO
+			if (iNewMode != OBS_MODE_DEATHCAM)
+			{
+				vieweffects->ClearAllFades();
+			}
+#endif
 		}
 	}
 }

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -997,12 +997,15 @@ void C_NEO_Player::PostThink(void)
 			Weapon_SetZoom(false);
 			m_bInVision = false;
 
-			if (this == GetLocalNEOPlayer())
+			if (IsLocalPlayer() && (GetTeamNumber() == TEAM_JINRAI || GetTeamNumber() == TEAM_NSF))
 			{
+				m_iSavedObserverMode = GetObserverMode();
+				SetObserverMode(OBS_MODE_DEATHCAM);
+				// Fade out 8s to blackout + 2s full blackout
 				ScreenFade_t sfade{
-					.duration = static_cast<unsigned short>(static_cast<float>(1<<SCREENFADE_FRACBITS) * 3.0f),
-					.holdTime = static_cast<unsigned short>(static_cast<float>(1<<SCREENFADE_FRACBITS) * 1.0f),
-					.fadeFlags = FFADE_OUT,
+					.duration = static_cast<unsigned short>(static_cast<float>(1<<SCREENFADE_FRACBITS) * 8.0f),
+					.holdTime = static_cast<unsigned short>(static_cast<float>(1<<SCREENFADE_FRACBITS) * 2.0f),
+					.fadeFlags = FFADE_OUT|FFADE_PURGE,
 					.r = 0,
 					.g = 0,
 					.b = 0,
@@ -1011,7 +1014,6 @@ void C_NEO_Player::PostThink(void)
 				vieweffects->Fade(sfade);
 			}
 		}
-
 		return;
 	}
 	else
@@ -1019,6 +1021,10 @@ void C_NEO_Player::PostThink(void)
 		if (!m_bFirstDeathTick)
 		{
 			m_bFirstDeathTick = true;
+			if (IsLocalPlayer())
+			{
+				SetObserverMode(OBS_MODE_NONE);
+			}
 		}
 	}
 
@@ -1070,6 +1076,41 @@ void C_NEO_Player::PostThink(void)
 	float flPitch = asin(-eyeForward[2]);
 	float flYaw = atan2(eyeForward[1], eyeForward[0]);
 	m_pPlayerAnimState->Update(RAD2DEG(flYaw), RAD2DEG(flPitch));
+}
+
+void C_NEO_Player::CalcDeathCamView(Vector &eyeOrigin, QAngle &eyeAngles, float &fov)
+{
+	if (auto *pRagdoll = static_cast<C_HL2MPRagdoll *>(m_hRagdoll.Get()))
+	{
+		// First person death cam
+		pRagdoll->GetAttachment(pRagdoll->LookupAttachment("eyes"), eyeOrigin, eyeAngles);
+		Vector vForward;
+		AngleVectors(eyeAngles, &vForward);
+		fov = GetFOV();
+
+		if (IsLocalPlayer() && gpGlobals->curtime >= (GetDeathTime() + 10.0f))
+		{
+			m_iObserverMode = m_iSavedObserverMode;
+			g_ClientVirtualReality.AlignTorsoAndViewToWeapon();
+
+			// Fade in 2s from blackout
+			ScreenFade_t sfade{
+				.duration = static_cast<unsigned short>(static_cast<float>(1<<SCREENFADE_FRACBITS) * 2.0f),
+				.holdTime = static_cast<unsigned short>(0),
+				.fadeFlags = FFADE_IN|FFADE_PURGE,
+				.r = 0,
+				.g = 0,
+				.b = 0,
+				.a = 255,
+			};
+			vieweffects->Fade(sfade);
+		}
+	}
+	else
+	{
+		// Fallback just in-case it somehow doesn't do m_hRagdoll
+		BaseClass::CalcDeathCamView(eyeOrigin, eyeAngles, fov);
+	}
 }
 
 bool C_NEO_Player::IsAllowedToSuperJump(void)

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -42,6 +42,7 @@
 #include <materialsystem/imaterialsystem.h>
 #include <materialsystem/itexture.h>
 #include "rendertexture.h"
+#include "ivieweffects.h"
 
 #include "model_types.h"
 
@@ -995,6 +996,20 @@ void C_NEO_Player::PostThink(void)
 
 			Weapon_SetZoom(false);
 			m_bInVision = false;
+
+			if (this == GetLocalNEOPlayer())
+			{
+				ScreenFade_t sfade{
+					.duration = static_cast<unsigned short>(static_cast<float>(1<<SCREENFADE_FRACBITS) * 3.0f),
+					.holdTime = static_cast<unsigned short>(static_cast<float>(1<<SCREENFADE_FRACBITS) * 1.0f),
+					.fadeFlags = FFADE_OUT,
+					.r = 0,
+					.g = 0,
+					.b = 0,
+					.a = 255,
+				};
+				vieweffects->Fade(sfade);
+			}
 		}
 
 		return;

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -166,6 +166,8 @@ public:
 	const char *GetNeoPlayerName() const;
 	bool ClientWantNeoName() const;
 
+	virtual void CalcDeathCamView( Vector& eyeOrigin, QAngle& eyeAngles, float& fov ) override;
+
 private:
 	void CheckThermOpticButtons();
 	void CheckVisionButtons();
@@ -222,6 +224,7 @@ private:
 	bool m_bPreviouslyReloading;
 	bool m_bPreviouslyPreparingToHideMsg;
 	bool m_bIsAllowedToToggleVision;
+	int m_iSavedObserverMode = 0;
 
 	CNeoHudElements *m_pNeoPanel;
 

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -85,6 +85,7 @@
 #ifdef NEO
 #include "neo_player.h"
 #include "weapon_tachi.h"
+#include "neo_gamerules.h"
 #endif
 
 ConVar autoaim_max_dist( "autoaim_max_dist", "2160" ); // 2160 = 180 feet
@@ -648,6 +649,10 @@ CBasePlayer::CBasePlayer( )
 	m_flMovementTimeForUserCmdProcessingRemaining = 0.0f;
 
 	m_flLastObjectiveTime = -1.f;
+
+#ifdef NEO
+	m_flDeathTime = 0.0f;
+#endif
 }
 
 CBasePlayer::~CBasePlayer( )
@@ -3751,6 +3756,19 @@ void CBasePlayer::PlayerRunCommand(CUserCmd *ucmd, IMoveHelper *moveHelper)
 			}
 		}
 	}
+
+#ifdef NEO
+	if (!IsAlive() && (GetTeamNumber() == TEAM_JINRAI || GetTeamNumber() == TEAM_NSF) &&
+			NEORules()->GetRoundStatus() == RoundLive &&
+			(gpGlobals->curtime < (GetDeathTime() + 10.0f)))
+	{
+		ucmd->forwardmove = 0;
+		ucmd->sidemove = 0;
+		ucmd->upmove = 0;
+		ucmd->impulse = 0;
+		ucmd->buttons &= ~(IN_ATTACK | IN_ATTACK2 | IN_ATTACK3 | IN_JUMP | IN_ALT1 | IN_ALT2 | IN_ZOOM);
+	}
+#endif
 	
 	PlayerMove()->RunCommand(this, ucmd, moveHelper);
 }


### PR DESCRIPTION
* 8s -> fade 2s stays -> 2s unfade
* Effect local client/player after death 1st tick only
* Death goes to death cam, first person by the head ragdoll
* Some stuff to figure out when to force unfade and un-deathcam
* fixes #143