### PR TITLE
Refactor HUD scheme color variables from 4 ints to Color

### DIFF
--- a/mp/game/neo/scripts/HudLayout.res
+++ b/mp/game/neo/scripts/HudLayout.res
@@ -534,19 +534,29 @@
 	{
 		"fieldName"		"NHudCompass"
 		"visible"		"1"
+		"y_bottom_pos"		"3"
 		"needle_visible"	"0"
 		"needle_colored"	"0"
 		"objective_visible"	"1"
+		"box_color"		"100 100 100 178"
 	}
 	NHudWeapon
 	{
 		"fieldName"		"NHudWeapon"
+		"visible"		"1"
+		"enabled"		"1"
 		"xpos"			"r203"
 		"ypos"			"446"
 		"wide"			"203"
 		"tall"			"32"
+		"box_color"		"100 100 100 178"
+		"top_left_corner"	"1"
+		"top_right_corner"	"1"
+		"bottom_left_corner"	"1"
+		"bottom_right_corner"	"1"
 		"text_xpos"		"194"
 		"text_ypos"		"2"
+		"digit_as_number"	"0"
 		"digit_xpos"		"24"
 		"digit_ypos"		"6"
 		"digit_max_width"	"150"
@@ -554,14 +564,23 @@
 		"digit2_ypos"		"16"
 		"icon_xpos"		"3"
 		"icon_ypos"		"5"
+		"ammo_color"		"255 255 255 178"
+		"emptied_ammo_color"	"255 255 255 89"
 	}
 	NHudHealth
 	{
 		"fieldName"		"NHudHealth"
+		"visible"		"1"
+		"enabled"		"1"
 		"xpos"			"0"
 		"ypos"			"446"
 		"wide"			"203"
 		"tall"			"32"
+		"box_color"		"100 100 100 178"
+		"top_left_corner"	"1"
+		"top_right_corner"	"1"
+		"bottom_left_corner"	"1"
+		"bottom_right_corner"	"1"
 		"healthtext_xpos"	"6"
 		"healthtext_ypos"	"2"
 		"healthbar_xpos"	"86"
@@ -570,6 +589,7 @@
 		"healthbar_h"		"6"
 		"healthnum_xpos"	"198"
 		"healthnum_ypos"	"2"
+		"health_color"		"255 255 255 178"
 		"camotext_xpos"		"6"
 		"camotext_ypos"		"12"
 		"camobar_xpos"		"86"
@@ -578,6 +598,7 @@
 		"camobar_h"		"6"
 		"camonum_xpos"		"198"
 		"camonum_ypos"		"12"
+		"camo_color"		"255 255 255 178"
 		"sprinttext_xpos"	"6"
 		"sprinttext_ypos"	"22"
 		"sprintbar_xpos"	"86"
@@ -586,5 +607,18 @@
 		"sprintbar_h"		"6"
 		"sprintnum_xpos"	"198"
 		"sprintnum_ypos"	"22"
+		"sprint_color"		"255 255 255 178"
+	}
+	RoundResult
+	{
+		"fieldName"		"RoundResult"
+		"image_y_offset"	"60"
+		"text_y_offset"		"420"
+	}
+	NRoundState
+	{
+		"fieldName"		"NRoundState"
+		"box_color"		"100 100 100 178"
+		"health_monochrome"	"1"
 	}
 }

--- a/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
@@ -93,10 +93,6 @@ void CNEOHud_Ammo::ApplySchemeSettings(vgui::IScheme* pScheme)
 	SetBounds(0, 0, m_resX, m_resY);
 	SetFgColor(COLOR_TRANSPARENT);
 	SetBgColor(COLOR_TRANSPARENT);
-
-	box_color = Color(box_color_r, box_color_g, box_color_b, box_color_a);
-	ammo_color = Color(ammo_color_r, ammo_color_g, ammo_color_b, ammo_color_a);
-	transparent_ammo_color = Color(ammo_color_r, ammo_color_g, ammo_color_b, ammo_color_a/2);
 }
 
 void CNEOHud_Ammo::DrawAmmo() const
