### PR TITLE
Fix round state HUD player's team mismatch, and allow spectator "team" to see all healthbars

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -229,6 +229,7 @@ public:
 
 		if (panel->IsVisible() && panel->IsEnabled())
 		{
+			panel->MoveToFront();
 			return;	// Prevent cursor stuck
 		}
 
@@ -296,6 +297,7 @@ public:
 
 		if (panel->IsVisible() && panel->IsEnabled())
 		{
+			panel->MoveToFront();
 			return;	// Prevent cursor stuck
 		}
 
@@ -349,6 +351,7 @@ public:
 
 		if (panel->IsVisible() && panel->IsEnabled())
 		{
+			panel->MoveToFront();
 			return;	// Prevent cursor stuck
 		}
 

--- a/mp/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -322,10 +322,11 @@ void CNEOHud_RoundState::DrawNeoHudElement()
 	const int localPlayerTeam = GetLocalPlayerTeam();
 	const int localPlayerIndex = GetLocalPlayerIndex();
 	const bool localPlayerSpec = !(localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF);
+
 	const int leftTeam = localPlayerSpec ? TEAM_JINRAI : localPlayerTeam;
-	const int enemyTeam = (leftTeam == TEAM_JINRAI) ? TEAM_NSF : TEAM_JINRAI;
+	const int rightTeam = (leftTeam == TEAM_JINRAI) ? TEAM_NSF : TEAM_JINRAI;
 	const auto leftTeamInfo = m_teamLogoColors[leftTeam];
-	const auto rightTeamInfo = m_teamLogoColors[enemyTeam];
+	const auto rightTeamInfo = m_teamLogoColors[rightTeam];
 
 	// Draw players
 	if (!g_PR)
@@ -335,27 +336,32 @@ void CNEOHud_RoundState::DrawNeoHudElement()
 	m_iFriendsTotal = 0;
 	m_iEnemiesAlive = 0;
 	m_iEnemiesTotal = 0;
