### PR TITLE
Center Text - Fix size and alias setting not being applied properly

### DIFF
--- a/mp/src/game/client/vgui_centerstringpanel.cpp
+++ b/mp/src/game/client/vgui_centerstringpanel.cpp
@@ -98,6 +98,13 @@ CCenterStringLabel::CCenterStringLabel( vgui::VPANEL parent ) :
 	m_flCentertimeOff = 0.0;
 
 	vgui::ivgui()->AddTickSignal( GetVPanel(), 100 );
+
+#ifdef NEO
+	// NEO HACK (nullsystem): It's to workaround the font settings not being
+	// applied properly
+	vgui::IScheme *pScheme = vgui::scheme()->GetIScheme(neoscheme);
+	ApplySchemeSettings(pScheme);
+#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Probably to due with how it create/destroy this class
* Basically the font should be large and aliased. Before it was only one or the other.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #505

