### PR TITLE
Fix 1st person spectator not seeing crosshair and viewmodel offset on aim

### DIFF
--- a/mp/src/game/client/c_baseplayer.cpp
+++ b/mp/src/game/client/c_baseplayer.cpp
@@ -1892,16 +1892,13 @@ void C_BasePlayer::CalcInEyeCamView(Vector& eyeOrigin, QAngle& eyeAngles, float&
 	engine->SetViewAngles( eyeAngles );
 
 #ifdef NEO
-	if (auto *pTargetNeoPlayer = dynamic_cast<CNEO_Player *>(target))
+	if (static_cast<CNEO_Player *>(target)->m_bInAim)
 	{
-		if (pTargetNeoPlayer->m_bInAim)
-		{
-			m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
-		}
-		else
-		{
-			m_Local.m_iHideHUD |= HIDEHUD_CROSSHAIR;
-		}
+		m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
+	}
+	else
+	{
+		m_Local.m_iHideHUD |= HIDEHUD_CROSSHAIR;
 	}
 #endif
 }

--- a/mp/src/game/client/c_baseplayer.cpp
+++ b/mp/src/game/client/c_baseplayer.cpp
@@ -1890,6 +1890,20 @@ void C_BasePlayer::CalcInEyeCamView(Vector& eyeOrigin, QAngle& eyeAngles, float&
 	}
 
 	engine->SetViewAngles( eyeAngles );
+
+#ifdef NEO
+	if (auto *pTargetNeoPlayer = dynamic_cast<CNEO_Player *>(target))
+	{
+		if (pTargetNeoPlayer->m_bInAim)
+		{
+			m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
+		}
+		else
+		{
+			m_Local.m_iHideHUD |= HIDEHUD_CROSSHAIR;
+		}
+	}
+#endif
 }
 
 float C_BasePlayer::GetDeathCamInterpolationTime()