-	int friendCount = 0;
-	int enemyCount = 0;
-	for (int i = 0; i < (MAX_PLAYERS + 1); i++) {
-		if (g_PR->IsConnected(i)) {
+	int leftCount = 0;
+	int rightCount = 0;
+	for (int i = 0; i < (MAX_PLAYERS + 1); i++)
+	{
+		if (g_PR->IsConnected(i))
+		{
 			const int playerTeam = g_PR->GetTeam(i);
-			if (playerTeam == leftTeam) {
+			if (playerTeam == leftTeam)
+			{
 				const bool isSameSquad = g_PR->GetStar(i) == g_PR->GetStar(localPlayerIndex);
-				if (localPlayerSpec || isSameSquad) {
-					const int xOffset = m_iFriendlyLogoXOffset - ((friendCount + 1) * m_ilogoSize) - (friendCount * 2);
-					DrawPlayer(i, friendCount, leftTeamInfo, xOffset, true);
-					friendCount++;
+				if (localPlayerSpec || isSameSquad)
+				{
+					const int xOffset = m_iFriendlyLogoXOffset - ((leftCount + 1) * m_ilogoSize) - (leftCount * 2);
+					DrawPlayer(i, leftCount, leftTeamInfo, xOffset, true);
+					leftCount++;
 				}
 
 				if (g_PR->IsAlive(i))
 					m_iFriendsAlive++;
 				m_iFriendsTotal++;
 			}
-			else if (playerTeam == enemyTeam) {
-				const int xOffset = m_iEnemyLogoXOffset + (enemyCount * m_ilogoSize) + (enemyCount * 2);
-				DrawPlayer(i, enemyCount, rightTeamInfo, xOffset, localPlayerSpec);
-				enemyCount++;
+			else if (playerTeam == rightTeam)
+			{
+				const int xOffset = m_iEnemyLogoXOffset + (rightCount * m_ilogoSize) + (rightCount * 2);
+				DrawPlayer(i, rightCount, rightTeamInfo, xOffset, localPlayerSpec);
+				rightCount++;
 
 				if (g_PR->IsAlive(i))
 					m_iEnemiesAlive++;

--- a/mp/src/game/client/neo/ui/neo_hud_round_state.h
+++ b/mp/src/game/client/neo/ui/neo_hud_round_state.h
@@ -38,9 +38,7 @@ protected:
 
 private:
 	void CheckActiveStar();
-	void DrawFriend(int playerIndex, int teamIndex, const TeamLogoColor &teamLogoColor,
-					const bool localPlayerInGame);
-	void DrawEnemy(int playerIndex, int teamIndex, const TeamLogoColor &teamLogoColor);
+	void DrawPlayer(int playerIndex, int teamIndex, const TeamLogoColor &teamLogoColor, const int xOffset, const bool drawHealthClass);
 	void UpdatePlayerAvatar(int playerIndex);
 	void SetTextureToAvatar(int playerIndex);
 

--- a/mp/src/game/client/neo/ui/neo_hud_round_state.h
+++ b/mp/src/game/client/neo/ui/neo_hud_round_state.h
@@ -4,6 +4,7 @@
 #pragma once
 #endif
 
+#include "neo_gamerules.h"
 #include "neo_hud_childelement.h"
 #include "hudelement.h"
 #include <vgui_controls/Panel.h>
@@ -15,6 +16,13 @@ class ImagePanel;
 class CNEOHud_RoundState : public CNEOHud_ChildElement, public CHudElement, public vgui::Panel
 {
 	DECLARE_CLASS_SIMPLE(CNEOHud_RoundState, Panel);
+
+	struct TeamLogoColor
+	{
+		int logo;
+		int totalLogo;
+		Color color;
+	};
 
 public:
 	CNEOHud_RoundState(const char *pElementName, vgui::Panel *parent = NULL);
@@ -29,10 +37,10 @@ protected:
 	virtual ConVar* GetUpdateFrequencyConVar() const;
 
 private:
-	void FireGameEvent(IGameEvent* event) OVERRIDE;
 	void CheckActiveStar();
-	void DrawFriend(int playerIndex, int teamIndex);
-	void DrawEnemy(int playerIndex, int teamIndex);
+	void DrawFriend(int playerIndex, int teamIndex, const TeamLogoColor &teamLogoColor,
+					const bool localPlayerInGame);
+	void DrawEnemy(int playerIndex, int teamIndex, const TeamLogoColor &teamLogoColor);
 	void UpdatePlayerAvatar(int playerIndex);
 	void SetTextureToAvatar(int playerIndex);
 
@@ -90,27 +98,17 @@ private:
 	int m_iPreviouslyActiveTeam;
 
 	// Graphic IDs
-	int m_iJinraiID;
-	int m_iJinraiTotalID;
-	int m_iNSFID;
-	int m_iNSFTotalID;
 	int m_iSupportID;
 	int m_iAssaultID;
 	int m_iReconID;
 	int m_iVIPID;
-	
-	// Graphic IDs used
-	int m_iFriendlyLogo;
-	int m_iFriendlyTotalLogo;
-	int m_iEnemyLogo;
-	int m_iEnemyTotalLogo;
+
+	TeamLogoColor m_teamLogoColors[TEAM__TOTAL] = {};
 
 	Color whiteColor = Color(255, 255, 255, 255);
 	Color fadedWhiteColor = Color(255, 255, 255, 176);
 	Color darkColor = Color(55, 55, 55, 255);
 	Color fadedDarkColor = Color(55, 55, 55, 176);
-	Color friendlyColor;
-	Color enemyColor;
 	Color deadColor = Color(155, 155, 155, 255);
 
 	vgui::ImageList* m_pImageList;

--- a/mp/src/game/client/neo/ui/neo_hud_round_state.h
+++ b/mp/src/game/client/neo/ui/neo_hud_round_state.h
@@ -17,13 +17,6 @@ class CNEOHud_RoundState : public CNEOHud_ChildElement, public CHudElement, publ
 {
 	DECLARE_CLASS_SIMPLE(CNEOHud_RoundState, Panel);
 
-	struct TeamLogoColor
-	{
-		int logo;
-		int totalLogo;
-		Color color;
-	};
-
 public:
 	CNEOHud_RoundState(const char *pElementName, vgui::Panel *parent = NULL);
 	~CNEOHud_RoundState();
@@ -37,8 +30,16 @@ protected:
 	virtual ConVar* GetUpdateFrequencyConVar() const;
 
 private:
+	struct TeamLogoColor
+	{
+		int logo;
+		int totalLogo;
+		Color color;
+	};
+
 	void CheckActiveStar();
-	void DrawPlayer(int playerIndex, int teamIndex, const TeamLogoColor &teamLogoColor, const int xOffset, const bool drawHealthClass);
+	void DrawPlayer(int playerIndex, int teamIndex, const TeamLogoColor &teamLogoColor,
+					const int xOffset, const bool drawHealthClass);
 	void UpdatePlayerAvatar(int playerIndex);
 	void SetTextureToAvatar(int playerIndex);
 

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -20,6 +20,8 @@ enum
 {
 	TEAM_JINRAI = LAST_SHARED_TEAM + 1,
 	TEAM_NSF,
+
+	TEAM__TOTAL, // Always last enum in here
 };
 
 #define TEAM_STR_JINRAI "Jinrai"


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Instead of keeping the state of the player's team and relying on the team event callback to change it, since we're already taking the player's team on draw, just do it by draw instead. This means we won't need to hold an extra state and reduce mismatch errors.
* This also fixes/deals with how the HUD is presented to the spectator, now all players and all health shown to the spectator
* Also a fix on cursor getting stuck when hitting this issue
* This changes some variables naming from friendly/enemy to left/right due to assuming spectator's view of those HUD now. Although not all as that'll increase the PR diff.
* Refactor `DrawEnemy/DrawFriend` into a more generic `DrawPlayer`. Now able to handle if a spectator seeing the HUD.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #387

