### PR TITLE
Fix crash to desktop

### DIFF
--- a/mp/src/game/client/hl2mp/clientmode_hl2mpnormal.cpp
+++ b/mp/src/game/client/hl2mp/clientmode_hl2mpnormal.cpp
@@ -175,7 +175,6 @@ void ClientModeHL2MPNormal::Init()
 
 #ifdef NEO
 ConVar cl_neo_decouple_vm_fov("cl_neo_decouple_vm_fov", "1", FCVAR_CHEAT, "Whether to decouple aim FOV from viewmodel FOV.", true, false, true, true);
-ConVar cl_neo_decoupled_vm_fov_lerp_scale("cl_neo_decoupled_vm_fov_lerp_scale", "10", FCVAR_CHEAT, "Multiplier for decoupled FOV lerp speed.", true, 0.01, false, 0);
 ConVar neo_viewmodel_fov_offset("neo_viewmodel_fov_offset", "0", FCVAR_ARCHIVE, "Sets the field-of-view offset for the viewmodel.", true, -20.0f, true, 40.0f);
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
* Fix potential nullptr dereference of `pOwner`.
* The `flScale` statement is removed entirely because it was not used for anything.
* Refactor deeply nested if statements.
* Refactor `dynamic_cast` of `C_NEOBaseCombatWeapon*` to `static_cast` for release, because all our guns are `C_NEOBaseCombatWeapon*` now.
* The `cl_neo_decoupled_vm_fov_lerp_scale` cvar is removed as unused.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #413