--- a/mp/src/game/shared/baseplayer_shared.cpp
+++ b/mp/src/game/shared/baseplayer_shared.cpp
@@ -1726,6 +1726,9 @@ void CBasePlayer::CalcVehicleView(
 void CBasePlayer::CalcObserverView( Vector& eyeOrigin, QAngle& eyeAngles, float& fov )
 {
 #if defined( CLIENT_DLL )
+#ifdef NEO
+	m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
+#endif
 	switch ( GetObserverMode() )
 	{
 

--- a/mp/src/game/shared/baseplayer_shared.cpp
+++ b/mp/src/game/shared/baseplayer_shared.cpp
@@ -1727,7 +1727,7 @@ void CBasePlayer::CalcObserverView( Vector& eyeOrigin, QAngle& eyeAngles, float&
 {
 #if defined( CLIENT_DLL )
 #ifdef NEO
-	m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
+	m_Local.m_iHideHUD |= HIDEHUD_CROSSHAIR;
 #endif
 	switch ( GetObserverMode() )
 	{

--- a/mp/src/game/shared/neo/neo_predicted_viewmodel.cpp
+++ b/mp/src/game/shared/neo/neo_predicted_viewmodel.cpp
@@ -347,19 +347,15 @@ float CNEOPredictedViewModel::lean(CNEO_Player *player){
 void CNEOPredictedViewModel::CalcViewModelView(CBasePlayer *pOwner,
 	const Vector& eyePosition, const QAngle& eyeAngles)
 {
-	const int observerMode = pOwner->GetObserverMode();
-	if (observerMode != OBS_MODE_NONE)
+	if (pOwner->GetObserverMode() == OBS_MODE_IN_EYE)
 	{
-		if (observerMode == OBS_MODE_IN_EYE)
+		if (auto *pTargetPlayer = dynamic_cast<CNEO_Player *>(pOwner->GetObserverTarget());
+				pTargetPlayer && !pTargetPlayer->IsObserver())
 		{
-			if (auto *pTargetPlayer = dynamic_cast<CNEO_Player *>(pOwner->GetObserverTarget());
-					pTargetPlayer && !pTargetPlayer->IsObserver())
-			{
-				// NEO NOTE (nullsystem): 1st person mode pOwner = pTargetPlayer eye position
-				// Take the target player's viewmodel FOV instead, otherwise it'll just look like it doesn't
-				// change viewmodel FOV on 1st spectate
-				return CalcViewModelView(pTargetPlayer, eyePosition, eyeAngles);
-			}
+			// NEO NOTE (nullsystem): 1st person mode pOwner = pTargetPlayer eye position
+			// Take the target player's viewmodel FOV instead, otherwise it'll just look like it doesn't
+			// change viewmodel FOV on 1st spectate
+			return CalcViewModelView(pTargetPlayer, eyePosition, eyeAngles);
 		}
 	}
 

--- a/mp/src/game/shared/neo/neo_predicted_viewmodel.cpp
+++ b/mp/src/game/shared/neo/neo_predicted_viewmodel.cpp
@@ -347,16 +347,36 @@ float CNEOPredictedViewModel::lean(CNEO_Player *player){
 void CNEOPredictedViewModel::CalcViewModelView(CBasePlayer *pOwner,
 	const Vector& eyePosition, const QAngle& eyeAngles)
 {
-	if (pOwner->GetObserverMode() == OBS_MODE_IN_EYE)
+	const int observerMode = pOwner->GetObserverMode();
+	if (observerMode != OBS_MODE_NONE)
 	{
-		if (auto *pTargetPlayer = dynamic_cast<CNEO_Player *>(pOwner->GetObserverTarget());
-				pTargetPlayer && !pTargetPlayer->IsObserver())
+		if (observerMode == OBS_MODE_IN_EYE)
 		{
-			// NEO NOTE (nullsystem): 1st person mode pOwner = pTargetPlayer eye position
-			// Take the target player's viewmodel FOV instead, otherwise it'll just look like it doesn't
-			// change viewmodel FOV on 1st spectate
-			return CalcViewModelView(pTargetPlayer, eyePosition, eyeAngles);
+			if (auto *pTargetPlayer = dynamic_cast<CNEO_Player *>(pOwner->GetObserverTarget());
+					pTargetPlayer && !pTargetPlayer->IsObserver())
+			{
+				// NEO NOTE (nullsystem): 1st person mode pOwner = pTargetPlayer eye position
+				// Take the target player's viewmodel FOV instead, otherwise it'll just look like it doesn't
+				// change viewmodel FOV on 1st spectate
+#ifdef CLIENT_DLL
+				if (pTargetPlayer->m_bInAim)
+				{
+					pOwner->m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
+				}
+				else
+				{
+					pOwner->m_Local.m_iHideHUD |= HIDEHUD_CROSSHAIR;
+				}
+#endif
+				return CalcViewModelView(pTargetPlayer, eyePosition, eyeAngles);
+			}
 		}
+#ifdef CLIENT_DLL
+		else
+		{
+			pOwner->m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
+		}
+#endif
 	}
 
 	// Is there a nicer way to do this?

--- a/mp/src/game/shared/neo/neo_predicted_viewmodel.cpp
+++ b/mp/src/game/shared/neo/neo_predicted_viewmodel.cpp
@@ -347,6 +347,18 @@ float CNEOPredictedViewModel::lean(CNEO_Player *player){
 void CNEOPredictedViewModel::CalcViewModelView(CBasePlayer *pOwner,
 	const Vector& eyePosition, const QAngle& eyeAngles)
 {
+	if (pOwner->GetObserverMode() == OBS_MODE_IN_EYE)
+	{
+		if (auto *pTargetPlayer = dynamic_cast<CNEO_Player *>(pOwner->GetObserverTarget());
+				pTargetPlayer && !pTargetPlayer->IsObserver())
+		{
+			// NEO NOTE (nullsystem): 1st person mode pOwner = pTargetPlayer eye position
+			// Take the target player's viewmodel FOV instead, otherwise it'll just look like it doesn't
+			// change viewmodel FOV on 1st spectate
+			return CalcViewModelView(pTargetPlayer, eyePosition, eyeAngles);
+		}
+	}
+
 	// Is there a nicer way to do this?
 	auto weapon = static_cast<CWeaponHL2MPBase*>(GetOwningWeapon());
 

--- a/mp/src/game/shared/neo/neo_predicted_viewmodel.cpp
+++ b/mp/src/game/shared/neo/neo_predicted_viewmodel.cpp
@@ -358,25 +358,9 @@ void CNEOPredictedViewModel::CalcViewModelView(CBasePlayer *pOwner,
 				// NEO NOTE (nullsystem): 1st person mode pOwner = pTargetPlayer eye position
 				// Take the target player's viewmodel FOV instead, otherwise it'll just look like it doesn't
 				// change viewmodel FOV on 1st spectate
-#ifdef CLIENT_DLL
-				if (pTargetPlayer->m_bInAim)
-				{
-					pOwner->m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
-				}
-				else
-				{
-					pOwner->m_Local.m_iHideHUD |= HIDEHUD_CROSSHAIR;
-				}
-#endif
 				return CalcViewModelView(pTargetPlayer, eyePosition, eyeAngles);
 			}
 		}
-#ifdef CLIENT_DLL
-		else
-		{
-			pOwner->m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
-		}
-#endif
 	}
 
 	// Is there a nicer way to do this?


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
1st person spectator now have crosshair/scoped crosshair, and viewmodel ADS offset when the player its spectating is doing ADS.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #393
- related #390

