### PR TITLE
Original HUD colours

### DIFF
--- a/mp/game/neo/scripts/HudLayout.res
+++ b/mp/game/neo/scripts/HudLayout.res
@@ -538,7 +538,7 @@
 		"needle_visible"	"0"
 		"needle_colored"	"0"
 		"objective_visible"	"1"
-		"box_color"		"100 100 100 178"
+		"box_color"		"200 200 200 40"
 	}
 	NHudWeapon
 	{
@@ -549,7 +549,7 @@
 		"ypos"			"446"
 		"wide"			"203"
 		"tall"			"32"
-		"box_color"		"100 100 100 178"
+		"box_color"		"200 200 200 40"
 		"top_left_corner"	"1"
 		"top_right_corner"	"1"
 		"bottom_left_corner"	"1"
@@ -564,8 +564,9 @@
 		"digit2_ypos"		"16"
 		"icon_xpos"		"3"
 		"icon_ypos"		"5"
-		"ammo_color"		"255 255 255 178"
-		"emptied_ammo_color"	"255 255 255 89"
+		"ammo_text_color"	"255 255 255 100"
+		"ammo_color"		"255 255 255 150"
+		"emptied_ammo_color"	"255 255 255 50"
 	}
 	NHudHealth
 	{
@@ -576,7 +577,7 @@
 		"ypos"			"446"
 		"wide"			"203"
 		"tall"			"32"
-		"box_color"		"100 100 100 178"
+		"box_color"		"200 200 200 40"
 		"top_left_corner"	"1"
 		"top_right_corner"	"1"
 		"bottom_left_corner"	"1"
@@ -589,7 +590,8 @@
 		"healthbar_h"		"6"
 		"healthnum_xpos"	"198"
 		"healthnum_ypos"	"2"
-		"health_color"		"255 255 255 178"
+		"health_text_color"		"255 255 255 100"
+		"health_color"		"255 255 255 150"
 		"camotext_xpos"		"6"
 		"camotext_ypos"		"12"
 		"camobar_xpos"		"86"
@@ -598,7 +600,8 @@
 		"camobar_h"		"6"
 		"camonum_xpos"		"198"
 		"camonum_ypos"		"12"
-		"camo_color"		"255 255 255 178"
+		"camo_text_color"		"255 255 255 100"
+		"camo_color"		"255 255 255 150"
 		"sprinttext_xpos"	"6"
 		"sprinttext_ypos"	"22"
 		"sprintbar_xpos"	"86"
@@ -607,7 +610,8 @@
 		"sprintbar_h"		"6"
 		"sprintnum_xpos"	"198"
 		"sprintnum_ypos"	"22"
-		"sprint_color"		"255 255 255 178"
+		"sprint_text_color"		"255 255 255 100"
+		"sprint_color"		"255 255 255 150"
 	}
 	RoundResult
 	{
@@ -618,7 +622,7 @@
 	NRoundState
 	{
 		"fieldName"		"NRoundState"
-		"box_color"		"100 100 100 178"
+		"box_color"		"200 200 200 40"
 		"health_monochrome"	"1"
 	}
 }

--- a/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ammo.cpp
@@ -118,7 +118,7 @@ void CNEOHud_Ammo::DrawAmmo() const
 	DrawNeoHudRoundedBox(xpos, ypos, xpos + wide, ypos + tall, box_color, top_left_corner, top_right_corner, bottom_left_corner, bottom_right_corner);
 
 	surface()->DrawSetTextFont(m_hSmallTextFont);
-	surface()->DrawSetTextColor(ammo_color);
+	surface()->DrawSetTextColor(ammo_text_color);
 	int fontWidth, fontHeight;
 	surface()->GetTextSize(m_hSmallTextFont, unicodeWepName, fontWidth, fontHeight);
 	surface()->DrawSetTextPos((text_xpos + xpos) - fontWidth, text_ypos + ypos);
@@ -158,7 +158,7 @@ void CNEOHud_Ammo::DrawAmmo() const
 		surface()->DrawSetTextPos(digit2_xpos + xpos - fontWidth, digit2_ypos + ypos);
 		surface()->DrawPrintText(unicodeClipsText, textLen);
 	}
