### PR TITLE
Disable HDR while using vision mode

### DIFF
--- a/mp/src/game/client/viewpostprocess.cpp
+++ b/mp/src/game/client/viewpostprocess.cpp
@@ -2528,6 +2528,22 @@ void DoEnginePostProcessing( int x, int y, int w, int h, bool bFlashlightIsOn, b
 	float flBloomScale = GetBloomAmount();
 
 	HDRType_t hdrType = g_pMaterialSystemHardwareConfig->GetHDRType();
+#ifdef NEO
+	auto target = C_NEO_Player::GetLocalNEOPlayer();
+	if (target)
+	{
+		if (target->GetObserverMode() == OBS_MODE_IN_EYE)
+		{
+			AssertMsg(!target->GetObserverTarget() || dynamic_cast<C_NEO_Player*>(target->GetObserverTarget()), "can't cast obs target into neo player");
+			target = static_cast<C_NEO_Player*>(target->GetObserverTarget());
+		}
+		if (target && target->IsInVision()) // don't want HDR to interfere with vision effects
+		{
+			hdrType = HDR_TYPE_NONE;
+			flBloomScale = 0.f;
+		}
+	}
+#endif
 
 	g_bFlashlightIsOn = bFlashlightIsOn;
 


### PR DESCRIPTION
Disable any HDR effects whilst rendering vision modes to avoid visual interference.

## Toolchain
- Windows MSVC VS2022

## To test
Simplest way to test this is:
* Verify you have HDR enabled in game graphics options first
* Join an HDR-enabled level (link below if you have none)
* Spawn as support
* Spawn some bots with `bot_add`
* Turn on thermal vision, see if the bots get a bloomy effect surrounding their outlines. If not, all is well.

For now, here's a simple HDR enabled test map: [hdr_test.zip](https://github.com/user-attachments/files/15972956/hdr_test.zip)

