### PR TITLE
Add missing arg in cmake debugging guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ In the CMake Target View, right-click "client (shared library)" and click on "Ad
         "-insecure",
         "-dev",
         "-sw",
+        "-neopath",
+        "C:\\PATH\\TO\\NEOTOKYOSOURCE"
         "-game",
         "C:\\PATH\\TO\\REPO_ROOT\\neo\\mp\\game\\neo"
       ]


### PR DESCRIPTION
## Description
Update `CONTRIBUTING.md` CMake debug guide to include necessary flag for game to boot. (It does warn the developer on first attempt, but to save time it should be included in the documentation.)

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

