### PR TITLE
Fix Supa7 firerate and right-side icon showing (Supa7 + AA13)

### DIFF
--- a/mp/game/neo/scripts/weapon_aa13.txt
+++ b/mp/game/neo/scripts/weapon_aa13.txt
@@ -92,18 +92,18 @@ WeaponData
 	{
 		"weapon"
 		{
-			"font"		"CSweaponsSmall"
-			"character"	"K"
+			"font"		"WeaponIcons"
+			"character"	"d"
 		}
 		"weapon_s"
 		{	
-			"font"		"CSweapons"
-			"character"	"K"
+			"font"		"WeaponIconsSelected"
+			"character"	"d"
 		}
 		"ammo"
 		{
-			"font"		"CSTypeDeath"
-			"character"	"J"
+			"font"		"WeaponIcons"
+			"character"	"p"
 		}
 		"crosshair"
 		{

--- a/mp/game/neo/scripts/weapon_supa7.txt
+++ b/mp/game/neo/scripts/weapon_supa7.txt
@@ -5,7 +5,7 @@ WeaponData
 	// Weapon characteristics:
 	"Damage"			"18"
 	"Bullets"			"8"
-	"CycleTime"			"0.875"
+	"CycleTime"			"0.8"
 	
 	// Weapon data is loaded by both the Game and Client DLLs.
 	"printname"			"MURATA SUPA 7"

--- a/mp/game/neo/scripts/weapon_supa7.txt
+++ b/mp/game/neo/scripts/weapon_supa7.txt
@@ -91,18 +91,18 @@ WeaponData
 	{
 		"weapon"
 		{
-				"font"		"CSweaponsSmall"
-				"character"	"K"
+				"font"		"WeaponIcons"
+				"character"	"d"
 		}
 		"weapon_s"
 		{	
-				"font"		"CSweapons"
-				"character"	"K"
+				"font"		"WeaponIconsSelected"
+				"character"	"d"
 		}
 		"ammo"
 		{
-				"font"		"CSTypeDeath"
-				"character"	"J"
+				"font"		"WeaponIcons"
+				"character"	"p"
 		}
 		"crosshair"
 		{

--- a/mp/src/game/shared/neo/weapons/weapon_supa7.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_supa7.cpp
@@ -332,7 +332,7 @@ void CWeaponSupa7::PrimaryAttack(void)
 	m_bSlugLoaded = false;
 
 	// Don't fire again until fire animation has completed
-	ProposeNextAttack(gpGlobals->curtime + (SequenceDuration() * 0.75));
+	ProposeNextAttack(gpGlobals->curtime + GetFireRate());
 	m_iClip1 -= 1;
 
 	// player "shoot" animation


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Supa7 OGNT firerate is 0.8 (measured using host_timescale 0.1, 8s), not 0.875 which the script stated before
* Fix not using script's firerate
* Fix right-side CS-style icons showing up by just setting it like other weapons (this includes AA13)

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #422
- fixes #440