-		
+
 	const char* ammoChar = nullptr;
 	int fireModeWidth = 0, fireModeHeight = 0;
 	int magSizeMax = 0;
@@ -207,6 +207,7 @@ void CNEOHud_Ammo::DrawAmmo() const
 		}			
 	}
 
+	surface()->DrawSetTextColor(ammo_color);
 	if (digit_as_number && activeWep->UsesClipsForAmmo1())
 	{ // Draw bullets in magazine in number form
 		surface()->DrawSetTextFont(m_hBulletFont);

--- a/mp/src/game/client/neo/ui/neo_hud_ammo.h
+++ b/mp/src/game/client/neo/ui/neo_hud_ammo.h
@@ -44,7 +44,7 @@ private:
 	CPanelAnimationVarAliasType(int, tall, "tall", "32", "proportional_ypos");
 	CPanelAnimationVarAliasType(int, visible, "visible", "1", "int");
 	CPanelAnimationVarAliasType(int, enabled, "enabled", "1", "int");
-	CPanelAnimationVar(Color, box_color, "box_color", "100 100 100 178");
+	CPanelAnimationVar(Color, box_color, "box_color", "200 200 200 40");
 
 	CPanelAnimationVarAliasType(bool, top_left_corner, "top_left_corner", "1", "bool");
 	CPanelAnimationVarAliasType(bool, top_right_corner, "top_right_corner", "1", "bool");
@@ -61,8 +61,9 @@ private:
 	CPanelAnimationVarAliasType(int, digit2_ypos, "digit2_ypos", "16", "proportional_ypos");
 	CPanelAnimationVarAliasType(int, icon_xpos, "icon_xpos", "3", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, icon_ypos, "icon_ypos", "5", "proportional_ypos");
-	CPanelAnimationVar(Color, ammo_color, "ammo_color", "255 255 255 178");
-	CPanelAnimationVar(Color, emptied_ammo_color, "emptied_ammo_color", "255 255 255 89");
+	CPanelAnimationVar(Color, ammo_text_color, "ammo_text_color", "255 255 255 100");
+	CPanelAnimationVar(Color, ammo_color, "ammo_color", "255 255 255 150");
+	CPanelAnimationVar(Color, emptied_ammo_color, "emptied_ammo_color", "255 255 255 50");
 private:
 	CNEOHud_Ammo(const CNEOHud_Ammo& other);
 };

--- a/mp/src/game/client/neo/ui/neo_hud_compass.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.cpp
@@ -257,18 +257,6 @@ void CNEOHud_Compass::DrawCompass() const
 			}
 		}
 	}
-
-	const Color fadeEndColor(m_boxColor.r(), m_boxColor.g(), m_boxColor.b(), 255);
-	DrawNeoHudRoundedBoxFaded(
-		resXHalf - xBoxWidthHalf, m_resY - yBoxHeight - margin,
-		resXHalf, m_resY - margin,
-		fadeEndColor, 255, 0, true,
-		true, false, true, false);
-	DrawNeoHudRoundedBoxFaded(
-		resXHalf, m_resY - yBoxHeight - margin,
-		resXHalf + xBoxWidthHalf, m_resY - margin,
-		fadeEndColor, 0, 255, true,
-		false, true, false, true);
 }
 
 void CNEOHud_Compass::DrawDebugCompass() const

--- a/mp/src/game/client/neo/ui/neo_hud_compass.h
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.h
@@ -44,7 +44,7 @@ private:
 	CPanelAnimationVarAliasType(bool, m_needleVisible, "needle_visible", "0", "bool");
 	CPanelAnimationVarAliasType(bool, m_needleColored, "needle_colored", "0", "bool");
 	CPanelAnimationVarAliasType(bool, m_objectiveVisible, "objective_visible", "1", "bool");
-	CPanelAnimationVar(Color, m_boxColor, "box_color", "100 100 100 178");
+	CPanelAnimationVar(Color, m_boxColor, "box_color", "200 200 200 40");
 
 private:
 	CNEOHud_Compass(const CNEOHud_Compass &other);