@@ -282,7 +278,7 @@ void CNEOHud_Ammo::DrawAmmo() const
 	if(maxClip > 0)
 	{
 		if (magSizeMax > 0) {
-			surface()->DrawSetTextColor(transparent_ammo_color);
+			surface()->DrawSetTextColor(emptied_ammo_color);
 			surface()->DrawSetTextPos(digit_xpos + xpos + (bulletWidth * magAmountToDrawFilled), digit_ypos + ypos);
 			surface()->DrawPrintText(&unicodeBullets[magAmountToDrawFilled], magSizeMax - magAmountToDrawFilled);
 		}

--- a/mp/src/game/client/neo/ui/neo_hud_ammo.h
+++ b/mp/src/game/client/neo/ui/neo_hud_ammo.h
@@ -38,18 +38,13 @@ private:
 	int m_fontWidth;
 	int m_bulletFontWidth, m_bulletFontHeight;
 
-	Color box_color, ammo_color, transparent_ammo_color;
-
 	CPanelAnimationVarAliasType(int, xpos, "xpos", "r203", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, ypos, "ypos", "446", "proportional_ypos");
 	CPanelAnimationVarAliasType(int, wide, "wide", "203", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, tall, "tall", "32", "proportional_ypos");
 	CPanelAnimationVarAliasType(int, visible, "visible", "1", "int");
 	CPanelAnimationVarAliasType(int, enabled, "enabled", "1", "int");
-	CPanelAnimationVarAliasType(int, box_color_r, "box_color_r", "116", "int");
-	CPanelAnimationVarAliasType(int, box_color_g, "box_color_g", "116", "int");
-	CPanelAnimationVarAliasType(int, box_color_b, "box_color_b", "116", "int");
-	CPanelAnimationVarAliasType(int, box_color_a, "box_color_a", "178", "int");
+	CPanelAnimationVar(Color, box_color, "box_color", "100 100 100 178");
 
 	CPanelAnimationVarAliasType(bool, top_left_corner, "top_left_corner", "1", "bool");
 	CPanelAnimationVarAliasType(bool, top_right_corner, "top_right_corner", "1", "bool");
@@ -66,10 +61,8 @@ private:
 	CPanelAnimationVarAliasType(int, digit2_ypos, "digit2_ypos", "16", "proportional_ypos");
 	CPanelAnimationVarAliasType(int, icon_xpos, "icon_xpos", "3", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, icon_ypos, "icon_ypos", "5", "proportional_ypos");
-	CPanelAnimationVarAliasType(int, ammo_color_r, "ammo_color_r", "255", "int");
-	CPanelAnimationVarAliasType(int, ammo_color_g, "ammo_color_g", "255", "int");
-	CPanelAnimationVarAliasType(int, ammo_color_b, "ammo_color_b", "255", "int");
-	CPanelAnimationVarAliasType(int, ammo_color_a, "ammo_color_a", "178", "int");
+	CPanelAnimationVar(Color, ammo_color, "ammo_color", "255 255 255 178");
+	CPanelAnimationVar(Color, emptied_ammo_color, "emptied_ammo_color", "255 255 255 89");
 private:
 	CNEOHud_Ammo(const CNEOHud_Ammo& other);
 };

--- a/mp/src/game/client/neo/ui/neo_hud_childelement.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_childelement.cpp
@@ -10,7 +10,6 @@
 
 using vgui::surface;
 
-#define NEO_HUDBOX_COLOR Color(116, 116, 116, 178)
 #define NEO_HUDBOX_CORNER_SCALE 1.0
 
 // NEO TODO (Rain): this should be expanded into two margin_width/height cvars, so players can tweak their HUD position if they wish to.

--- a/mp/src/game/client/neo/ui/neo_hud_childelement.h
+++ b/mp/src/game/client/neo/ui/neo_hud_childelement.h
@@ -6,7 +6,6 @@
 
 class C_NEO_Player;
 
-#define NEO_HUDBOX_COLOR Color(116, 116, 116, 178)
 #define NEO_HUD_ELEMENT_FREQ_CVAR_NAME(Name) cl_neo_hud_ ## Name ## _update_freq
 #ifndef xstr
 #define xstr(a) str(a)
@@ -33,7 +32,7 @@ public:
 	void resetLastUpdateTime();
 
 protected:
-	virtual void DrawNeoHudRoundedBox(const int x0, const int y0, const int x1, const int y1, Color color = NEO_HUDBOX_COLOR,
+	virtual void DrawNeoHudRoundedBox(const int x0, const int y0, const int x1, const int y1, Color color,
 			bool topLeft = true, bool topRight = true, bool bottomLeft = true, bool bottomRight = true) const;
 	virtual void DrawNeoHudRoundedBoxFaded(const int x0, const int y0, const int x1, const int y1, Color color,
 		unsigned int alpha0, unsigned int alpha1, bool bHorizontal,

--- a/mp/src/game/client/neo/ui/neo_hud_compass.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.cpp
@@ -201,7 +201,7 @@ void CNEOHud_Compass::DrawCompass() const
 	DrawNeoHudRoundedBox(
 		resXHalf - xBoxWidthHalf, m_resY - yBoxHeight - margin,
 		resXHalf + xBoxWidthHalf, m_resY - margin,
-		NEO_HUDBOX_COLOR);
+		m_boxColor);
 
 	// Draw the compass "needle"
 	if (m_needleVisible)
@@ -258,16 +258,16 @@ void CNEOHud_Compass::DrawCompass() const
 		}
 	}
 
