### PR TITLE
Fix cursor stuck after disconnect while in menu then reconnect

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1219,6 +1219,20 @@ void C_NEO_Player::Spawn( void )
 
 	SetViewOffset(VEC_VIEW_NEOSCALE(this));
 
+	// NEO NOTE (nullsystem): Reset Vis/Enabled/MouseInput/Cursor state here, otherwise it can get stuck at situations
+	for (const auto pname : {PANEL_CLASS, PANEL_TEAM, PANEL_NEO_LOADOUT})
+	{
+		if (auto *panel = static_cast<vgui::EditablePanel*>
+				(GetClientModeNormal()->GetViewport()->FindChildByName(pname)))
+		{
+			panel->SetVisible(false);
+			panel->SetEnabled(false);
+			panel->SetMouseInputEnabled(false);
+			panel->SetCursorAlwaysVisible(false);
+			//panel->SetKeyBoardInputEnabled(false);
+		}
+	}
+
 	if (GetTeamNumber() == TEAM_UNASSIGNED)
 	{
 		m_bShowTeamMenu = true;


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
It's possible to get in a state where the panel will cause the cursor to be stuck being not usable in 1st person viewing mode and not much to be done about it aside from restarting. This just resets the panel states, and it's at the section where the previously when the HUD panels was managed it was reset, but now it's all via gHUD, it wasn't reset properly.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #411

