### PR TITLE
Team/Class/Loadout menu opening correctly

### DIFF
--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -1116,12 +1116,6 @@ void ClientModeShared::FireGameEvent( IGameEvent *event )
 		{
 			// that's me
 			pPlayer->TeamChange( team );
-
-			auto neoPlayer = dynamic_cast<C_NEO_Player*>(pPlayer);
-			if(neoPlayer)
-			{
-				engine->ClientCmd("classmenu");
-			}
 		}
 	}
 #ifdef NEO

--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -1116,6 +1116,12 @@ void ClientModeShared::FireGameEvent( IGameEvent *event )
 		{
 			// that's me
 			pPlayer->TeamChange( team );
+
+			auto neoPlayer = dynamic_cast<C_NEO_Player*>(pPlayer);
+			if(neoPlayer)
+			{
+				engine->ClientCmd("classmenu");
+			}
 		}
 	}
 #ifdef NEO

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1122,6 +1122,12 @@ void C_NEO_Player::CalcDeathCamView(Vector &eyeOrigin, QAngle &eyeAngles, float 
 	}
 }
 
+void C_NEO_Player::TeamChange(int iNewTeam)
+{
+	engine->ClientCmd(classmenu.GetName());
+	BaseClass::TeamChange(iNewTeam);
+}
+
 bool C_NEO_Player::IsAllowedToSuperJump(void)
 {
 	if (!IsSprinting())

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -172,6 +172,7 @@ public:
 	bool ClientWantNeoName() const;
 
 	virtual void CalcDeathCamView( Vector& eyeOrigin, QAngle& eyeAngles, float& fov ) override;
+	virtual void TeamChange(int iNewTeam) override;
 
 private:
 	void CheckThermOpticButtons();

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -194,8 +194,7 @@ public:
 	CNetworkArray(Vector, m_rvFriendlyPlayerPositions, MAX_PLAYERS);
 	CNetworkArray(float, m_rfAttackersScores, (MAX_PLAYERS + 1));
 	CNetworkArray(int, m_rfAttackersHits, (MAX_PLAYERS + 1));
-
-	bool m_bShowClassMenu, m_bShowTeamMenu;
+	
 	CNetworkVar(bool, m_bHasBeenAirborneForTooLongToSuperJump);
 
 	CNetworkVar(bool, m_bGhostExists);
@@ -221,8 +220,6 @@ public:
 	CNetworkVar(bool, m_bClientWantNeoName);
 
 	unsigned char m_NeoFlags;
-
-	bool m_bIsClassMenuOpen, m_bIsTeamMenuOpen;
 
 private:
 	bool m_bFirstDeathTick;

--- a/mp/src/game/client/neo/game_controls/neo_classmenu.cpp
+++ b/mp/src/game/client/neo/game_controls/neo_classmenu.cpp
@@ -204,14 +204,13 @@ void CNeoClassMenu::ChangeMenu(const char* menuName = NULL)
 	C_NEO_Player* player = C_NEO_Player::GetLocalNEOPlayer();
 	if (player)
 	{
-		player->m_bShowClassMenu = false;
 		if (menuName == NULL)
 		{
 			return;
 		}
 		if (Q_stricmp(menuName, "teammenu") == 0)
 		{
-			player->m_bShowTeamMenu = true;
+			engine->ClientCmd(menuName);
 		}
 	}
 	else

--- a/mp/src/game/client/neo/game_controls/neo_loadoutmenu.cpp
+++ b/mp/src/game/client/neo/game_controls/neo_loadoutmenu.cpp
@@ -300,7 +300,7 @@ void CNeoLoadoutMenu::ChangeMenu(const char* menuName = NULL)
 		}
 		if (Q_stricmp(menuName, "classmenu") == 0)
 		{
-			player->m_bShowClassMenu = true;
+			engine->ClientCmd(menuName);
 		}
 	}
 	else

--- a/mp/src/game/client/neo/game_controls/neo_teammenu.cpp
+++ b/mp/src/game/client/neo/game_controls/neo_teammenu.cpp
@@ -29,8 +29,6 @@
 #include "replay/replaycamera.h"
 #endif
 
-#include "c_neo_player.h"
-
 //#include <game_controls/IconPanel.h>
 
 #include <vgui_controls/TextEntry.h>