-	static const Color FADE_END_COLOR(116, 116, 116, 255);
+	const Color fadeEndColor(m_boxColor.r(), m_boxColor.g(), m_boxColor.b(), 255);
 	DrawNeoHudRoundedBoxFaded(
 		resXHalf - xBoxWidthHalf, m_resY - yBoxHeight - margin,
 		resXHalf, m_resY - margin,
-		FADE_END_COLOR, 255, 0, true,
+		fadeEndColor, 255, 0, true,
 		true, false, true, false);
 	DrawNeoHudRoundedBoxFaded(
 		resXHalf, m_resY - yBoxHeight - margin,
 		resXHalf + xBoxWidthHalf, m_resY - margin,
-		FADE_END_COLOR, 0, 255, true,
+		fadeEndColor, 0, 255, true,
 		false, true, false, true);
 }
 

--- a/mp/src/game/client/neo/ui/neo_hud_compass.h
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.h
@@ -44,6 +44,7 @@ private:
 	CPanelAnimationVarAliasType(bool, m_needleVisible, "needle_visible", "0", "bool");
 	CPanelAnimationVarAliasType(bool, m_needleColored, "needle_colored", "0", "bool");
 	CPanelAnimationVarAliasType(bool, m_objectiveVisible, "objective_visible", "1", "bool");
+	CPanelAnimationVar(Color, m_boxColor, "box_color", "100 100 100 178");
 
 private:
 	CNEOHud_Compass(const CNEOHud_Compass &other);

--- a/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
@@ -145,45 +145,41 @@ void CNEOHud_HTA::DrawHTA() const
 		g_pVGuiLocalize->ConvertANSIToUnicode(value_Aux, unicodeValue_Aux, sizeof(unicodeValue_Aux));
 	}
 
-	Color box_color = Color(box_color_r, box_color_g, box_color_b, box_color_a);
-	Color healthColor = Color(health_color_r, health_color_g, health_color_b, health_color_a);
-	Color camoColor = Color(camo_color_r, camo_color_g, camo_color_b, camo_color_a);
-	Color sprintColor = Color(sprint_color_r, sprint_color_g, sprint_color_b, sprint_color_a);
-	DrawNeoHudRoundedBox(xpos, ypos, xpos + wide, ypos + tall, box_color, top_left_corner, top_right_corner, bottom_left_corner, bottom_right_corner);
+	DrawNeoHudRoundedBox(xpos, ypos, xpos + wide, ypos + tall, m_boxColor, top_left_corner, top_right_corner, bottom_left_corner, bottom_right_corner);
 
 	surface()->DrawSetTextFont(m_hFont);
-	surface()->DrawSetTextColor(healthColor);
+	surface()->DrawSetTextColor(m_healthColor);
 	surface()->DrawSetTextPos(healthtext_xpos + xpos, healthtext_ypos + ypos);
 	surface()->DrawPrintText(L"INTEGRITY", 9);
 	if (playerIsNotSupport)
 	{
-		surface()->DrawSetTextColor(camoColor);
+		surface()->DrawSetTextColor(m_camoColor);
 		surface()->DrawSetTextPos(camotext_xpos + xpos, camotext_ypos + ypos);
 		surface()->DrawPrintText(L"THERM-OPTIC", 11);
-		surface()->DrawSetTextColor(sprintColor);
+		surface()->DrawSetTextColor(m_sprintColor);
 		surface()->DrawSetTextPos(sprinttext_xpos + xpos, sprinttext_ypos + ypos);
 		surface()->DrawPrintText(L"AUX", 3);
 	}
 
 	int fontWidth, fontHeight;
