### PR TITLE
Client vs server build integrity check + server startup print neo_version info

### DIFF
--- a/mp/src/game/client/cdll_client_int.cpp
+++ b/mp/src/game/client/cdll_client_int.cpp
@@ -171,6 +171,7 @@ extern vgui::IInputInternal *g_InputInternal;
 #endif
 
 #ifdef NEO
+#include "neo_version.h"
 #include "neo_mount_original.h"
 #endif
 
@@ -952,6 +953,10 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 	if ( InitDataModel() != INIT_OK )
 		return false;
 	InitFbx();
+#endif
+
+#if defined(NEO) && defined(DEBUG)
+	InitializeDbgNeoClGitHashEdit();
 #endif
 
 	// it's ok if this is NULL. That just means the sourcevr.dll wasn't found

--- a/mp/src/game/server/gameinterface.cpp
+++ b/mp/src/game/server/gameinterface.cpp
@@ -132,6 +132,7 @@ extern ConVar tf_mm_servermode;
 
 #ifdef NEO
 #include "neo_mount_original.h"
+#include "neo_version.h"
 #endif
 
 extern IToolFrameworkServer *g_pToolFrameworkServer;
@@ -643,6 +644,7 @@ bool CServerGameDLL::DLLInit( CreateInterfaceFn appSystemFactory,
 	{
 		return false;
 	}
+	NeoVersionPrint();
 #endif
 
 	// Yes, both the client and game .dlls will try to Connect, the soundemittersystem.dll will handle this gracefully

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -1,5 +1,6 @@
 #include "cbase.h"
 #include "neo_gamerules.h"
+#include "neo_version_info.h"
 #include "in_buttons.h"
 #include "ammodef.h"
 
@@ -35,6 +36,23 @@ ConVar neo_sv_player_restore("neo_sv_player_restore", "1", FCVAR_REPLICATED, "If
 
 ConVar neo_name("neo_name", "", FCVAR_USERINFO | FCVAR_ARCHIVE, "The nickname to set instead of the steam profile name.");
 ConVar cl_onlysteamnick("cl_onlysteamnick", "0", FCVAR_USERINFO | FCVAR_ARCHIVE, "Only show players Steam names, otherwise show player set names.", true, 0.0f, true, 1.0f);
+
+#ifdef GAME_DLL
+#ifdef DEBUG
+// Debug build by default relax integrity check requirement among debug clients
+static constexpr char INTEGRITY_CHECK_DBG[] = "1";
+#else
+static constexpr char INTEGRITY_CHECK_DBG[] = "0";
+#endif
+ConVar neo_sv_build_integrity_check("neo_sv_build_integrity_check", "1", FCVAR_GAMEDLL | FCVAR_REPLICATED,
+									"If enabled, the server checks the build's Git hash between the client and"
+									" the server. If it doesn't match, the server rejects and disconnects the client.",
+									true, 0.0f, true, 1.0f);
+ConVar neo_sv_build_integrity_check_allow_debug("neo_sv_build_integrity_check_allow_debug", INTEGRITY_CHECK_DBG, FCVAR_GAMEDLL | FCVAR_REPLICATED,
+									"If enabled, when the server checks the client hashes, it'll also allow debug"
+									" builds which has a given special bit to bypass the check.",
+									true, 0.0f, true, 1.0f);
+#endif
 
 REGISTER_GAMERULES_CLASS( CNEORules );
 
@@ -1292,6 +1310,28 @@ void CNEORules::RestartGame()
 #ifdef GAME_DLL
 bool CNEORules::ClientConnected(edict_t *pEntity, const char *pszName, const char *pszAddress, char *reject, int maxrejectlen)
 {
+	if (neo_sv_build_integrity_check.GetBool())
+	{
+		const char *clientGitHash = engine->GetClientConVarValue(engine->IndexOfEdict(pEntity), "__neo_cl_git_hash");
+		const bool dbgBuildSkip = (neo_sv_build_integrity_check_allow_debug.GetBool()) ? (clientGitHash[0] & 0b1000'0000) : false;
+		if (dbgBuildSkip)
+		{
+			DevWarning("Client debug build integrity check bypass! Client: %s | Server: %s\n", clientGitHash, GIT_LONGHASH);
+		}
+		// NEO NOTE (nullsystem): Due to debug builds, if we're to match exactly, we'll have to mask out final bit first
+		char cmpClientGitHash[sizeof(GIT_LONGHASH) + 1];
+		V_strcpy_safe(cmpClientGitHash, clientGitHash);
+		cmpClientGitHash[0] &= 0b0111'1111;
+		if (!dbgBuildSkip && V_strcmp(cmpClientGitHash, GIT_LONGHASH))
+		{
+			// Truncate the git hash so it's short hash and doesn't make message too long
+			static constexpr int MAX_GITHASH_SHOW = 7;
+			V_snprintf(reject, maxrejectlen, "Build integrity failed! Client vs server mis-match: Check your neo_version. "
+											 "Client: %.*s | Server: %.*s",
+					   MAX_GITHASH_SHOW, cmpClientGitHash, MAX_GITHASH_SHOW, GIT_LONGHASH);
+			return false;
+		}
+	}
 	return BaseClass::ClientConnected(pEntity, pszName, pszAddress,
 		reject, maxrejectlen);
 #if(0)

--- a/mp/src/game/shared/neo/neo_version.h
+++ b/mp/src/game/shared/neo/neo_version.h
@@ -1,0 +1,7 @@
+#pragma once
+
+void NeoVersionPrint();
+
+#if defined(CLIENT_DLL) && defined(DEBUG)
+void InitializeDbgNeoClGitHashEdit();
+#endif


### PR DESCRIPTION

<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Server now just prints neo_version on startup
* Server and client long git hashes are now matched up on startup to check build integrity. If they don't, the client cannot connect unless they have matching git hashes.
* Server convar `neo_sv_build_integrity_check` to enable/disable this integrity check feature. Enabled by default.
* Server convar `neo_sv_build_integrity_check_allow_debug` to enable/disable integrity checking for debug clients. Disabled by default for release builds, enabled by default for debug builds.
    * A warning message will indicate if a client bypassed the checking
    * Debug bypass is determined by the first byte's final bit of (8-bits) char. 1 = debug build, 0 = release build.
    * String matching will first mask out that char so even if `neo_sv_build_integrity_check_allow_debug` is disabled, a matching git hash between debug client and server can still be matched.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #437
* fixes #485

## Examples
Client-side example of integrity check fail setting bogus "foobar" to trigger it:
![clientintegrityfailexample](https://github.com/NeotokyoRebuild/neo/assets/15316579/a89abb63-b7be-4df2-95a1-41d59091b5f6)

Server side will log this line:
```
Dropped PLAYER from server (Build integrity failed! Client vs server mis-match: Check your neo_version. Client: foobar | Server: e266b6d)
```
