### PR TITLE
Allow ADS while changing weapons + static_cast GetActiveWeapon

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -698,8 +698,7 @@ void C_NEO_Player::ItemPreFrame( void )
 
 	if (m_afButtonPressed & IN_DROP)
 	{
-		auto neoWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
-		if (neoWep)
+		if (auto neoWep = static_cast<CNEOBaseCombatWeapon *>(GetActiveWeapon()))
 		{
 			Weapon_Drop(neoWep);
 		}
@@ -776,8 +775,7 @@ void C_NEO_Player::PreThink( void )
 	{
 		speed /= 1.666;
 	}
-	auto pNeoWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
-	if (pNeoWep)
+	if (auto pNeoWep = static_cast<CNEOBaseCombatWeapon *>(GetActiveWeapon()))
 	{
 		speed *= pNeoWep->GetSpeedScale();
 	}
@@ -1049,10 +1047,10 @@ void C_NEO_Player::PostThink(void)
 
 	CheckLeanButtons();
 
-	if (C_BaseCombatWeapon *pWep = GetActiveWeapon())
+	if (auto *pNeoWep = static_cast<C_NEOBaseCombatWeapon *>(GetActiveWeapon()))
 	{
 		const bool clientAimHold = ClientWantsAimHold(this);
-		if (pWep->m_bInReload && !m_bPreviouslyReloading)
+		if (pNeoWep->m_bInReload && !m_bPreviouslyReloading)
 		{
 			Weapon_SetZoom(false);
 		}
@@ -1063,19 +1061,18 @@ void C_NEO_Player::PostThink(void)
 		else if ((m_afButtonPressed & IN_AIM) && (!CanSprint() || !(m_nButtons & IN_SPEED)))
 		{
 			// Binds hack: we want grenade secondary attack to trigger on aim (mouse button 2)
-			if (auto *pNeoWep = dynamic_cast<C_NEOBaseCombatWeapon *>(pWep);
-					pNeoWep && pNeoWep->GetNeoWepBits() & NEO_WEP_THROWABLE)
+			if (pNeoWep->GetNeoWepBits() & NEO_WEP_THROWABLE)
 			{
 				pNeoWep->SecondaryAttack();
 			}
 			else
 			{
-				Weapon_AimToggle(pWep, clientAimHold ? NEO_TOGGLE_FORCE_AIM : NEO_TOGGLE_DEFAULT);
+				Weapon_AimToggle(pNeoWep, clientAimHold ? NEO_TOGGLE_FORCE_AIM : NEO_TOGGLE_DEFAULT);
 			}
 		}
 		else if (clientAimHold && (m_afButtonReleased & IN_AIM))
 		{
-			Weapon_AimToggle(pWep, NEO_TOGGLE_FORCE_UN_AIM);
+			Weapon_AimToggle(pNeoWep, NEO_TOGGLE_FORCE_UN_AIM);
 		}
 
 #if !defined( NO_ENTITY_PREDICTION )
@@ -1086,7 +1083,7 @@ void C_NEO_Player::PostThink(void)
 #else
 		if (true) {
 #endif
-			m_bPreviouslyReloading = pWep->m_bInReload;
+			m_bPreviouslyReloading = pNeoWep->m_bInReload;
 		}
 	}
 
@@ -1489,25 +1486,16 @@ bool C_NEO_Player::HandleDeathSpecCamSwitch(Vector& eyeOrigin, QAngle& eyeAngles
 
 float C_NEO_Player::GetActiveWeaponSpeedScale() const
 {
-	// NEO TODO (Rain): change to static cast once all weapons are guaranteed to derive from the class
-	auto pWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
+	auto pWep = static_cast<C_NEOBaseCombatWeapon *>(GetActiveWeapon());
 	return (pWep ? pWep->GetSpeedScale() : 1.0f);
 }
 
-void C_NEO_Player::Weapon_AimToggle(C_BaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType)
+void C_NEO_Player::Weapon_AimToggle(C_NEOBaseCombatWeapon *pNeoWep, const NeoWeponAimToggleE toggleType)
 {
-	// NEO TODO/HACK: Not all neo weapons currently inherit
-	// through a base neo class, so we can't static_cast!!
-	auto neoCombatWep = dynamic_cast<C_NEOBaseCombatWeapon*>(pWep);
-	if (!neoCombatWep)
-	{
-		return;
-	}
-
 	// This implies the wep ptr is valid, so we don't bother checking
-	if (IsAllowedToZoom(neoCombatWep))
+	if (IsAllowedToZoom(pNeoWep))
 	{
-		if (toggleType != NEO_TOGGLE_FORCE_UN_AIM && neoCombatWep->IsReadyToAimIn())
+		if (toggleType != NEO_TOGGLE_FORCE_UN_AIM)
 		{
 			const bool showCrosshair = (m_Local.m_iHideHUD & HIDEHUD_CROSSHAIR) == HIDEHUD_CROSSHAIR;
 			Weapon_SetZoom(showCrosshair);

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -151,7 +151,7 @@ public:
 
 	void DrawCompass(void);
 
-	void Weapon_AimToggle(C_BaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType);
+	void Weapon_AimToggle(C_NEOBaseCombatWeapon *pNeoWep, const NeoWeponAimToggleE toggleType);
 	void Weapon_SetZoom(const bool bZoomIn);
 
 	void Weapon_Drop(C_NEOBaseCombatWeapon *pWeapon);

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -660,8 +660,7 @@ void CNEO_Player::PreThink(void)
 	{
 		speed /= 1.666;
 	}
-	auto pNeoWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
-	if (pNeoWep)
+	if (auto pNeoWep = static_cast<CNEOBaseCombatWeapon *>(GetActiveWeapon()))
 	{
 		speed *= pNeoWep->GetSpeedScale();
 	}
@@ -1062,10 +1061,10 @@ void CNEO_Player::PostThink(void)
 
 	CheckLeanButtons();
 
-	if (CBaseCombatWeapon *pWep = GetActiveWeapon())
+	if (auto *pNeoWep = static_cast<CNEOBaseCombatWeapon *>(GetActiveWeapon()))
 	{
 		const bool clientAimHold = ClientWantsAimHold(this);
-		if (pWep->m_bInReload && !m_bPreviouslyReloading)
+		if (pNeoWep->m_bInReload && !m_bPreviouslyReloading)
 		{
 			Weapon_SetZoom(false);
 		}
@@ -1076,21 +1075,20 @@ void CNEO_Player::PostThink(void)
 		else if ((m_afButtonPressed & IN_AIM) && (!CanSprint() || !(m_nButtons & IN_SPEED)))
 		{
 			// Binds hack: we want grenade secondary attack to trigger on aim (mouse button 2)
-			if (auto *pNeoWep = dynamic_cast<CNEOBaseCombatWeapon *>(pWep);
-					pNeoWep && pNeoWep->GetNeoWepBits() & NEO_WEP_THROWABLE)
+			if (pNeoWep->GetNeoWepBits() & NEO_WEP_THROWABLE)
 			{
 				pNeoWep->SecondaryAttack();
 			}
 			else
 			{
-				Weapon_AimToggle(pWep, clientAimHold ? NEO_TOGGLE_FORCE_AIM : NEO_TOGGLE_DEFAULT);
+				Weapon_AimToggle(pNeoWep, clientAimHold ? NEO_TOGGLE_FORCE_AIM : NEO_TOGGLE_DEFAULT);
 			}
 		}
 		else if (clientAimHold && (m_afButtonReleased & IN_AIM))
 		{
-			Weapon_AimToggle(pWep, NEO_TOGGLE_FORCE_UN_AIM);
+			Weapon_AimToggle(pNeoWep, NEO_TOGGLE_FORCE_UN_AIM);
 		}
-		m_bPreviouslyReloading = pWep->m_bInReload;
+		m_bPreviouslyReloading = pNeoWep->m_bInReload;
 
 		if (m_afButtonPressed & IN_DROP)
 		{
@@ -1098,7 +1096,7 @@ void CNEO_Player::PostThink(void)
 			EyeVectors(&eyeForward);
 			const float forwardOffset = 250.0f;
 			eyeForward *= forwardOffset;
-			Weapon_Drop(pWep, NULL, &eyeForward);
+			Weapon_Drop(pNeoWep, NULL, &eyeForward);
 		}
 	}
 
@@ -1136,16 +1134,11 @@ void CNEO_Player::PlayerDeathThink()
 	BaseClass::PlayerDeathThink();
 }
 
-void CNEO_Player::Weapon_AimToggle(CNEOBaseCombatWeapon* pNeoWep, const NeoWeponAimToggleE toggleType)
+void CNEO_Player::Weapon_AimToggle(CNEOBaseCombatWeapon *pNeoWep, const NeoWeponAimToggleE toggleType)
 {
-	if (!pNeoWep)
-	{
-		return;
-	}
-
 	if (IsAllowedToZoom(pNeoWep))
 	{
-		if (toggleType != NEO_TOGGLE_FORCE_UN_AIM && pNeoWep->IsReadyToAimIn())
+		if (toggleType != NEO_TOGGLE_FORCE_UN_AIM)
 		{
 			const bool showCrosshair = (m_Local.m_iHideHUD & HIDEHUD_CROSSHAIR) == HIDEHUD_CROSSHAIR;
 			Weapon_SetZoom(showCrosshair);
@@ -1155,13 +1148,6 @@ void CNEO_Player::Weapon_AimToggle(CNEOBaseCombatWeapon* pNeoWep, const NeoWepon
 			Weapon_SetZoom(false);
 		}
 	}
-}
-
-void CNEO_Player::Weapon_AimToggle(CBaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType)
-{
-	// NEO TODO/HACK: Not all neo weapons currently inherit
-	// through a base neo class, so we can't static_cast!!
-	Weapon_AimToggle(dynamic_cast<CNEOBaseCombatWeapon*>(pWep), toggleType);
 }
 
 void CNEO_Player::SetNameDupePos(const int dupePos)
@@ -2923,8 +2909,7 @@ int CNEO_Player::ShouldTransmit(const CCheckTransmitInfo* pInfo)
 
 float CNEO_Player::GetActiveWeaponSpeedScale() const
 {
-	// NEO TODO (Rain): change to static cast once all weapons are guaranteed to derive from the class
-	auto pWep = dynamic_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
+	auto pWep = static_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
 	return (pWep ? pWep->GetSpeedScale() : 1.0f);
 }
 

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -116,8 +116,7 @@ public:
 
 	void UpdateNetworkedFriendlyLocations(void);
 
-	void Weapon_AimToggle(CBaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType);
-	void Weapon_AimToggle(CNEOBaseCombatWeapon* pWep, const NeoWeponAimToggleE toggleType);
+	void Weapon_AimToggle(CNEOBaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType);
 
 	// "neo_name" if available otherwise "name"
 	// Set "viewFrom" if fetching the name in the view of another player

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -98,7 +98,6 @@ const char *GetWeaponByLoadoutId(int id)
 
 CNEOBaseCombatWeapon::CNEOBaseCombatWeapon( void )
 {
-	m_bReadyToAimIn = false;
 }
 
 void CNEOBaseCombatWeapon::Precache()
@@ -247,8 +246,6 @@ bool CNEOBaseCombatWeapon::Deploy(void)
 	{
 		AddEffects(EF_BONEMERGE);
 
-		m_bReadyToAimIn = false;
-
 #ifdef DEBUG
 		CNEO_Player* pOwner = NULL;
 		if (GetOwner())
@@ -325,17 +322,6 @@ void CNEOBaseCombatWeapon::CheckReload(void)
 	}
 
 	BaseClass::CheckReload();
-}
-
-void CNEOBaseCombatWeapon::ItemPreFrame(void)
-{
-	if (!m_bReadyToAimIn)
-	{
-		if (gpGlobals->curtime >= m_flNextPrimaryAttack)
-		{
-			m_bReadyToAimIn = true;
-		}
-	}
 }
 
 // Handles lowering the weapon view model when character is sprinting

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -146,7 +146,6 @@ public:
 
 	virtual float GetSpeedScale(void) const { Assert(false); return 1.0; } // Should never call this base class; implement in children.
 
-	virtual void ItemPreFrame(void);
 	virtual void ItemPostFrame(void);
 
 	virtual void PrimaryAttack(void);
@@ -158,9 +157,6 @@ public:
 	virtual float GetInnateInaccuracy(void) const { return 0.0f; } // NEO TODO (Rain): make this abstract & implement some amount of inaccuracy (spread) for weapons?
 
 	bool IsGhost(void) const { return (GetNeoWepBits() & NEO_WEP_GHOST) ? true : false; }
-
-	// We do this check to avoid a player unintentionally aiming in due to holding down their aim key while an automatic wep switch occurs.
-	bool IsReadyToAimIn(void) const { return m_bReadyToAimIn; }
 
 	bool IsExplosive(void) const { return (GetNeoWepBits() & NEO_WEP_EXPLOSIVE) ? true : false; }
 
@@ -235,9 +231,6 @@ protected:
 	CNetworkVar(int, m_nNumShotsFired);
 	CNetworkVar(bool, m_bRoundChambered);
 	CNetworkVar(bool, m_bRoundBeingChambered);
-
-private:
-	bool m_bReadyToAimIn;
 
 private:
 	CNEOBaseCombatWeapon(const CNEOBaseCombatWeapon &other);


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Removed the restriction on preventing ADS while weapon changing
* There doesn't seem to be an auto switch or it causing issues requiring the restriction
* static_cast the usage of GetActiveWeapon since it's all NT weapons now

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #356

