### PR TITLE
Player stuck when leaning

### DIFF
--- a/mp/src/game/shared/gamemovement.cpp
+++ b/mp/src/game/shared/gamemovement.cpp
@@ -756,13 +756,7 @@ Vector CGameMovement::GetPlayerMins( void ) const
 	{
 #ifdef NEO
 		Assert(dynamic_cast<CNEO_Player*>(player));
-		Vector mins = player->m_Local.m_bDucked ? VEC_DUCK_HULL_MIN_SCALED(static_cast<CNEO_Player*>(player)) : VEC_HULL_MIN_SCALED(static_cast<CNEO_Player*>(player));
-		// We may be leaning sideways, in which case we need to block the lean camera from clipping walls etc.
-		if (player->GetViewOffset().y < 0)
-		{
-			mins.y += player->GetViewOffset().y;
-		}
-		return mins;
+		return player->m_Local.m_bDucked ? VEC_DUCK_HULL_MIN_SCALED(static_cast<CNEO_Player*>(player)) : VEC_HULL_MIN_SCALED(static_cast<CNEO_Player*>(player));
 #else
 		return player->m_Local.m_bDucked ? VEC_DUCK_HULL_MIN_SCALED(player) : VEC_HULL_MIN_SCALED(player);
 #endif
@@ -784,13 +778,7 @@ Vector CGameMovement::GetPlayerMaxs( void ) const
 	{
 #ifdef NEO
 		Assert(dynamic_cast<CNEO_Player*>(player));
-		Vector maxs = player->m_Local.m_bDucked ? VEC_DUCK_HULL_MAX_SCALED(static_cast<CNEO_Player*>(player)) : VEC_HULL_MAX_SCALED(static_cast<CNEO_Player*>(player));
-		// We may be leaning sideways, in which case we need to block the lean camera from clipping walls etc.
-		if (player->GetViewOffset().y > 0)
-		{
-			maxs.y += player->GetViewOffset().y;
-		}
-		return maxs;
+		return player->m_Local.m_bDucked ? VEC_DUCK_HULL_MAX_SCALED(static_cast<CNEO_Player*>(player)) : VEC_HULL_MAX_SCALED(static_cast<CNEO_Player*>(player));
 #else
 		return player->m_Local.m_bDucked ? VEC_DUCK_HULL_MAX_SCALED(player) : VEC_HULL_MAX_SCALED(player);
 #endif


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
Video of original problem

Uploading Recording 2024-07-06 165938.mp4…

Since player collision hull does not rotate with the entity, changing the hull min and max y offset when leaning does not have the intended effect here. Instead causes players to get stuck when beginning a lean on a staircase in certain directions

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
I think #152 was opened as a result of this problem, don't see any camera jitter when walking up stairs now
- fixes #152

