### PR TITLE
Fix dying + disconnect causing Ghost/weps to noclip fall, fix ghost spawn frozen in air

### DIFF
--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1763,9 +1763,7 @@ void CNEO_Player::Event_Killed( const CTakeDamageInfo &info )
 			pVecThrowDir.z = random->RandomFloat(-0.5f, 0.5f);
 			VectorNormalize(pVecThrowDir);
 			Assert(pVecThrowDir.IsValid());
-			pWep->Drop(pVecThrowDir);
-			pWep->SetRemoveable(false);
-			Weapon_Detach(pWep);
+			Weapon_Drop(pWep, NULL, &pVecThrowDir);
 		}
 	}
 

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -822,6 +822,7 @@ static inline void SpawnTheGhost()
 					else
 					{
 						ghost->SetAbsOrigin(ghostSpawn->GetAbsOrigin());
+						ghost->Drop(Vector{0.0f, 0.0f, 0.0f});
 					}
 
 					break;
@@ -1980,10 +1981,16 @@ void CNEORules::ClientDisconnected(edict_t* pClient)
 		auto ghost = GetNeoWepWithBits(pNeoPlayer, NEO_WEP_GHOST);
 		if (ghost)
 		{
-			ghost->Drop(vec3_origin);
-			ghost->SetRemoveable(false);
+			// NEO JANK (nullsystem): Teleport so that disconnected player don't noclips the ghost?
+			Vector stillVec{0.0f, 0.0f, 0.0f};
+			QAngle angles;
+			ghost->Drop(stillVec);
 			pNeoPlayer->Weapon_Detach(ghost);
+			Vector origin = ghost->GetAbsOrigin();
+			ghost->Teleport(&origin, &angles, NULL);
+			ghost->SetMoveType(MOVETYPE_FLYGRAVITY);
 		}
+		pNeoPlayer->RemoveAllWeapons();
 
 		// Save XP/death counts
 		if (neo_sv_player_restore.GetBool())

--- a/mp/src/game/shared/neo/weapons/weapon_ghost.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_ghost.cpp
@@ -169,6 +169,14 @@ void CWeaponGhost::OnPickedUp(CBaseCombatCharacter *pNewOwner)
 	}
 }
 
+void CWeaponGhost::Drop(const Vector &vecVelocity)
+{
+	BaseClass::Drop(vecVelocity);
+#if !defined( CLIENT_DLL )
+	SetRemoveable(false);
+#endif
+}
+
 float CWeaponGhost::DistanceToPos(const Vector& otherPlayerPos)
 {
 	auto owner = GetOwner();

--- a/mp/src/game/shared/neo/weapons/weapon_ghost.h
+++ b/mp/src/game/shared/neo/weapons/weapon_ghost.h
@@ -32,6 +32,7 @@ public:
 	virtual void PrimaryAttack(void) OVERRIDE { }
 	virtual void SecondaryAttack(void) OVERRIDE { }
 
+	virtual void Drop(const Vector &vecVelocity) override;
 	virtual void ItemHolsterFrame(void);
 	virtual void OnPickedUp(CBaseCombatCharacter *pNewOwner);
 	void HandleGhostUnequip(void);


### PR DESCRIPTION

<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* On dying player ghost drop: Just use a "proper" function to drop weapons
* On disconnected/kicked player ghost drop: Use teleport/workaround so it doesn't fall through
* Ghost spawning: Give it gravity so it doesn't just stays there on given spawn origin

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #423
* fixes #433

