### PR TITLE
Friendly markers - Remove CTargetID, dist/HP in friendly marker, pos

### DIFF
--- a/mp/src/game/client/CMakeLists.txt
+++ b/mp/src/game/client/CMakeLists.txt
@@ -1678,7 +1678,7 @@ target_sources_grouped(
     FILES
     hl2mp/hl2mp_hud_chat.cpp
     hl2mp/hl2mp_hud_chat.h
-    hl2mp/hl2mp_hud_target_id.cpp
+    #hl2mp/hl2mp_hud_target_id.cpp
     hl2mp/hl2mp_hud_team.cpp
     hl2mp/hud_deathnotice.cpp
     hl2mp/ui/backgroundpanel.cpp

--- a/mp/src/game/client/hl2mp/hl2mp_hud_target_id.cpp
+++ b/mp/src/game/client/hl2mp/hl2mp_hud_target_id.cpp
@@ -12,7 +12,7 @@
 
 using namespace vgui;
 
-#ifdef NEO
+#ifndef NEO
 DECLARE_NAMED_HUDELEMENT(CTargetID, TargetID);
 #endif
 

--- a/mp/src/game/client/neo/ui/neo_hud_friendly_marker.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_friendly_marker.cpp
@@ -54,16 +54,9 @@ CNEOHud_FriendlyMarker::CNEOHud_FriendlyMarker(const char* pElemName, vgui::Pane
 	surface()->GetScreenSize(wide, tall);
 	SetBounds(0, 0, wide, tall);
 
-	// NEO HACK (Rain): this is kind of awkward, we should get the handle on ApplySchemeSettings
-	vgui::IScheme *scheme = vgui::scheme()->GetIScheme(neoscheme);
-	Assert(scheme);
-
-	m_hFont = scheme->GetFont("NHudOCRSmall", true);
-
 	m_hTex = surface()->CreateNewTextureID();
 	Assert(m_hTex > 0);
 	surface()->DrawSetTextureFile(m_hTex, "vgui/hud/star", 1, false);
-
 	surface()->DrawGetTextureSize(m_hTex, m_iMarkerTexWidth, m_iMarkerTexHeight);
 
 	SetFgColor(Color(0, 0, 0, 0));
@@ -71,6 +64,14 @@ CNEOHud_FriendlyMarker::CNEOHud_FriendlyMarker(const char* pElemName, vgui::Pane
 
 	SetVisible(true);
 }
+
+void CNEOHud_FriendlyMarker::ApplySchemeSettings(vgui::IScheme *pScheme)
+{
+	BaseClass::ApplySchemeSettings(pScheme);
+
+	m_hFont = pScheme->GetFont("NHudOCRSmall", true);
+}
+
 void CNEOHud_FriendlyMarker::DrawNeoHudElement()
 {
 	if (!ShouldDraw())
@@ -91,14 +92,15 @@ void CNEOHud_FriendlyMarker::DrawNeoHudElement()
 	m_IsSpectator = team->GetTeamNumber() == TEAM_SPECTATOR;
 	
 	
-	if(m_IsSpectator)
+	if (m_IsSpectator)
 	{
 		auto nsf = GetGlobalTeam(TEAM_NSF);
 		DrawPlayerForTeam(nsf, localPlayer);
 		
 		auto jinrai = GetGlobalTeam(TEAM_JINRAI);
 		DrawPlayerForTeam(jinrai, localPlayer);
-	} else
+	}
+	else
 	{
 		DrawPlayerForTeam(team, localPlayer);
 	}
@@ -107,49 +109,67 @@ void CNEOHud_FriendlyMarker::DrawNeoHudElement()
 void CNEOHud_FriendlyMarker::DrawPlayerForTeam(C_Team* team, const C_NEO_Player* localPlayer) const
 {
 	auto memberCount = team->GetNumPlayers();
+	auto teamColour = GetTeamColour(team->GetTeamNumber());
 	for (int i = 0; i < memberCount; ++i)
 	{
-		auto player = team->GetPlayer(i);
-		auto teamColour = GetTeamColour(team->GetTeamNumber());
+		auto player = dynamic_cast<C_NEO_Player *>(team->GetPlayer(i));
 		if(player && localPlayer->entindex() != player->entindex() && player->IsAlive())
 		{
-			DrawPlayer(teamColour, player);
+			DrawPlayer(teamColour, player, localPlayer);
 		}		
 	}
 }
 
-void CNEOHud_FriendlyMarker::DrawPlayer(Color teamColor, C_BasePlayer* player) const
+void CNEOHud_FriendlyMarker::DrawPlayer(Color teamColor, C_NEO_Player *player, const C_NEO_Player *localPlayer) const
 {
 	int x, y;
 	static const float heightOffset = 48.0f;
-	auto pPos = player->GetAbsOrigin();
-	auto pos = Vector(
-		pPos.x,
-		pPos.y,
-		pPos.z + heightOffset);
+	auto pos = player->EyePosition();
 
 	if (GetVectorInScreenSpace(pos, x, y))
 	{
-		auto n = dynamic_cast<C_NEO_Player*>(player);
-		auto a = n->m_rvFriendlyPlayerPositions;
-		static const int maxNameLenght = 32 + 1;		
-		auto playerName = n->GetNeoPlayerName();
+		auto playerName = player->GetNeoPlayerName();
 
-		wchar_t playerNameUnicode[maxNameLenght];
-		char playerNameTrimmed[maxNameLenght];
-		snprintf(playerNameTrimmed, maxNameLenght, "%s", playerName);
-		auto textLen = V_strlen(playerNameTrimmed);
-		g_pVGuiLocalize->ConvertANSIToUnicode(playerNameTrimmed, playerNameUnicode, sizeof(playerNameUnicode));
-
-		auto fadeTextMultiplier = GetFadeValueTowardsScreenCentre(x, y);
-		if(fadeTextMultiplier > 0.001)
+		const float fadeTextMultiplier = GetFadeValueTowardsScreenCentre(x, y);
+		if (fadeTextMultiplier > 0.001f)
 		{
+			static constexpr int MAX_MARKER_STRLEN = 48 + 1;
+			const bool localPlayerAlive = const_cast<C_NEO_Player *>(localPlayer)->IsAlive();
+			const bool localPlayerSpec = (localPlayer->GetTeamNumber() < FIRST_GAME_TEAM);
+
 			surface()->DrawSetTextFont(m_hFont);
 			surface()->DrawSetTextColor(FadeColour(teamColor, fadeTextMultiplier));
-			int textWidth, textHeight;
-			surface()->GetTextSize(m_hFont, playerNameUnicode, textWidth, textHeight);
-			surface()->DrawSetTextPos(x - (textWidth / 2), y + m_iMarkerHeight);
-			surface()->DrawPrintText(playerNameUnicode, textLen);
+			int textYOffset = 0;
+			char textASCII[MAX_MARKER_STRLEN];
+
+			auto DisplayText = [this, &textYOffset, x, y](const char *textASCII) {
+				wchar_t textUTF[MAX_MARKER_STRLEN];
+				g_pVGuiLocalize->ConvertANSIToUnicode(textASCII, textUTF, sizeof(textUTF));
+				int textWidth, textHeight;
+				surface()->GetTextSize(m_hFont, textUTF, textWidth, textHeight);
+				surface()->DrawSetTextPos(x - (textWidth / 2), y + m_iMarkerHeight + textYOffset);
+				surface()->DrawPrintText(textUTF, V_strlen(textASCII));
+				textYOffset += textHeight;
+			};
+
+			// Draw player's name and health
+			snprintf(textASCII, MAX_MARKER_STRLEN, "%s", playerName);
+			DisplayText(textASCII);
+
+			// Draw distance to player - Only if local player alive and same team
+			// OR local not alive or spectator and this player has ghost
+			if ((localPlayerAlive && localPlayer->GetTeamNumber() == player->GetTeamNumber()) ||
+					((!localPlayerAlive || localPlayerSpec) && player->IsCarryingGhost()))
+			{
+				const float flDistance = METERS_PER_INCH * player->GetAbsOrigin().DistTo(localPlayer->GetAbsOrigin());
+				snprintf(textASCII, MAX_MARKER_STRLEN, "%s: %.0fm",
+						 player->IsCarryingGhost() ? "GHOST DISTANCE" : "DISTANCE",
+						 flDistance);
+				DisplayText(textASCII);
+			}
+
+			snprintf(textASCII, MAX_MARKER_STRLEN, "%d%%", player->GetHealth());
+			DisplayText(textASCII);
 		}
 
 		surface()->DrawSetTexture(m_hTex);

--- a/mp/src/game/client/neo/ui/neo_hud_friendly_marker.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_friendly_marker.cpp
@@ -112,7 +112,7 @@ void CNEOHud_FriendlyMarker::DrawPlayerForTeam(C_Team* team, const C_NEO_Player*
 	auto teamColour = GetTeamColour(team->GetTeamNumber());
 	for (int i = 0; i < memberCount; ++i)
 	{
-		auto player = dynamic_cast<C_NEO_Player *>(team->GetPlayer(i));
+		auto player = static_cast<C_NEO_Player *>(team->GetPlayer(i));
 		if(player && localPlayer->entindex() != player->entindex() && player->IsAlive())
 		{
 			DrawPlayer(teamColour, player, localPlayer);
@@ -153,7 +153,7 @@ void CNEOHud_FriendlyMarker::DrawPlayer(Color teamColor, C_NEO_Player *player, c
 			};
 
 			// Draw player's name and health
-			snprintf(textASCII, MAX_MARKER_STRLEN, "%s", playerName);
+			V_snprintf(textASCII, MAX_MARKER_STRLEN, "%s", playerName);
 			DisplayText(textASCII);
 
 			// Draw distance to player - Only if local player alive and same team
@@ -162,13 +162,13 @@ void CNEOHud_FriendlyMarker::DrawPlayer(Color teamColor, C_NEO_Player *player, c
 					((!localPlayerAlive || localPlayerSpec) && player->IsCarryingGhost()))
 			{
 				const float flDistance = METERS_PER_INCH * player->GetAbsOrigin().DistTo(localPlayer->GetAbsOrigin());
-				snprintf(textASCII, MAX_MARKER_STRLEN, "%s: %.0fm",
+				V_snprintf(textASCII, MAX_MARKER_STRLEN, "%s: %.0fm",
 						 player->IsCarryingGhost() ? "GHOST DISTANCE" : "DISTANCE",
 						 flDistance);
 				DisplayText(textASCII);
 			}
 
-			snprintf(textASCII, MAX_MARKER_STRLEN, "%d%%", player->GetHealth());
+			V_snprintf(textASCII, MAX_MARKER_STRLEN, "%d%%", player->GetHealth());
 			DisplayText(textASCII);
 		}
 

--- a/mp/src/game/client/neo/ui/neo_hud_friendly_marker.h
+++ b/mp/src/game/client/neo/ui/neo_hud_friendly_marker.h
@@ -17,13 +17,14 @@ class CNEOHud_FriendlyMarker : public CNEOHud_WorldPosMarker
 public:
 	CNEOHud_FriendlyMarker(const char *pElemName, vgui::Panel *parent = NULL);
 	
-	virtual void Paint();
+	virtual void ApplySchemeSettings(vgui::IScheme *pScheme) override;
+	virtual void Paint() override;
 
 protected:
-	virtual void DrawNeoHudElement();
+	virtual void DrawNeoHudElement() override;
 	void DrawPlayerForTeam(C_Team* team, const C_NEO_Player* localPlayer) const;
-	virtual ConVar* GetUpdateFrequencyConVar() const;
-	virtual void UpdateStateForNeoHudElementDraw();
+	virtual ConVar* GetUpdateFrequencyConVar() const override;
+	virtual void UpdateStateForNeoHudElementDraw() override;
 
 private:
 	int m_iMarkerTexWidth, m_iMarkerTexHeight;
@@ -35,10 +36,10 @@ private:
 	int m_y0[MAX_PLAYERS];
 	int m_y1[MAX_PLAYERS];
 
-	vgui::HTexture m_hTex;
-	vgui::HFont m_hFont;
+	vgui::HTexture m_hTex = 0UL;
+	vgui::HFont m_hFont = 0UL;
 
-	void DrawPlayer(Color teamColor, C_BasePlayer* player) const;
+	void DrawPlayer(Color teamColor, C_NEO_Player *player, const C_NEO_Player *localPlayer) const;
 	static Color GetTeamColour(int team);
 
 };

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_marker.h
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_marker.h
@@ -37,8 +37,8 @@ private:
 	int m_iGhostingTeam;
 	int m_iClientTeam;
 
-	char m_szMarkerText[12 + 1];
-	wchar_t m_wszMarkerTextUnicode[12 + 1];
+	char m_szMarkerText[32 + 1];
+	wchar_t m_wszMarkerTextUnicode[32 + 1];
 
 	float m_flDistMeters;
 

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -811,10 +811,7 @@ void CNEO_Player::PreThink(void)
 				const int playerIdx = NEORules()->GetGhosterPlayer();
 				if (auto player = static_cast<CNEO_Player*>(UTIL_PlayerByIndex(playerIdx)))
 				{
-					const Vector playerEye = player->EyePosition();
-					const Vector playerBase = player->GetAbsOrigin();
-					const float playerMidZ = (playerEye.z - playerBase.z) / 2.0f;
-					vecNextGhostMarkerPos = Vector(playerBase.x, playerBase.y, playerBase.z + playerMidZ);
+					vecNextGhostMarkerPos = player->EyePosition();
 				}
 			}
 			m_vecGhostMarkerPos = vecNextGhostMarkerPos;


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Remove old large text CTargetID
* Introduce distance and HP for friendly markers, shown depending on local vs target player's state
* Position now set to eye's z position, close to OG:NT

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #427
* fixes #428
* fixes #429

