### PR TITLE
Client side MOTD control

### DIFF
--- a/mp/src/game/client/clientmode_shared.h
+++ b/mp/src/game/client/clientmode_shared.h
@@ -16,6 +16,12 @@
 #include "GameEventListener.h"
 #include <baseviewport.h>
 
+#ifdef NEO
+#include "vguitextwindow.h"
+
+extern ConVar cl_disablehtmlmotd;
+#endif
+
 class CBaseHudChat;
 class CBaseHudWeaponSelection;
 class CViewSetup;
@@ -130,9 +136,27 @@ public:
 	virtual void	DisplayReplayMessage( const char *pLocalizeName, float flDuration, bool bUrgent,
 										  const char *pSound, bool bDlg );
 
-	virtual bool	IsInfoPanelAllowed() OVERRIDE { return true; }
+	virtual bool	IsInfoPanelAllowed() OVERRIDE
+	{
+#ifdef NEO
+		if (cl_disablehtmlmotd.GetInt() == MotdPreference::ShowNothing)
+		{
+			return false;
+		}
+#endif
+		return true;
+	}
+
 	virtual void	InfoPanelDisplayed() OVERRIDE { }
-	virtual bool	IsHTMLInfoPanelAllowed() OVERRIDE { return true; }
+
+	virtual bool	IsHTMLInfoPanelAllowed() OVERRIDE
+	{
+#ifdef NEO
+		return (cl_disablehtmlmotd.GetInt() == MotdPreference::ShowFullHtml);
+#else
+		return true;
+#endif
+	}
 
 protected:
 	CBaseViewport			*m_pViewport;

--- a/mp/src/game/client/game_controls/vguitextwindow.cpp
+++ b/mp/src/game/client/game_controls/vguitextwindow.cpp
@@ -445,7 +445,13 @@ void CTextWindow::ShowPanel( bool bShow )
 		SetVisible( false );
 		SetMouseInputEnabled( false );
 
-		if ( UnloadOnDismissal() && m_bShownURL && m_pHTMLMessage)
+		if ((
+#ifdef NEO
+				UnloadOnDismissal()
+#else
+				m_bUnloadOnDismissal
+#endif
+			) && m_bShownURL && m_pHTMLMessage)
 		{
 			m_pHTMLMessage->OpenURL( "about:blank", NULL );
 			m_bShownURL = false;

--- a/mp/src/game/client/game_controls/vguitextwindow.cpp
+++ b/mp/src/game/client/game_controls/vguitextwindow.cpp
@@ -32,7 +32,9 @@ extern INetworkStringTable *g_pStringTableInfoPanel;
 
 #define TEMP_HTML_FILE	"textwindow_temp.html"
 
-ConVar cl_disablehtmlmotd( "cl_disablehtmlmotd", "0", FCVAR_ARCHIVE, "Disable HTML motds." );
+ConVar cl_disablehtmlmotd("cl_disablehtmlmotd", "0", FCVAR_ARCHIVE,
+	"0: Show full HTML MOTD. 1: Disable HTML but show text MOTD. 2: Hide all MOTDs.",
+	true, 0.f, true, static_cast<float>(MotdPreference::EnumCount - 1));
 
 //=============================================================================
 // HPE_BEGIN:

--- a/mp/src/game/client/game_controls/vguitextwindow.cpp
+++ b/mp/src/game/client/game_controls/vguitextwindow.cpp
@@ -32,12 +32,18 @@ extern INetworkStringTable *g_pStringTableInfoPanel;
 
 #define TEMP_HTML_FILE	"textwindow_temp.html"
 
+#ifdef NEO
 ConVar cl_disablehtmlmotd("cl_disablehtmlmotd", "1", FCVAR_ARCHIVE,
 	"0: Show full HTML MOTD. 1: Disable HTML but show text MOTD. 2: Hide all MOTDs.",
 	true, 0.f, true, static_cast<float>(MotdPreference::EnumCount - 1));
+#else
+ConVar cl_disablehtmlmotd("cl_disablehtmlmotd", "0", FCVAR_ARCHIVE, "Disable HTML motds.");
+#endif
 
+#ifdef NEO
 ConVar cl_motd_unload_on_dismissal("cl_motd_unload_on_dismissal", "1", FCVAR_ARCHIVE,
 	"If enabled, the MOTD contents will be unloaded when you close the MOTD.");
+#endif
 
 //=============================================================================
 // HPE_BEGIN:
@@ -388,6 +394,7 @@ void CTextWindow::OnKeyCodePressed( vgui::KeyCode code )
 	BaseClass::OnKeyCodePressed(code);
 }
 
+#ifdef NEO
 bool CTextWindow::UnloadOnDismissal() const
 {
 	if (cl_motd_unload_on_dismissal.GetBool())
@@ -396,6 +403,7 @@ bool CTextWindow::UnloadOnDismissal() const
 	}
 	return m_bUnloadOnDismissal;
 }
