### PR TITLE
Scoreboard spectator section fixes

### DIFF
--- a/mp/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/mp/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -591,11 +591,11 @@ void CNEOScoreBoard::AddSection(int teamType, int teamNumber)
 	{
 		pPlayerList->AddSection(sectionID, "");
 
-		pPlayerList->AddColumnToSection(sectionID, "ping", "", SectionedListPanel::COLUMN_BRIGHT, m_iPingWidth );
+		pPlayerList->AddColumnToSection(sectionID, "ping", teamNumber == TEAM_UNASSIGNED ? "Unassigned" : "Spectators", SectionedListPanel::COLUMN_BRIGHT, m_iPingWidth );
 		// Avatars are always displayed at 32x32 regardless of resolution
 		if ( ShowAvatars() )
 		{
-			pPlayerList->AddColumnToSection( sectionID, "avatar", teamNumber == TEAM_UNASSIGNED ? "Unassigned" : "Spectators", SectionedListPanel::COLUMN_IMAGE, m_iAvatarWidth );
+			pPlayerList->AddColumnToSection( sectionID, "avatar", "", SectionedListPanel::COLUMN_IMAGE, m_iAvatarWidth );
 		}
 		pPlayerList->AddColumnToSection(sectionID, "name", "", 0, ShowAvatars() ? m_iNameWidth - m_iAvatarWidth : m_iNameWidth );
 	}
@@ -666,7 +666,8 @@ void CNEOScoreBoard::GetPlayerScoreInfo(int playerIndex, KeyValues *kv)
 
 	if ( g_PR->IsFakePlayer( playerIndex ) )
 	{
-		kv->SetString("ping", "BOT");
+		// Assume bots in spec are SourceTV etc. Looks cleaner if their ping is just empty string.
+		kv->SetString("ping", g_PR->GetTeam(playerIndex) <= TEAM_SPECTATOR ? "" : "BOT");
 	}
 	else
 	{


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
Fixes some minor scoreboard issues.
The "Spectator" title was left in the wrong column after making avatars optional. It's now moved to the far left.
I thought it was annoying to see "BOT" for the SourceTV/autorecorder thing so in spectators we show empty string instead.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #446

