### PR TITLE
Allow grenade (frag/smoke) prime+throw on sprint + fix secondary hold

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1056,7 +1056,7 @@ void C_NEO_Player::PostThink(void)
 		{
 			Weapon_SetZoom(false);
 		}
-		else if ((m_afButtonPressed & IN_AIM) && (!CanSprint() || !(m_nButtons & IN_SPEED)))
+		else if (m_afButtonPressed & IN_AIM)
 		{
 			// Binds hack: we want grenade secondary attack to trigger on aim (mouse button 2)
 			if (auto *pNeoWep = dynamic_cast<C_NEOBaseCombatWeapon *>(pWep);
@@ -1064,7 +1064,7 @@ void C_NEO_Player::PostThink(void)
 			{
 				pNeoWep->SecondaryAttack();
 			}
-			else
+			else if (!CanSprint() || !(m_nButtons & IN_SPEED))
 			{
 				Weapon_AimToggle(pWep, clientAimHold ? NEO_TOGGLE_FORCE_AIM : NEO_TOGGLE_DEFAULT);
 			}

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1072,7 +1072,7 @@ void CNEO_Player::PostThink(void)
 		{
 			Weapon_SetZoom(false);
 		}
-		else if ((m_afButtonPressed & IN_AIM) && (!CanSprint() || !(m_nButtons & IN_SPEED)))
+		else if (m_afButtonPressed & IN_AIM)
 		{
 			// Binds hack: we want grenade secondary attack to trigger on aim (mouse button 2)
 			if (auto *pNeoWep = dynamic_cast<CNEOBaseCombatWeapon *>(pWep);
@@ -1080,7 +1080,7 @@ void CNEO_Player::PostThink(void)
 			{
 				pNeoWep->SecondaryAttack();
 			}
-			else
+			else if (!CanSprint() || !(m_nButtons & IN_SPEED))
 			{
 				Weapon_AimToggle(pWep, clientAimHold ? NEO_TOGGLE_FORCE_AIM : NEO_TOGGLE_DEFAULT);
 			}

--- a/mp/src/game/shared/neo/weapons/weapon_grenade.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_grenade.cpp
@@ -146,7 +146,7 @@ void CWeaponGrenade::SecondaryAttack(void)
 
 		// Don't let weapon idle interfere in the middle of a throw!
 		m_flTimeWeaponIdle = FLT_MAX;
-		m_flNextPrimaryAttack = gpGlobals->curtime + RETHROW_DELAY;
+		m_flNextSecondaryAttack = gpGlobals->curtime + RETHROW_DELAY;
 	}
 	// If I'm now out of ammo, switch away
 	if (!HasPrimaryAmmo())
@@ -225,7 +225,7 @@ void CWeaponGrenade::ItemPostFrame(void)
 				break;
 
 			case GRENADE_PAUSED_SECONDARY:
-				if (!(pOwner->m_nButtons & IN_ATTACK2))
+				if (!(pOwner->m_nButtons & IN_AIM))
 				{
 					//See if we're ducking
 					if (pOwner->m_nButtons & IN_DUCK)
@@ -255,8 +255,6 @@ void CWeaponGrenade::ItemPostFrame(void)
 			}
 		}
 	}
-
-	ProcessAnimationEvents();
 
 	BaseClass::ItemPostFrame();
 }
@@ -344,7 +342,7 @@ void CWeaponGrenade::ThrowGrenade(CBasePlayer *pPlayer)
 void CWeaponGrenade::LobGrenade(CBasePlayer *pPlayer)
 {
 	// Binds hack: we want grenade secondary attack to trigger on aim, not the attack2 bind.
-	if (pPlayer->m_afButtonPressed & IN_ATTACK2)
+	if (pPlayer->m_afButtonPressed & IN_AIM)
 	{
 		return;
 	}
@@ -391,7 +389,7 @@ void CWeaponGrenade::LobGrenade(CBasePlayer *pPlayer)
 void CWeaponGrenade::RollGrenade(CBasePlayer *pPlayer)
 {
 	// Binds hack: we want grenade secondary attack to trigger on aim, not the attack2 bind.
-	if (pPlayer->m_afButtonPressed & IN_ATTACK2)
+	if (pPlayer->m_afButtonPressed & IN_AIM)
 	{
 		return;
 	}

--- a/mp/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
@@ -124,7 +124,7 @@ void CWeaponSmokeGrenade::SecondaryAttack(void)
 
 		// Don't let weapon idle interfere in the middle of a throw!
 		m_flTimeWeaponIdle = FLT_MAX;
-		m_flNextPrimaryAttack = gpGlobals->curtime + RETHROW_DELAY;
+		m_flNextSecondaryAttack = gpGlobals->curtime + RETHROW_DELAY;
 	}
 	// If I'm now out of ammo, switch away
 	if (!HasPrimaryAmmo())
@@ -203,7 +203,7 @@ void CWeaponSmokeGrenade::ItemPostFrame(void)
 				break;
 
 			case GRENADE_PAUSED_SECONDARY:
-				if (!(pOwner->m_nButtons & IN_ATTACK2))
+				if (!(pOwner->m_nButtons & IN_AIM))
 				{
 					//See if we're ducking
 					if (pOwner->m_nButtons & IN_DUCK)
@@ -233,8 +233,6 @@ void CWeaponSmokeGrenade::ItemPostFrame(void)
 			}
 		}
 	}
-
-	ProcessAnimationEvents();
 
 	BaseClass::ItemPostFrame();
 }
@@ -323,7 +321,7 @@ void CWeaponSmokeGrenade::ThrowGrenade(CBasePlayer* pPlayer)
 void CWeaponSmokeGrenade::LobGrenade(CBasePlayer* pPlayer)
 {
 	// Binds hack: we want grenade secondary attack to trigger on aim, not the attack2 bind.
-	if (pPlayer->m_afButtonPressed & IN_ATTACK2)
+	if (pPlayer->m_afButtonPressed & IN_AIM)
 	{
 		return;
 	}
@@ -370,7 +368,7 @@ void CWeaponSmokeGrenade::LobGrenade(CBasePlayer* pPlayer)
 void CWeaponSmokeGrenade::RollGrenade(CBasePlayer* pPlayer)
 {
 	// Binds hack: we want grenade secondary attack to trigger on aim, not the attack2 bind.
-	if (pPlayer->m_afButtonPressed & IN_ATTACK2)
+	if (pPlayer->m_afButtonPressed & IN_AIM)
 	{
 		return;
 	}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Grenade used to be treated like other weapons where it get blocked when sprinting, this just gives an exemption for grenades/throwables to allow prime+throw on sprint.
* Regarding secondary throw, this is also allowed on sprint also.
* Secondary throw also fixed to make it hold rather than instant throw
* Make sure shoot and aim behavior for other weapons isn't affected/kept prevented on sprint

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #456