@@ -227,7 +225,7 @@ void CNeoTeamMenu::CloseMenu()
 void CNeoTeamMenu::OnKeyCodeReleased(vgui::KeyCode code)
 { // Navigating using the keyboard hack
 	switch (code) {
-	case 92: // F1 - Close the menu
+	case KEY_F1: // F1 - Close the menu
 		CloseMenu();
 	}
 	// Leaving this here, useful to check what key is being pressed

--- a/mp/src/game/client/neo/game_controls/neo_teammenu.cpp
+++ b/mp/src/game/client/neo/game_controls/neo_teammenu.cpp
@@ -225,14 +225,13 @@ void CNeoTeamMenu::ChangeMenu(const char* menuName = NULL)
 	C_NEO_Player* player = C_NEO_Player::GetLocalNEOPlayer();
 	if (player)
 	{
-		player->m_bShowTeamMenu = false;
 		if (menuName == NULL)
 		{
 			return;
 		}
 		if (Q_stricmp(menuName, "classmenu") == 0)
 		{
-			player->m_bShowClassMenu = true;
+			engine->ClientCmd(menuName);
 		}
 	}
 	else

--- a/mp/src/game/client/neo/game_controls/neo_teammenu.cpp
+++ b/mp/src/game/client/neo/game_controls/neo_teammenu.cpp
@@ -183,68 +183,52 @@ void CNeoTeamMenu::OnCommand(const char *command)
 		const int nsfNumPlayers = (pNsf != NULL ? pNsf->Get_Number_Players() : 0);
 		int randomTeam = jinNumPlayers > nsfNumPlayers ? TEAM_NSF : (nsfNumPlayers > jinNumPlayers ? TEAM_JINRAI : RandomInt(TEAM_JINRAI, TEAM_NSF));
 		V_sprintf_safe(commandBuffer, "jointeam %i", randomTeam);
-		ChangeMenu("classmenu");
+		CloseMenu();
 		engine->ClientCmd(commandBuffer);
 		return;
 	}
 
 	if (Q_strcmp(commandBuffer, "jointeam 1") == 0)
 	{ // joining spectators
-		ChangeMenu(NULL);
+		CloseMenu();
 		engine->ClientCmd(commandBuffer);
 		return;
 	}
 
 	if (Q_strcmp(commandBuffer, "jointeam 0") == 0)
 	{ // joining unnasigned
-		ChangeMenu(NULL);
+		CloseMenu();
 		engine->ClientCmd(commandBuffer);
 		return;
 	}
 
 	if (Q_stristr(commandBuffer, "jointeam") != 0) // Note using stristr, not strcmp. Equates to true when jointeam in commandBuffer
 	{ // joining jinrai or nsf
-		ChangeMenu("classmenu");
+		CloseMenu();
 		engine->ClientCmd(commandBuffer);
 		return;
 	}
 
 	if (Q_stricmp(commandBuffer, "vguicancel") == 0)
 	{ // cancel, close menu
-		ChangeMenu(NULL);
+		CloseMenu();
 	}
 	
 	// new command, should we sanitize and return without executing? (Players can edit button commands with ctrl-alt-shift-b) NEO FIXME
 	engine->ClientCmd(command);
 }
 
-void CNeoTeamMenu::ChangeMenu(const char* menuName = NULL)
+void CNeoTeamMenu::CloseMenu()
 {
 	CommandCompletion();
 	ShowPanel(false);
-	C_NEO_Player* player = C_NEO_Player::GetLocalNEOPlayer();
-	if (player)
-	{
-		if (menuName == NULL)
-		{
-			return;
-		}
-		if (Q_stricmp(menuName, "classmenu") == 0)
-		{
-			engine->ClientCmd(menuName);
-		}
-	}
-	else
-	{
-		Assert(false);
-	}
 }
 
 void CNeoTeamMenu::OnKeyCodeReleased(vgui::KeyCode code)
 { // Navigating using the keyboard hack
 	switch (code) {
 	case 92: // F1 - Close the menu
-		ChangeMenu(NULL);
+		CloseMenu();
 	}
 	// Leaving this here, useful to check what key is being pressed
 	/*char buffer[8] = "";

--- a/mp/src/game/client/neo/game_controls/neo_teammenu.h
+++ b/mp/src/game/client/neo/game_controls/neo_teammenu.h
@@ -62,7 +62,7 @@ public:
 protected:
     void FindButtons();
     void OnCommand(const char *command);
-    void ChangeMenu(const char* menuName);
+    void CloseMenu();
     void OnKeyCodeReleased(vgui::KeyCode code);
 
     void SetLabelText(const char *textEntryName, const char *text);


### PR DESCRIPTION
## Description
Cleanup menu openings
Do not open class menu on round start for spectators

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #385
- fixes #378