-	surface()->DrawSetTextColor(healthColor);
+	surface()->DrawSetTextColor(m_healthColor);
 	surface()->GetTextSize(m_hFont, unicodeValue_Integrity, fontWidth, fontHeight);
 	surface()->DrawSetTextPos(healthnum_xpos + xpos - fontWidth, healthnum_ypos + ypos);
 	surface()->DrawPrintText(unicodeValue_Integrity, valLen_Integrity);
 	if (playerIsNotSupport)
 	{
-		surface()->DrawSetTextColor(camoColor);
+		surface()->DrawSetTextColor(m_camoColor);
 		surface()->GetTextSize(m_hFont, unicodeValue_ThermOptic, fontWidth, fontHeight);
 		surface()->DrawSetTextPos(camonum_xpos + xpos - fontWidth, camonum_ypos + ypos);
 		surface()->DrawPrintText(unicodeValue_ThermOptic, valLen_ThermOptic);
-		surface()->DrawSetTextColor(sprintColor);
+		surface()->DrawSetTextColor(m_sprintColor);
 		surface()->GetTextSize(m_hFont, unicodeValue_Aux, fontWidth, fontHeight);
 		surface()->DrawSetTextPos(sprintnum_xpos + xpos - fontWidth, sprintnum_ypos + ypos);
 		surface()->DrawPrintText(unicodeValue_Aux, valLen_Aux);
 	}
 
 	// Integrity progress bar
