### PR TITLE
Ghost - Cap point round end state HUD fix, HUD visibiliy post round

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -66,7 +66,6 @@ IMPLEMENT_CLIENTCLASS_DT(C_NEO_Player, DT_NEO_Player, CNEO_Player)
 	RecvPropString(RECVINFO(m_pszTestMessage)),
 
 	RecvPropInt(RECVINFO(m_iXP)),
-	RecvPropInt(RECVINFO(m_iCapTeam)),
 	RecvPropInt(RECVINFO(m_iLoadoutWepChoice)),
 	RecvPropInt(RECVINFO(m_iNextSpawnClassChoice)),
 	RecvPropInt(RECVINFO(m_bInLean)),
@@ -422,7 +421,6 @@ C_NEO_Player::C_NEO_Player()
 	m_iNeoSkin = NEO_SKIN_FIRST;
 	m_iNeoStar = NEO_DEFAULT_STAR;
 
-	m_iCapTeam = TEAM_UNASSIGNED;
 	m_iLoadoutWepChoice = 0;
 	m_iNextSpawnClassChoice = -1;
 	m_iXP.GetForModify() = 0;
@@ -442,7 +440,6 @@ C_NEO_Player::C_NEO_Player()
 
 	m_bFirstDeathTick = true;
 	m_bPreviouslyReloading = false;
-	m_bPreviouslyPreparingToHideMsg = false;
 	m_bLastTickInThermOpticCamo = false;
 	m_bIsAllowedToToggleVision = false;
 
@@ -978,28 +975,6 @@ void C_NEO_Player::PostThink(void)
 	if (GetLocalNEOPlayer() == this)
 	{
 		neo_this_client_speed.SetValue(MIN(GetAbsVelocity().Length2D() / GetNormSpeed(), 1.0f));
-	}
-
-	//DevMsg("Roll: %f\n", m_angEyeAngles[2]);
-
-	bool preparingToHideMsg = (m_iCapTeam != TEAM_UNASSIGNED);
-
-	if (!preparingToHideMsg && m_bPreviouslyPreparingToHideMsg)
-	{
-		auto indicator = GET_HUDELEMENT(CNEOHud_GameEvent);
-		if (indicator)
-		{
-			indicator->SetVisible(false);
-			m_bPreviouslyPreparingToHideMsg = false;
-		}
-		else
-		{
-			Assert(false);
-		}
-	}
-	else
-	{
-		m_bPreviouslyPreparingToHideMsg = preparingToHideMsg;
 	}
 
 	if (!IsAlive())

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -188,7 +188,6 @@ public:
 	//wchar_t m_pszTestMessage;
 
 	CNetworkVar(int, m_iXP);
-	CNetworkVar(int, m_iCapTeam);
 	CNetworkVar(int, m_iLoadoutWepChoice);
 	CNetworkVar(int, m_iNextSpawnClassChoice);
 
@@ -226,7 +225,6 @@ public:
 private:
 	bool m_bFirstDeathTick;
 	bool m_bPreviouslyReloading;
-	bool m_bPreviouslyPreparingToHideMsg;
 	bool m_bIsAllowedToToggleVision;
 	int m_iSavedObserverMode = 0;
 

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
@@ -94,9 +94,10 @@ void CNEOHud_GhostBeacons::DrawNeoHudElement()
 	}
 
 	auto localPlayer = C_NEO_Player::GetLocalNEOPlayer();
