### PR TITLE
Always hide HTA/ammo hud if observer

### DIFF
--- a/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
@@ -287,7 +287,8 @@ void CNEOHud_Ammo::DrawAmmo() const
 
 void CNEOHud_Ammo::DrawNeoHudElement()
 {
-	if (!ShouldDraw())
+	auto *localPlayer = C_NEO_Player::GetLocalNEOPlayer();
+	if (!ShouldDraw() || (!localPlayer || localPlayer->IsObserver()))
 	{
 		return;
 	}

--- a/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
@@ -230,7 +230,8 @@ void CNEOHud_HTA::DrawNeoHudElement()
 {
 	DrawBuildInfo(); // Always draw build info
 
-	if (!ShouldDraw())
+	auto *localPlayer = C_NEO_Player::GetLocalNEOPlayer();
+	if (!ShouldDraw() || (!localPlayer || localPlayer->IsObserver()))
 	{
 		return;
 	}


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
Observers (spectator/dead players) don't need to see the Health-Therm-AUX and Ammo HUDs.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #508

