### PR TITLE
Automatic Release Upload

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -200,18 +200,13 @@ jobs:
       uses: actions/download-artifact@v4
 
     - name: Packing artifacts
-      run: |
-        for i in neo-*
-        do
-          7z a -tzip -mx=9 "${i}.zip" "./${i}/*"
-        done
+      run: 'parallel 7z a -tzip -mx=9 "{}.zip" "./{}/*" ::: neo-*'
         
     - name: Create latest release
-      uses: mathieucarbou/marvinpinto-action-automatic-releases@latest
+      uses: slord399/action-automatic-releases@v1.0.1
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         prerelease: true
         automatic_release_tag: "latest"
         title: "Latest Build"
-        files: |
-          neo-*.zip
+        files: neo-*.zip


### PR DESCRIPTION
## Description
Adds automatic release uploading from latest artifacts to release page. Only uploads if it's built from the master branch, has a changelog and stuff. You can see how it looks over at my fork: https://github.com/xedmain/ntrebuild/releases

Compresses the artifacts into max compressed zips using 7z. Takes approx 4 minutes to pack all of them.