### PR TITLE
Int+acc attacker dmg tracking, spawn reset accumlator, fix menu timeout

### DIFF
--- a/mp/src/game/client/menu.cpp
+++ b/mp/src/game/client/menu.cpp
@@ -111,6 +111,7 @@ void CHudMenu::VidInit( void )
 //-----------------------------------------------------------------------------
 void CHudMenu::OnThink()
 {
+#ifndef NEO // NEO NOTE (nullsystem): Disable global set timeout which restricted it to 5s max
 	float flSelectionTimeout = MENU_SELECTION_TIMEOUT;
 
 	// If we've been open for a while without input, hide
@@ -118,6 +119,7 @@ void CHudMenu::OnThink()
 	{
 		m_bMenuDisplayed = false;
 	}
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -84,7 +84,8 @@ IMPLEMENT_CLIENTCLASS_DT(C_NEO_Player, DT_NEO_Player, CNEO_Player)
 	RecvPropInt(RECVINFO(m_nVisionLastTick)),
 
 	RecvPropArray(RecvPropVector(RECVINFO(m_rvFriendlyPlayerPositions[0])), m_rvFriendlyPlayerPositions),
-	RecvPropArray(RecvPropFloat(RECVINFO(m_rfAttackersScores[0])), m_rfAttackersScores),
+	RecvPropArray(RecvPropInt(RECVINFO(m_rfAttackersScores[0])), m_rfAttackersScores),
+	RecvPropArray(RecvPropFloat(RECVINFO(m_rfAttackersAccumlator[0])), m_rfAttackersAccumlator),
 	RecvPropArray(RecvPropInt(RECVINFO(m_rfAttackersHits[0])), m_rfAttackersHits),
 
 	RecvPropInt(RECVINFO(m_NeoFlags)),
@@ -97,7 +98,8 @@ END_RECV_TABLE()
 
 BEGIN_PREDICTION_DATA(C_NEO_Player)
 	DEFINE_PRED_FIELD(m_rvFriendlyPlayerPositions, FIELD_VECTOR, FTYPEDESC_INSENDTABLE),
-	DEFINE_PRED_ARRAY(m_rfAttackersScores, FIELD_FLOAT, MAX_PLAYERS + 1, FTYPEDESC_INSENDTABLE),
+	DEFINE_PRED_ARRAY(m_rfAttackersScores, FIELD_INTEGER, MAX_PLAYERS + 1, FTYPEDESC_INSENDTABLE),
+	DEFINE_PRED_ARRAY(m_rfAttackersAccumlator, FIELD_FLOAT, MAX_PLAYERS + 1, FTYPEDESC_INSENDTABLE),
 	DEFINE_PRED_ARRAY(m_rfAttackersHits, FIELD_INTEGER, MAX_PLAYERS + 1, FTYPEDESC_INSENDTABLE),
 	DEFINE_PRED_FIELD(m_vecGhostMarkerPos, FIELD_VECTOR, FTYPEDESC_INSENDTABLE),
 
@@ -125,11 +127,7 @@ static void __MsgFunc_DamageInfo(bf_read& msg)
 
 	// Print damage stats into the console
 	// Print to console
-	AttackersTotals totals;
-	totals.dealtTotalDmgs = 0.0f;
-	totals.dealtTotalHits = 0;
-	totals.takenTotalDmgs = 0.0f;
-	totals.takenTotalHits = 0;
+	AttackersTotals totals = {};
 
 	const int thisIdx = localPlayer->entindex();
 
@@ -169,29 +167,27 @@ static void __MsgFunc_DamageInfo(bf_read& msg)
 			continue;
 		}
 
-		const float dmgTo = min(neoAttacker->GetAttackersScores(thisIdx), 100.0f);
-		const float dmgFrom = min(localPlayer->GetAttackersScores(pIdx), 100.0f);
-		if (dmgTo > 0.0f || dmgFrom > 0.0f)
+		const AttackersTotals attackerInfo = {
+			.dealtDmgs = neoAttacker->GetAttackersScores(thisIdx),
+			.dealtHits = neoAttacker->GetAttackerHits(thisIdx),
+			.takenDmgs = localPlayer->GetAttackersScores(pIdx),
+			.takenHits = localPlayer->GetAttackerHits(pIdx),
+		};
+		if (attackerInfo.dealtDmgs > 0 || attackerInfo.takenDmgs > 0)
 		{
-			const int hitsTo = neoAttacker->GetAttackerHits(thisIdx);
-			const int hitsFrom = localPlayer->GetAttackerHits(pIdx);
 			const char *dmgerClass = GetNeoClassName(neoAttacker->GetClass());
 
 			static char infoLine[128];
-			DmgLineStr(infoLine, sizeof(infoLine), dmgerName, dmgerClass,
-				dmgTo, dmgFrom, hitsTo, hitsFrom);
+			DmgLineStr(infoLine, sizeof(infoLine), dmgerName, dmgerClass, attackerInfo);
 			ConMsg("%s", infoLine);
 
-			totals.dealtTotalDmgs += dmgTo;
-			totals.takenTotalDmgs += dmgFrom;
-			totals.dealtTotalHits += hitsTo;
-			totals.takenTotalHits += hitsFrom;
+			totals += attackerInfo;
 		}
 	}
 
