### PR TITLE
Spectator - Use aim, not attack2 for next, add specnext/prevplayer

### DIFF
--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -736,12 +736,22 @@ int ClientModeShared::HandleSpectatorKeyInput( int down, ButtonCode_t keynum, co
 #endif
 		return 0; // we handled it, don't handle twice or send to server
 	}
+#ifdef NEO
+	else if (down && pszCurrentBinding &&
+			 (Q_strcmp(pszCurrentBinding, "+specnextplayer") == 0 || Q_strcmp(pszCurrentBinding, "+attack") == 0))
+#else
 	else if ( down && pszCurrentBinding && Q_strcmp( pszCurrentBinding, "+attack" ) == 0 )
+#endif
 	{
 		engine->ClientCmd( "spec_next" );
 		return 0;
 	}
+#ifdef NEO
+	else if (down && pszCurrentBinding &&
+			 (Q_strcmp(pszCurrentBinding, "+specprevplayer") == 0 || Q_strcmp(pszCurrentBinding, "+aim") == 0))
+#else
 	else if ( down && pszCurrentBinding && Q_strcmp( pszCurrentBinding, "+attack2" ) == 0 )
+#endif
 	{
 		engine->ClientCmd( "spec_prev" );
 		return 0;

--- a/mp/src/game/client/in_main.cpp
+++ b/mp/src/game/client/in_main.cpp
@@ -152,6 +152,8 @@ static	kbutton_t	in_lean_left;
 static	kbutton_t	in_lean_right;
 static	kbutton_t	in_thermoptic;
 static	kbutton_t	in_vision;
+static	kbutton_t	in_spec_next;
+static	kbutton_t	in_spec_prev;
 #endif
 
 /*
@@ -518,6 +520,12 @@ void IN_ThermOpticDown(const CCommand &args) { KeyDown(&in_thermoptic, args[1]);
 
 void IN_VisionUp(const CCommand &args) { KeyUp(&in_vision, args[1]); }
 void IN_VisionDown(const CCommand &args) { KeyDown(&in_vision, args[1]); }
+
+void IN_SpecNextUp(const CCommand &args) { KeyUp(&in_spec_next, args[1]); }
+void IN_SpecNextDown(const CCommand &args) { KeyDown(&in_spec_next, args[1]); }
+
+void IN_SpecPrevUp(const CCommand &args) { KeyUp(&in_spec_prev, args[1]); }
+void IN_SpecPrevDown(const CCommand &args) { KeyDown(&in_spec_prev, args[1]); }
 
 void IN_LeanLeftToggle(const CCommand& args)
 {
@@ -1725,6 +1733,12 @@ static ConCommand endvision("-vision", IN_VisionUp);
 
 static ConCommand toggle_leanleft("toggle_leanl", IN_LeanLeftToggle);
 static ConCommand toggle_leanright("toggle_leanr", IN_LeanRightToggle);
+
+static ConCommand startspecnextplayer("+specnextplayer", IN_SpecNextDown);
+static ConCommand endspecnextplayer("-specnextplayer", IN_SpecNextUp);
+
+static ConCommand startspecprevplayer("+specprevplayer", IN_SpecPrevDown);
+static ConCommand endspecprevplayer("-specprevplayer", IN_SpecPrevUp);
 #endif
 
 /*


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Default configuration uses aim rather than attack2 for RMB so use that
* Also, add +specnextplayer and +specprevplayer for additional key to use instead of +attack/+aim if player wants to. If +attack/+aim keys are binded to non-mouse keys, +specnext/prevplayer can override that.
* However, these won't be in the settings menu as that configures the keys exclusively. So it'll be up to the player to use the command to keybind instead.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

* fixes #434