--- a/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
@@ -148,31 +148,31 @@ void CNEOHud_HTA::DrawHTA() const
 	DrawNeoHudRoundedBox(xpos, ypos, xpos + wide, ypos + tall, m_boxColor, top_left_corner, top_right_corner, bottom_left_corner, bottom_right_corner);
 
 	surface()->DrawSetTextFont(m_hFont);
-	surface()->DrawSetTextColor(m_healthColor);
+	surface()->DrawSetTextColor(m_healthTextColor);
 	surface()->DrawSetTextPos(healthtext_xpos + xpos, healthtext_ypos + ypos);
 	surface()->DrawPrintText(L"INTEGRITY", 9);
 	if (playerIsNotSupport)
 	{
-		surface()->DrawSetTextColor(m_camoColor);
+		surface()->DrawSetTextColor(m_camoTextColor);
 		surface()->DrawSetTextPos(camotext_xpos + xpos, camotext_ypos + ypos);
 		surface()->DrawPrintText(L"THERM-OPTIC", 11);
-		surface()->DrawSetTextColor(m_sprintColor);
+		surface()->DrawSetTextColor(m_sprintTextColor);
 		surface()->DrawSetTextPos(sprinttext_xpos + xpos, sprinttext_ypos + ypos);
 		surface()->DrawPrintText(L"AUX", 3);
 	}
 
 	int fontWidth, fontHeight;
-	surface()->DrawSetTextColor(m_healthColor);
+	surface()->DrawSetTextColor(m_healthTextColor);
 	surface()->GetTextSize(m_hFont, unicodeValue_Integrity, fontWidth, fontHeight);
 	surface()->DrawSetTextPos(healthnum_xpos + xpos - fontWidth, healthnum_ypos + ypos);
 	surface()->DrawPrintText(unicodeValue_Integrity, valLen_Integrity);
 	if (playerIsNotSupport)
 	{
-		surface()->DrawSetTextColor(m_camoColor);
+		surface()->DrawSetTextColor(m_camoTextColor);
 		surface()->GetTextSize(m_hFont, unicodeValue_ThermOptic, fontWidth, fontHeight);
 		surface()->DrawSetTextPos(camonum_xpos + xpos - fontWidth, camonum_ypos + ypos);
 		surface()->DrawPrintText(unicodeValue_ThermOptic, valLen_ThermOptic);
-		surface()->DrawSetTextColor(m_sprintColor);
+		surface()->DrawSetTextColor(m_sprintTextColor);
 		surface()->GetTextSize(m_hFont, unicodeValue_Aux, fontWidth, fontHeight);
 		surface()->DrawSetTextPos(sprintnum_xpos + xpos - fontWidth, sprintnum_ypos + ypos);
 		surface()->DrawPrintText(unicodeValue_Aux, valLen_Aux);
@@ -204,13 +204,14 @@ void CNEOHud_HTA::DrawHTA() const
 			sprintbar_xpos + xpos + (sprintbar_w * (aux / 100.0)),
 			sprintbar_ypos + ypos + sprintbar_h);
 
-		surface()->DrawSetColor(textColorTransparent);
+		surface()->DrawSetColor(m_camoTextColor);
 		surface()->DrawOutlinedRect(
 			camobar_xpos + xpos,
 			camobar_ypos + ypos,
 			camobar_xpos + xpos + camobar_w,
 			camobar_ypos + ypos + camobar_h);
 
+		surface()->DrawSetColor(m_sprintTextColor);
 		surface()->DrawOutlinedRect(
 			sprintbar_xpos + xpos,
 			sprintbar_ypos + ypos,
@@ -218,7 +219,7 @@ void CNEOHud_HTA::DrawHTA() const
 			sprintbar_ypos + ypos + sprintbar_h);
 	}
 
