### PR TITLE
Document SourceMod require ShowMenu whitelist for plugins to show menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,13 @@ ln -s materialsystem_srv.so materialsystem.so;
     * Double check on the log that VAC is disabled before continuing
 7. In-game on Windows it'll showup in the server list, on Linux it probably won't and you'll have to use `connect` command directly (EX: `connect 192.168.1.###` for LAN server)
 
+### SourceMod server modification plugins
+[SourceMod](https://www.sourcemod.net/) plugins generally works with NT;RE, however it'll need to be added to the `ShowMenu` whitelist before the menu will work. To do this:
+1. Go to directory `addons/sourcemod/gamedata/core.games` and you'll see `common.games.txt`
+2. Create the directory `custom` and copy `common.games.txt` over to there
+3. Open `custom/common.games.txt` and scrolldown till you see "Which games support ShowMenu?" comment
+4. Add `neo` to that supported list like this: `"game" "neo"`
+
 ## Shader authoring (Windows setup)
 
 ### Compiling the shaders

--- a/README.md
+++ b/README.md
@@ -283,11 +283,11 @@ ln -s materialsystem_srv.so materialsystem.so;
 7. In-game on Windows it'll showup in the server list, on Linux it probably won't and you'll have to use `connect` command directly (EX: `connect 192.168.1.###` for LAN server)
 
 ### SourceMod server modification plugins
-[SourceMod](https://www.sourcemod.net/) plugins generally works with NT;RE, however it'll need to be added to the `ShowMenu` whitelist before the menu will work. To do this:
-1. Go to directory `addons/sourcemod/gamedata/core.games` and you'll see `common.games.txt`
-2. Create the directory `custom` and copy `common.games.txt` over to there
-3. Open `custom/common.games.txt` and scrolldown till you see "Which games support ShowMenu?" comment
-4. Add `neo` to that supported list like this: `"game" "neo"`
+[SourceMod](https://www.sourcemod.net/) plugins should generally work with NT;RE, however they have to be added to the `ShowMenu` whitelist to make the menu display properly. To do this:
+1. Go to directory `addons/sourcemod/gamedata/core.games` where you should find `common.games.txt`
+2. Create the directory `custom` and make a copy of `common.games.txt` into it
+3. Open `custom/common.games.txt` and look for a comment that says "Which games support ShowMenu?"
+4. Add `neo` to that list like this: `"game" "neo"`
 
 ## Shader authoring (Windows setup)
 


### PR DESCRIPTION

<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
It was thought that the menu seems broken with SourceMod, but really, it's just that `neo` has to be added to SourceMod's "supports ShowMenu" whitelist, then the menu will work just fine.

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #154

