### PR TITLE
Cleaner scope

### DIFF
--- a/mp/src/game/client/hud_crosshair.cpp
+++ b/mp/src/game/client/hud_crosshair.cpp
@@ -357,7 +357,7 @@ void CHudCrosshair::Paint( void )
 		// Stretching the scope wouldn't be a great workaround, because it ties the scope
 		// FOV to screen resolution, which can give an unfair advantage on widescreen
 		// or multi-monitor setups.
-		const Color blockColor = Color(10, 10, 10, 255);
+		const Color blockColor = Color(16, 17, 16, 255);
 
 		// Draw black box on left side of the scope.
 		DrawBox(0, 0, iX - (iWidth / 2), screenHeight, blockColor, 1.0f);


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Cleaner scope. Every pixel that had any transparency has been left untouched, a black ring placed around the center and a surface blur used to bleed into the surrounding colour used to block  parts of the screen not covered by the texture.

This PR only had the changes to the outer block colour to match the outer colour of the scope in https://github.com/NeotokyoRebuild/neoAssets/pull/2

If you approve please also approve https://github.com/NeotokyoRebuild/neoAssets/pull/2