-	surface()->DrawSetColor(textColorTransparent);
+	surface()->DrawSetColor(m_healthTextColor);
 	surface()->DrawOutlinedRect(
 		healthbar_xpos + xpos,
 		healthbar_ypos + ypos,

--- a/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.h
+++ b/mp/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.h
@@ -42,7 +42,7 @@ private:
 	CPanelAnimationVarAliasType(float, tall, "tall", "32", "proportional_float");
 	CPanelAnimationVarAliasType(float, visible, "visible", "1", "proportional_float");
 	CPanelAnimationVarAliasType(float, enabled, "enabled", "1", "proportional_float");
-	CPanelAnimationVar(Color, m_boxColor, "box_color", "100 100 100 178");
+	CPanelAnimationVar(Color, m_boxColor, "box_color", "200 200 200 40");
 
 	CPanelAnimationVarAliasType(bool, top_left_corner, "top_left_corner", "1", "bool");
 	CPanelAnimationVarAliasType(bool, top_right_corner, "top_right_corner", "1", "bool");
@@ -57,7 +57,8 @@ private:
 	CPanelAnimationVarAliasType(float, healthbar_h, "healthbar_h", "6", "proportional_float");
 	CPanelAnimationVarAliasType(int, healthnum_xpos, "healthnum_xpos", "198", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, healthnum_ypos, "healthnum_ypos", "2", "proportional_ypos");
-	CPanelAnimationVar(Color, m_healthColor, "health_color", "255 255 255 178");
+	CPanelAnimationVar(Color, m_healthTextColor, "health_text_color", "255 255 255 100");
+	CPanelAnimationVar(Color, m_healthColor, "health_color", "255 255 255 150");
 
 	CPanelAnimationVarAliasType(int, camotext_xpos, "camotext_xpos", "6", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, camotext_ypos, "camotext_ypos", "12", "proportional_ypos");
@@ -67,7 +68,8 @@ private:
 	CPanelAnimationVarAliasType(float, camobar_h, "camobar_h", "6", "proportional_float");
 	CPanelAnimationVarAliasType(int, camonum_xpos, "camonum_xpos", "198", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, camonum_ypos, "camonum_ypos", "12", "proportional_ypos");
-	CPanelAnimationVar(Color, m_camoColor, "camo_color", "255 255 255 178");
+	CPanelAnimationVar(Color, m_camoTextColor, "camo_text_color", "255 255 255 100");
+	CPanelAnimationVar(Color, m_camoColor, "camo_color", "255 255 255 150");
 
 	CPanelAnimationVarAliasType(int, sprinttext_xpos, "sprinttext_xpos", "6", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, sprinttext_ypos, "sprinttext_ypos", "22", "proportional_ypos");
@@ -77,7 +79,8 @@ private:
 	CPanelAnimationVarAliasType(float, sprintbar_h, "sprintbar_h", "6", "proportional_float");
 	CPanelAnimationVarAliasType(int, sprintnum_xpos, "sprintnum_xpos", "198", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, sprintnum_ypos, "sprintnum_ypos", "22", "proportional_ypos");
-	CPanelAnimationVar(Color, m_sprintColor, "sprint_color", "255 255 255 178");
+	CPanelAnimationVar(Color, m_sprintTextColor, "sprint_text_color", "255 255 255 100");
+	CPanelAnimationVar(Color, m_sprintColor, "sprint_color", "255 255 255 150");
 
 private:
 	CNEOHud_HTA(const CNEOHud_HTA& other);

--- a/mp/src/game/client/neo/ui/neo_hud_round_state.h
+++ b/mp/src/game/client/neo/ui/neo_hud_round_state.h
@@ -92,7 +92,7 @@ private:
 
 	int m_iNextAvatarUpdate = 0;
 
-	CPanelAnimationVar(Color, box_color, "box_color", "100 100 100 178");
+	CPanelAnimationVar(Color, box_color, "box_color", "200 200 200 40");
 	CPanelAnimationVarAliasType(bool, health_monochrome, "health_monochrome", "1", "bool");
 
 private:


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Used a custom map with a totally black wall to test hud colours, think these are the original. Didn't touch the compass and round status text colour. Compass text in the original has a fade effect that needs to be implemented still, and round status element needs to be readable so left as is. Technically health sprint aux bar outlines should be drawn outside the bar itself instead of on top of the bars, so the outlines are brighter than they should be when next to actual bar. Can fix if this really bugs someone.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #455