-	surface()->DrawSetColor(healthColor);
+	surface()->DrawSetColor(m_healthColor);
 	surface()->DrawFilledRect(
 		healthbar_xpos + xpos,
 		healthbar_ypos + ypos,
@@ -193,7 +189,7 @@ void CNEOHud_HTA::DrawHTA() const
 	if (playerIsNotSupport)
 	{
 		// ThermOptic progress bar
-		surface()->DrawSetColor(camoColor);
+		surface()->DrawSetColor(m_camoColor);
 		surface()->DrawFilledRect(
 			camobar_xpos + xpos,
 			camobar_ypos + ypos,
@@ -201,7 +197,7 @@ void CNEOHud_HTA::DrawHTA() const
 			camobar_ypos + ypos + camobar_h);
 
 		// AUX progress bar
-		surface()->DrawSetColor(sprintColor);
+		surface()->DrawSetColor(m_sprintColor);
 		surface()->DrawFilledRect(
 			sprintbar_xpos + xpos,
 			sprintbar_ypos + ypos,

--- a/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.h
+++ b/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.h
@@ -42,10 +42,7 @@ private:
 	CPanelAnimationVarAliasType(float, tall, "tall", "32", "proportional_float");
 	CPanelAnimationVarAliasType(float, visible, "visible", "1", "proportional_float");
 	CPanelAnimationVarAliasType(float, enabled, "enabled", "1", "proportional_float");
-	CPanelAnimationVarAliasType(int, box_color_r, "box_color_r", "116", "int");
-	CPanelAnimationVarAliasType(int, box_color_g, "box_color_g", "116", "int");
-	CPanelAnimationVarAliasType(int, box_color_b, "box_color_b", "116", "int");
-	CPanelAnimationVarAliasType(int, box_color_a, "box_color_a", "178", "int");
+	CPanelAnimationVar(Color, m_boxColor, "box_color", "100 100 100 178");
 
 	CPanelAnimationVarAliasType(bool, top_left_corner, "top_left_corner", "1", "bool");
 	CPanelAnimationVarAliasType(bool, top_right_corner, "top_right_corner", "1", "bool");
@@ -60,10 +57,7 @@ private:
 	CPanelAnimationVarAliasType(float, healthbar_h, "healthbar_h", "6", "proportional_float");
 	CPanelAnimationVarAliasType(int, healthnum_xpos, "healthnum_xpos", "198", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, healthnum_ypos, "healthnum_ypos", "2", "proportional_ypos");
-	CPanelAnimationVarAliasType(int, health_color_r, "health_color_r", "255", "int");
-	CPanelAnimationVarAliasType(int, health_color_g, "health_color_g", "255", "int");
-	CPanelAnimationVarAliasType(int, health_color_b, "health_color_b", "255", "int");
-	CPanelAnimationVarAliasType(int, health_color_a, "health_color_a", "178", "int");
+	CPanelAnimationVar(Color, m_healthColor, "health_color", "255 255 255 178");
 
 	CPanelAnimationVarAliasType(int, camotext_xpos, "camotext_xpos", "6", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, camotext_ypos, "camotext_ypos", "12", "proportional_ypos");
@@ -73,10 +67,7 @@ private:
 	CPanelAnimationVarAliasType(float, camobar_h, "camobar_h", "6", "proportional_float");
 	CPanelAnimationVarAliasType(int, camonum_xpos, "camonum_xpos", "198", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, camonum_ypos, "camonum_ypos", "12", "proportional_ypos");
-	CPanelAnimationVarAliasType(int, camo_color_r, "camo_color_r", "255", "int");
-	CPanelAnimationVarAliasType(int, camo_color_g, "camo_color_g", "255", "int");
-	CPanelAnimationVarAliasType(int, camo_color_b, "camo_color_b", "255", "int");
-	CPanelAnimationVarAliasType(int, camo_color_a, "camo_color_a", "178", "int");
+	CPanelAnimationVar(Color, m_camoColor, "camo_color", "255 255 255 178");
 
 	CPanelAnimationVarAliasType(int, sprinttext_xpos, "sprinttext_xpos", "6", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, sprinttext_ypos, "sprinttext_ypos", "22", "proportional_ypos");
@@ -86,10 +77,7 @@ private:
 	CPanelAnimationVarAliasType(float, sprintbar_h, "sprintbar_h", "6", "proportional_float");
 	CPanelAnimationVarAliasType(int, sprintnum_xpos, "sprintnum_xpos", "198", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, sprintnum_ypos, "sprintnum_ypos", "22", "proportional_ypos");
-	CPanelAnimationVarAliasType(int, sprint_color_r, "sprint_color_r", "255", "int");
-	CPanelAnimationVarAliasType(int, sprint_color_g, "sprint_color_g", "255", "int");
-	CPanelAnimationVarAliasType(int, sprint_color_b, "sprint_color_b", "255", "int");
-	CPanelAnimationVarAliasType(int, sprint_color_a, "sprint_color_a", "178", "int");
+	CPanelAnimationVar(Color, m_sprintColor, "sprint_color", "255 255 255 178");
 
 private:
 	CNEOHud_HTA(const CNEOHud_HTA& other);

--- a/mp/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -24,7 +24,7 @@
 
 using vgui::surface;
 
-DECLARE_NAMED_HUDELEMENT(CNEOHud_RoundState, neo_round_state);
+DECLARE_NAMED_HUDELEMENT(CNEOHud_RoundState, NRoundState);
 
 NEO_HUD_ELEMENT_DECLARE_FREQ_CVAR(RoundState, 0.1)
 
@@ -276,7 +276,6 @@ void CNEOHud_RoundState::DrawNeoHudElement()
 	surface()->DrawSetTextFont(m_hOCRFont);
 
 	// Draw Box
-	Color box_color = Color(box_color_r, box_color_g, box_color_b, box_color_a);
 	DrawNeoHudRoundedBox(m_iLeftOffset, Y_POS, m_iRightOffset, m_iBoxYEnd, box_color, true, true, true, true);
 
 	// Draw time
@@ -390,7 +389,6 @@ void CNEOHud_RoundState::DrawPlayer(int playerIndex, int teamIndex, const TeamLo
 									const int xOffset, const bool drawHealthClass)
 {
 	// Draw Outline
-	Color box_color = Color(box_color_r, box_color_g, box_color_b, box_color_a);
 	surface()->DrawSetColor(box_color);
 	surface()->DrawFilledRect(xOffset - 1, Y_POS - 1, xOffset + m_ilogoSize + 1,
 							  Y_POS + m_ilogoSize + 1 + (drawHealthClass ? 5 : 0));

--- a/mp/src/game/client/neo/ui/neo_hud_round_state.h
+++ b/mp/src/game/client/neo/ui/neo_hud_round_state.h
@@ -92,10 +92,7 @@ private:
 
 	int m_iNextAvatarUpdate = 0;
 
-	CPanelAnimationVarAliasType(int, box_color_r, "box_color_r", "116", "int");
-	CPanelAnimationVarAliasType(int, box_color_g, "box_color_g", "116", "int");
-	CPanelAnimationVarAliasType(int, box_color_b, "box_color_b", "116", "int");
-	CPanelAnimationVarAliasType(int, box_color_a, "box_color_a", "178", "int");
+	CPanelAnimationVar(Color, box_color, "box_color", "100 100 100 178");
 	CPanelAnimationVarAliasType(bool, health_monochrome, "health_monochrome", "1", "bool");
 
 private:


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Instead of `int` of `_r _g _b _a`, it's now all `Color` which is more convenient to edit and use
* Added other variables also to the `HudLayout.res` to make them visible to player
* Hud BG Color from "116 116 116 178" to "100 100 100 178" closer to OG:NT but not gonna try to do the whole lot as that'll take a while to compare. Doesn't even seem to be the same color visual between OG:NT and NT;RE overall or can't match.
* `neo_round_state` -> `NRoundState`
* Compass add `box_color`


## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #459

