### PR TITLE
Chat colour fix, chat format fix, retrieval zone colour fix

### DIFF
--- a/mp/src/game/client/hud_basechat.cpp
+++ b/mp/src/game/client/hud_basechat.cpp
@@ -1872,15 +1872,26 @@ void CBaseHudChat::ChatPrintf( int iPlayerIndex, int iFilter, const char *fmt, .
 
 		if ( pName )
 		{
+#ifdef NEO
+			wchar_t wideName[MAX_PLAYER_NAME_LENGTH+1];
+			char pNameWithColon[MAX_PLAYER_NAME_LENGTH+1];
+			V_snprintf(pNameWithColon, MAX_PLAYER_NAME_LENGTH+1, "%s:", pName);
+			g_pVGuiLocalize->ConvertANSIToUnicode(pNameWithColon, wideName, sizeof( wideName ) );
+#else
 			wchar_t wideName[MAX_PLAYER_NAME_LENGTH];
 			g_pVGuiLocalize->ConvertANSIToUnicode( pName, wideName, sizeof( wideName ) );
+#endif
 
 			const wchar_t *nameInString = wcsstr( wbuf, wideName );
 
 			if ( nameInString )
 			{
 				iNameStart = (nameInString - wbuf);
+#ifdef NEO
+				iNameLength = wcslen( wideName ) - 1;
+#else
 				iNameLength = wcslen( wideName );
+#endif
 			}
 		}
 

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_cap_point.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_cap_point.cpp
@@ -78,9 +78,7 @@ void CNEOHud_GhostCapPoint::DrawNeoHudElement()
 	auto *player = C_NEO_Player::GetLocalNEOPlayer();
 	const int playerTeam = player->GetTeamNumber();
 
-	static const Color COLORCAP_JINRAI(76, 255, 0, 255);
-	static const Color COLORCAP_NSF(0, 76, 255, 255);
-	Color targetColor = (m_iCapTeam == TEAM_JINRAI) ? COLORCAP_JINRAI : COLORCAP_NSF;
+	Color targetColor = (m_iCapTeam == TEAM_JINRAI) ? COLOR_JINRAI : COLOR_NSF;
 
 	const bool playerIsPlaying = (playerTeam == TEAM_JINRAI || playerTeam == TEAM_NSF);
 	if (playerIsPlaying)

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1224,7 +1224,7 @@ void CNEO_Player::SetNeoPlayerName(const char *newNeoName)
 	// NEO NOTE (nullsystem): Generally it's never NULL but just incase
 	if (newNeoName)
 	{
-		V_memcpy(m_szNeoName.GetForModify(), newNeoName, sizeof(m_szNeoName));
+		V_memcpy(m_szNeoName.GetForModify(), newNeoName, sizeof(m_szNeoName)-1);
 		m_szNeoNameHasSet = true;
 	}
 }

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -1782,20 +1782,20 @@ const char* CNEORules::GetChatFormat(bool bTeamOnly, CBasePlayer* pPlayer)
 		{
 			switch (pPlayer->GetTeamNumber())
 			{
-			case TEAM_JINRAI: return FMT_TEAM_JINRAI " (team) " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			case TEAM_NSF: return FMT_TEAM_NSF " (team) " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			case TEAM_SPECTATOR: return FMT_TEAM_SPECTATOR " (team) " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			default: return FMT_TEAM_UNASSIGNED " (team) " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_JINRAI: return FMT_TEAM_JINRAI " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_NSF: return FMT_TEAM_NSF " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_SPECTATOR: return FMT_TEAM_SPECTATOR " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			default: return FMT_TEAM_UNASSIGNED " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
 			}
 		}
 		else
 		{
 			switch (pPlayer->GetTeamNumber())
 			{
-			case TEAM_JINRAI: return FMT_TEAM_JINRAI " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			case TEAM_NSF: return FMT_TEAM_NSF " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			case TEAM_SPECTATOR: return FMT_TEAM_SPECTATOR " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			default: return FMT_TEAM_UNASSIGNED " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_JINRAI: return FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_NSF: return FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_SPECTATOR: return FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			default: return FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
 			}
 		}
 	}
@@ -1805,20 +1805,20 @@ const char* CNEORules::GetChatFormat(bool bTeamOnly, CBasePlayer* pPlayer)
 		{
 			switch (pPlayer->GetTeamNumber())
 			{
-			case TEAM_JINRAI: return FMT_DEAD " " FMT_TEAM_JINRAI " (team) " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			case TEAM_NSF: return FMT_DEAD " " FMT_TEAM_NSF " (team) " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			case TEAM_SPECTATOR: return FMT_TEAM_SPECTATOR " (team) " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			default: return FMT_TEAM_UNASSIGNED " (team) " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_JINRAI: return FMT_DEAD FMT_TEAM_JINRAI " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_NSF: return FMT_DEAD FMT_TEAM_NSF " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_SPECTATOR: return FMT_TEAM_SPECTATOR " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			default: return FMT_TEAM_UNASSIGNED " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
 			}
 		}
 		else
 		{
 			switch (pPlayer->GetTeamNumber())
 			{
-			case TEAM_JINRAI: return FMT_DEAD " " FMT_TEAM_JINRAI " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			case TEAM_NSF: return FMT_DEAD " " FMT_TEAM_NSF " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			case TEAM_SPECTATOR: return FMT_TEAM_SPECTATOR " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
-			default: return FMT_TEAM_UNASSIGNED " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_JINRAI: return FMT_DEAD " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_NSF: return FMT_DEAD " " FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			case TEAM_SPECTATOR: return FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
+			default: return FMT_PLAYERNAME ": " FMT_CHATMESSAGE;
 			}
 		}
 	}

--- a/mp/src/game/shared/neo/neo_player_shared.h
+++ b/mp/src/game/shared/neo/neo_player_shared.h
@@ -211,8 +211,8 @@ enum NeoStar {
 #define COLOR_NSF COLOR_NEO_BLUE
 #define COLOR_SPEC COLOR_NEO_ORANGE
 
-#define COLOR_NEO_BLUE Color(181, 216, 248, 255)
-#define COLOR_NEO_GREEN Color(192, 244, 196, 255)
+#define COLOR_NEO_BLUE Color(154, 205, 255, 255)
+#define COLOR_NEO_GREEN Color(154, 255, 154, 255)
 #define COLOR_NEO_ORANGE Color(243, 190, 52, 255)
 #define COLOR_NEO_WHITE Color(218, 217, 213, 255)
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Adds colon to name search, changes JINRAI and NSF colours to match original. When searching for name of sender in chat message, the search string now has a colon appended to the end. This stops the senders name from being found too early in the tags that are prepended to the message before the sender's name (*DEAD*, [Jinrai], [NSF]) being incorrectly detected as the sender's name, making chat messages be coloured in incorrectly. This is not guaranteed to always work if we add clan tags which can have colons in them, or locations of sender on the map which can also have a colon in them.

Also changes chat format slightly to match plugin parity

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #436
- fixes #298
- fixes #297