+#endif
 
 void CTextWindow::SetData(KeyValues *data)
 {

--- a/mp/src/game/client/game_controls/vguitextwindow.cpp
+++ b/mp/src/game/client/game_controls/vguitextwindow.cpp
@@ -36,6 +36,9 @@ ConVar cl_disablehtmlmotd("cl_disablehtmlmotd", "1", FCVAR_ARCHIVE,
 	"0: Show full HTML MOTD. 1: Disable HTML but show text MOTD. 2: Hide all MOTDs.",
 	true, 0.f, true, static_cast<float>(MotdPreference::EnumCount - 1));
 
+ConVar cl_motd_unload_on_dismissal("cl_motd_unload_on_dismissal", "1", FCVAR_ARCHIVE,
+	"If enabled, the MOTD contents will be unloaded when you close the MOTD.");
+
 //=============================================================================
 // HPE_BEGIN:
 // [Forrest] Replaced text window command string with TEXTWINDOW_CMD enumeration
@@ -385,6 +388,15 @@ void CTextWindow::OnKeyCodePressed( vgui::KeyCode code )
 	BaseClass::OnKeyCodePressed(code);
 }
 
+bool CTextWindow::UnloadOnDismissal() const
+{
+	if (cl_motd_unload_on_dismissal.GetBool())
+	{
+		return true;
+	}
+	return m_bUnloadOnDismissal;
+}
+
 void CTextWindow::SetData(KeyValues *data)
 {
 #ifdef SDK2013CE
@@ -425,7 +437,7 @@ void CTextWindow::ShowPanel( bool bShow )
 		SetVisible( false );
 		SetMouseInputEnabled( false );
 
-		if ( m_bUnloadOnDismissal && m_bShownURL && m_pHTMLMessage )
+		if ( UnloadOnDismissal() && m_bShownURL && m_pHTMLMessage)
 		{
 			m_pHTMLMessage->OpenURL( "about:blank", NULL );
 			m_bShownURL = false;

--- a/mp/src/game/client/game_controls/vguitextwindow.cpp
+++ b/mp/src/game/client/game_controls/vguitextwindow.cpp
@@ -32,7 +32,7 @@ extern INetworkStringTable *g_pStringTableInfoPanel;
 
 #define TEMP_HTML_FILE	"textwindow_temp.html"
 
-ConVar cl_disablehtmlmotd("cl_disablehtmlmotd", "0", FCVAR_ARCHIVE,
+ConVar cl_disablehtmlmotd("cl_disablehtmlmotd", "1", FCVAR_ARCHIVE,
 	"0: Show full HTML MOTD. 1: Disable HTML but show text MOTD. 2: Hide all MOTDs.",
 	true, 0.f, true, static_cast<float>(MotdPreference::EnumCount - 1));
 

--- a/mp/src/game/client/game_controls/vguitextwindow.h
+++ b/mp/src/game/client/game_controls/vguitextwindow.h
@@ -18,6 +18,14 @@
 #include <game/client/iviewport.h>
 #include "shareddefs.h"
 
+enum MotdPreference {
+	ShowFullHtml = 0,
+	ShowTextOnly,
+	ShowNothing,
+
+	EnumCount,
+};
+
 namespace vgui
 {
 	class TextEntry;

--- a/mp/src/game/client/game_controls/vguitextwindow.h
+++ b/mp/src/game/client/game_controls/vguitextwindow.h
@@ -73,6 +73,8 @@ protected:
 
 	void OnKeyCodePressed( vgui::KeyCode code );
 
+	bool UnloadOnDismissal() const;
+
 	IViewPort	*m_pViewPort;
 	char		m_szTitle[255];
 	char		m_szMessage[2048];

--- a/mp/src/game/client/game_controls/vguitextwindow.h
+++ b/mp/src/game/client/game_controls/vguitextwindow.h
@@ -73,7 +73,9 @@ protected:
 
 	void OnKeyCodePressed( vgui::KeyCode code );
 
+#ifdef NEO
 	bool UnloadOnDismissal() const;
+#endif
 
 	IViewPort	*m_pViewPort;
 	char		m_szTitle[255];

--- a/mp/src/game/server/neo/neo_client.cpp
+++ b/mp/src/game/server/neo/neo_client.cpp
@@ -20,7 +20,7 @@
 void Host_Say( edict_t *pEdict, bool teamonly );
 
 ConVar sv_motd_unload_on_dismissal( "sv_motd_unload_on_dismissal",
-	"0", 0,
+	"1", 0,
 	"If enabled, the MOTD contents will be unloaded when the player \
 closes the MOTD." );
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
This is a complementary PR for #366 and provides client-side control for MOTD rendering.

It also defaults the MOTD to text-only mode, so we're not by default vulnerable to attacks against the HTML renderer, and adds client side control of dismissed MOTD unloading.

Changes:
* Add `cl_disablehtmlmotd` value `2` for completely disabling the MOTD client side.
* Set default of `cl_disablehtmlmotd` to `1` instead of `0`.
* Add `cl_motd_unload_on_dismissal` which allows clients to override a `sv_motd_unload_on_dismissal 0` to force the unload.
* Set default of `sv_motd_unload_on_dismissal ` to `1` instead of `0`.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- related #366 