-	ConMsg("\nTOTAL: Dealt: %.0f in %d hits | Taken: %.0f in %d hits\n%s\n",
-		totals.dealtTotalDmgs, totals.dealtTotalHits,
-		totals.takenTotalDmgs, totals.takenTotalHits,
+	ConMsg("\nTOTAL: Dealt: %d in %d hits | Taken: %d in %d hits\n%s\n",
+		totals.dealtDmgs, totals.dealtHits,
+		totals.takenDmgs, totals.takenHits,
 		BORDER);
 }
 USER_MESSAGE_REGISTER(DamageInfo);
@@ -539,9 +535,9 @@ void C_NEO_Player::ZeroFriendlyPlayerLocArray()
 	}
 }
 
-float C_NEO_Player::GetAttackersScores(const int attackerIdx) const
+int C_NEO_Player::GetAttackersScores(const int attackerIdx) const
 {
-	return m_rfAttackersScores.Get(attackerIdx);
+	return min(m_rfAttackersScores.Get(attackerIdx), 100);
 }
 
 const char *C_NEO_Player::GetNeoPlayerName() const
@@ -1213,7 +1209,11 @@ void C_NEO_Player::Spawn( void )
 
 	for (int i = 0; i < m_rfAttackersScores.Count(); ++i)
 	{
-		m_rfAttackersScores.Set(i, 0.0f);
+		m_rfAttackersScores.Set(i, 0);
+	}
+	for (int i = 0; i < m_rfAttackersAccumlator.Count(); ++i)
+	{
+		m_rfAttackersAccumlator.Set(i, 0.0f);
 	}
 	for (int i = 0; i < m_rfAttackersHits.Count(); ++i)
 	{

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -165,7 +165,7 @@ public:
 	bool IsInVision() const { return m_bInVision; }
 	bool IsInAim() const { return m_bInAim; }
 
-	float GetAttackersScores(const int attackerIdx) const;
+	int GetAttackersScores(const int attackerIdx) const;
 	int GetAttackerHits(const int attackerIdx) const;
 
 	const char *GetNeoPlayerName() const;
@@ -192,7 +192,8 @@ public:
 	CNetworkVar(int, m_iNextSpawnClassChoice);
 
 	CNetworkArray(Vector, m_rvFriendlyPlayerPositions, MAX_PLAYERS);
-	CNetworkArray(float, m_rfAttackersScores, (MAX_PLAYERS + 1));
+	CNetworkArray(int, m_rfAttackersScores, (MAX_PLAYERS + 1));
+	CNetworkArray(float, m_rfAttackersAccumlator, (MAX_PLAYERS + 1));
 	CNetworkArray(int, m_rfAttackersHits, (MAX_PLAYERS + 1));
 
 	bool m_bShowClassMenu, m_bShowTeamMenu;

--- a/mp/src/game/server/basecombatcharacter.cpp
+++ b/mp/src/game/server/basecombatcharacter.cpp
@@ -771,6 +771,11 @@ void CBaseCombatCharacter::Spawn( void )
 	m_aliveTimer.Start();
 	m_hasBeenInjured = 0;
 
+#ifdef NEO
+	// NEO FIX: Accumulator wasn't zeroed on spawning
+	m_flDamageAccumulator = 0.0f;
+#endif
+
 	for( int t=0; t<MAX_DAMAGE_TEAMS; ++t )
 	{
 		m_damageHistory[t].team = TEAM_INVALID;

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -179,7 +179,7 @@ public:
 	
 	int ShouldTransmit( const CCheckTransmitInfo *pInfo) OVERRIDE;
 
-	float GetAttackersScores(const int attackerIdx) const;
+	int GetAttackersScores(const int attackerIdx) const;
 	int GetAttackerHits(const int attackerIdx) const;
 
 	void SetNameDupePos(const int dupePos);
@@ -237,7 +237,8 @@ public:
 	CNetworkVar(int, m_nVisionLastTick);
 
 	CNetworkArray(Vector, m_rvFriendlyPlayerPositions, MAX_PLAYERS);
-	CNetworkArray(float, m_rfAttackersScores, (MAX_PLAYERS + 1));
+	CNetworkArray(int, m_rfAttackersScores, (MAX_PLAYERS + 1));
+	CNetworkArray(float, m_rfAttackersAccumlator, (MAX_PLAYERS + 1));
 	CNetworkArray(int, m_rfAttackersHits, (MAX_PLAYERS + 1));
 
 	CNetworkVar(unsigned char, m_NeoFlags);

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -1686,8 +1686,8 @@ static CNEO_Player* FetchAssists(CNEO_Player* attacker, CNEO_Player* victim)
 			continue;
 		}
 
-		const float assistDmg = victim->GetAttackersScores(assistIdx);
-		static const float MIN_DMG_QUALIFY_ASSIST = 50.0f;
+		const int assistDmg = victim->GetAttackersScores(assistIdx);
+		static const int MIN_DMG_QUALIFY_ASSIST = 50;
 		if (assistDmg >= MIN_DMG_QUALIFY_ASSIST)
 		{
 			return static_cast<CNEO_Player*>(UTIL_PlayerByIndex(assistIdx));

--- a/mp/src/game/shared/neo/neo_player_shared.cpp
+++ b/mp/src/game/shared/neo/neo_player_shared.cpp
@@ -117,24 +117,26 @@ bool ClientWantsAimHold(const CNEO_Player* player)
 
 int DmgLineStr(char* infoLine, const int infoLineMax,
 	const char* dmgerName, const char* dmgerClass,
-	const float dmgTo, const float dmgFrom, const int hitsTo, const int hitsFrom)
+	const AttackersTotals &totals)
 {
 	memset(infoLine, 0, infoLineMax);
-	if (dmgTo > 0.0f && dmgFrom > 0.0f)
+	if (totals.dealtDmgs > 0 && totals.takenDmgs > 0)
 	{
-		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Dealt: %.0f in %d hits | Taken: %.0f in %d hits\n",
-			dmgerName, dmgerClass,
-			dmgTo, hitsTo, dmgFrom, hitsFrom);
+		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Dealt: %d in %d hits | Taken: %d in %d hits\n",
+				   dmgerName, dmgerClass,
+				   totals.dealtDmgs, totals.dealtHits, totals.takenDmgs, totals.takenHits);
 	}