-	if (localPlayer->GetTeamNumber() < FIRST_GAME_TEAM || !localPlayer->IsAlive())
+	if (localPlayer->GetTeamNumber() < FIRST_GAME_TEAM || !localPlayer->IsAlive() || NEORules()->IsRoundOver())
 	{
 		// NEO NOTE (nullsystem): Spectator and dead players even in spec shouldn't see beacons
+		// Post-round also should switch off beacon
 		return;
 	}
 

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_cap_point.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_cap_point.cpp
@@ -74,7 +74,7 @@ void CNEOHud_GhostCapPoint::UpdateStateForNeoHudElementDraw()
 
 void CNEOHud_GhostCapPoint::DrawNeoHudElement()
 {
-	if (!ShouldDraw())
+	if (!ShouldDraw() || NEORules()->IsRoundOver())
 	{
 		return;
 	}

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
@@ -92,7 +92,7 @@ void CNEOHud_GhostMarker::UpdateStateForNeoHudElementDraw()
 
 void CNEOHud_GhostMarker::DrawNeoHudElement()
 {
-	if (!ShouldDraw())
+	if (!ShouldDraw() || NEORules()->IsRoundOver())
 	{
 		return;
 	}

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -46,7 +46,6 @@ SendPropInt(SENDINFO(m_iNeoClass)),
 SendPropInt(SENDINFO(m_iNeoSkin)),
 SendPropInt(SENDINFO(m_iNeoStar)),
 SendPropInt(SENDINFO(m_iXP)),
-SendPropInt(SENDINFO(m_iCapTeam), 3),
 SendPropInt(SENDINFO(m_iLoadoutWepChoice)),
 SendPropInt(SENDINFO(m_iNextSpawnClassChoice)),
 SendPropInt(SENDINFO(m_bInLean)),
@@ -85,7 +84,6 @@ DEFINE_FIELD(m_iNeoClass, FIELD_INTEGER),
 DEFINE_FIELD(m_iNeoSkin, FIELD_INTEGER),
 DEFINE_FIELD(m_iNeoStar, FIELD_INTEGER),
 DEFINE_FIELD(m_iXP, FIELD_INTEGER),
-DEFINE_FIELD(m_iCapTeam, FIELD_INTEGER),
 DEFINE_FIELD(m_iLoadoutWepChoice, FIELD_INTEGER),
 DEFINE_FIELD(m_bDroppedAnything, FIELD_BOOLEAN),
 DEFINE_FIELD(m_iNextSpawnClassChoice, FIELD_INTEGER),
@@ -394,7 +392,6 @@ CNEO_Player::CNEO_Player()
 	m_bInAim = false;
 	m_bInLean = NEO_LEAN_NONE;
 
-	m_iCapTeam = TEAM_UNASSIGNED;
 	m_iLoadoutWepChoice = 0;
 	m_iNextSpawnClassChoice = -1;
 

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -213,8 +213,6 @@ public:
 	CNetworkVar(int, m_iNeoSkin);
 	CNetworkVar(int, m_iNeoStar);
 
-	CNetworkVar(int, m_iCapTeam);
-
 	CNetworkVar(int, m_iXP);
 
 	CNetworkVar(int, m_iLoadoutWepChoice);

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -971,15 +971,18 @@ void CNEORules::StartNextRound()
 
 	DevMsg("New round start here!\n");
 }
+#endif
 
 bool CNEORules::IsRoundOver() const
 {
+#ifdef GAME_DLL
 	// We don't want to start preparing for a new round
 	// if the game has ended for the current map.
 	if (g_fGameOver)
 	{
 		return false;
 	}
+#endif
 
 	// Next round start has been scheduled, so current round must be over.
 	if (m_flNeoNextRoundStartTime != 0)
@@ -990,7 +993,6 @@ bool CNEORules::IsRoundOver() const
 
 	return false;
 }
-#endif
 
 void CNEORules::CreateStandardEntities(void)
 {

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -193,8 +193,8 @@ public:
 	virtual float FlPlayerFallDamage(CBasePlayer* pPlayer) OVERRIDE;
 #endif
 
-#ifdef GAME_DLL
 	bool IsRoundOver() const;
+#ifdef GAME_DLL
 	void StartNextRound();
 
 	virtual const char* GetChatFormat(bool bTeamOnly, CBasePlayer* pPlayer) OVERRIDE;

--- a/mp/src/game/shared/neo/neo_ghost_cap_point.cpp
+++ b/mp/src/game/shared/neo/neo_ghost_cap_point.cpp
@@ -188,7 +188,7 @@ void CNEOGhostCapturePoint::Think_CheckMyRadius(void)
 	}
 
 	// This round has already ended, we can't be capped into
-	if (NEORules()->GetRoundRemainingTime() < 0)
+	if (NEORules()->IsRoundOver())
 	{
 		return;
 	}
@@ -240,34 +240,6 @@ void CNEOGhostCapturePoint::Think_CheckMyRadius(void)
 		m_iSuccessfulCaptorClientIndex = i;
 
 		DevMsg("Player got ghost inside my radius\n");
-
-		player->m_iCapTeam = player->GetTeamNumber();
-
-		// Center print the cap message.
-		// NEO TODO (Rain): better looking message with the team logo.
-		CRecipientFilter filter;
-		filter.AddAllPlayers();
-
-#if(0) // NEO FIXME (Rain): wide name handling
-		wchar wmsg[64 + MAX_PLAYER_NAME_LENGTH];
-
-		wchar wPlayerName[MAX_PLAYER_NAME_LENGTH];
-		g_pVGuiLocalize->ConvertANSIToUnicode(player->GetPlayerName(), wPlayerName, sizeof(wPlayerName));
-
-		V_swprintf_safe(wmsg, L"%s wins\n%s captured the ghost",
-			player->GetTeamNumber() == TEAM_JINRAI ? L"Jinrai" : L"NSF",
-			wPlayerName);
-#endif
-		char msg[64 + MAX_PLACE_NAME_LENGTH];
-		COMPILE_TIME_ASSERT(sizeof(msg) <= 512); // max supported
-
-		V_sprintf_safe(msg, "%s captured the ghost", player->GetPlayerName());
-
-		UserMessageBegin(filter, "RoundResult");
-		WRITE_STRING(player->GetTeamNumber() == TEAM_JINRAI ? "jinrai": "nsf");	// which team won
-		WRITE_FLOAT(gpGlobals->curtime);										// when did they win
-		WRITE_STRING(msg);														// extra message (who capped or last kill or who got the most points or whatever)
-		MessageEnd();
 
 		// Return early; we pass next think responsibility to gamerules,
 		// whenever it sees fit to start capzone thinking again.


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Before, the round end state HUD was trigger to any player that's by the capzone
* Instead, it should jsut be left to the gamerule which will provide the similar round end state HUD anyway
* This also turns off the visibility of ghost-related HUDs post round in the cap point, ghost beacons, and ghost marker
* Refactor to remove unnecessary variable usages

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #513