-	else if (dmgTo > 0.0f)
+	else if (totals.dealtDmgs > 0)
 	{
-		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Dealt: %.0f in %d hits\n",
-			dmgerName, dmgerClass, dmgTo, hitsTo);
+		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Dealt: %d in %d hits\n",
+				   dmgerName, dmgerClass,
+				   totals.dealtDmgs, totals.dealtHits);
 	}
-	else if (dmgFrom > 0.0f)
+	else if (totals.takenDmgs > 0)
 	{
-		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Taken: %.0f in %d hits\n",
-			dmgerName, dmgerClass, dmgFrom, hitsFrom);
+		Q_snprintf(infoLine, infoLineMax, "%s [%s]: Taken: %d in %d hits\n",
+				   dmgerName, dmgerClass,
+				   totals.takenDmgs, totals.takenHits);
 	}
 	return Q_strlen(infoLine);
 }

--- a/mp/src/game/shared/neo/neo_player_shared.h
+++ b/mp/src/game/shared/neo/neo_player_shared.h
@@ -286,20 +286,28 @@ enum NeoWeponAimToggleE {
 
 bool ClientWantsAimHold(const CNEO_Player* player);
 
+struct AttackersTotals
+{
+	int dealtDmgs;
+	int dealtHits;
+	int takenDmgs;
+	int takenHits;
+
+	void operator+=(const AttackersTotals &other)
+	{
+		dealtDmgs += other.dealtDmgs;
+		dealtHits += other.dealtHits;
+		takenDmgs += other.takenDmgs;
+		takenHits += other.takenHits;
+	}
+};
+
 int DmgLineStr(char* infoLine, const int infoLineMax,
 	const char* dmgerName, const char* dmgerClass,
-	const float dmgTo, const float dmgFrom, const int hitsTo, const int hitsFrom);
+	const AttackersTotals &totals);
 
 void KillerLineStr(char* killByLine, const int killByLineMax,
 	CNEO_Player* neoAttacker, const CNEO_Player* neoVictim);
-
-struct AttackersTotals
-{
-	float dealtTotalDmgs;
-	int dealtTotalHits;
-	float takenTotalDmgs;
-	int takenTotalHits;
-};
 
 [[nodiscard]] auto StrToInt(std::string_view strView) -> std::optional<int>;
 [[nodiscard]] int NeoAimFOV(const int fovDef, CBaseCombatWeapon *wep);


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Instead of single float health variable, it's now accumlated quite like how `CBaseCombatCharacter::OnTakeDamage_Alive` does it
* Minor refactor to utilize the AttackersTotals struct more
* Fix accumlator not being reset in spawn
* Fix menu timeout being restricted to 5s max, just removed the usage of the global timeout
* Attacker info menu timeout increased to 60s

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #309

