### PR TITLE
Correct damage indicators

### DIFF
--- a/mp/game/neo/scripts/HudAnimations.txt
+++ b/mp/game/neo/scripts/HudAnimations.txt
@@ -159,6 +159,8 @@ event SuitFlashlightOff
 
 event HudTakeDamageFront
 {
+	Animate HudDamageIndicator DmgFullscreenColor	"255 88 0 25"	Linear 0.0 0.0
+	Animate HudDamageIndicator DmgFullscreenColor	"255 0 0 0"	Deaccel 0.0 1.0
 }
 
 event HudTakeDamageLeft

--- a/mp/src/game/client/CMakeLists.txt
+++ b/mp/src/game/client/CMakeLists.txt
@@ -1460,7 +1460,6 @@ target_sources_grouped(
     hl2/hud_battery.cpp
     hl2/hud_blood.cpp
     hl2/hud_credits.cpp
-    hl2/hud_damageindicator.cpp
     hl2/hud_flashlight.cpp
     hl2/hud_health.cpp
     hl2/hud_poisondamageindicator.cpp
@@ -1514,6 +1513,7 @@ target_sources_grouped(
     neo/ui/neo_hud_childelement.h
     neo/ui/neo_hud_compass.cpp
     neo/ui/neo_hud_compass.h
+    neo/ui/neo_hud_damage_indicator.cpp
     neo/ui/neo_hud_friendly_marker.cpp
     neo/ui/neo_hud_friendly_marker.h
     neo/ui/neo_hud_game_event.cpp

--- a/mp/src/game/client/hl2/hud_damageindicator.cpp
+++ b/mp/src/game/client/hl2/hud_damageindicator.cpp
@@ -363,53 +363,17 @@ void CHudDamageIndicator::MsgFunc_Damage( bf_read &msg )
 	if ( !pPlayer )
 		return;
 
-	// player has just died, just run the dead damage animation
+	// player has just died, return
 	if ( pPlayer->GetHealth() <= 0 )
 	{
-		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HudPlayerDeath" );
 		return;
 	}
 
-	// ignore damage without direction
-	// this should never happen, unless it's drowning damage, 
-	// or the player is forcibly killed, handled above
-	if ( vecFrom == vec3_origin && !(bitsDamage & DMG_DROWN))
-		return;
-
-	Vector vecDelta = (vecFrom - MainViewOrigin());
-	VectorNormalize( vecDelta );
-
-	int highDamage = DAMAGE_LOW;
-
 	if ( damageTaken > 0 || armor > 0 )
 	{
-		// see which quandrant the effect is in
-		float angle;
-		GetDamagePosition( vecDelta, &angle );
-
 		// see which effect to play
-		DamageAnimation_t *dmgAnim = g_DamageAnimations;
-		for ( ; dmgAnim->name != NULL; ++dmgAnim )
-		{
-			if ( dmgAnim->bitsDamage && !(bitsDamage & dmgAnim->bitsDamage) )
-				continue;
-
-			if ( dmgAnim->angleMinimum && angle < dmgAnim->angleMinimum )
-				continue;
-
-			if ( dmgAnim->angleMaximum && angle > dmgAnim->angleMaximum )
-				continue;
-
-			if ( dmgAnim->damage && dmgAnim->damage != highDamage )
-				continue;
-
-			// we have a match, break
-			break;
-		}
-
-		if ( dmgAnim->name )
-		{
-			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( dmgAnim->name );
+		if (bitsDamage & DMG_BULLET || bitsDamage & DMG_SLASH || bitsDamage & DMG_CLUB) {
+			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("HudTakeDamageFront");
 		}
 	}
 }

--- a/mp/src/game/client/hl2/hud_damageindicator.cpp
+++ b/mp/src/game/client/hl2/hud_damageindicator.cpp
@@ -33,45 +33,45 @@ using namespace vgui;
 //-----------------------------------------------------------------------------
 class CHudDamageIndicator : public CHudElement, public vgui::Panel
 {
-	DECLARE_CLASS_SIMPLE( CHudDamageIndicator, vgui::Panel );
+	DECLARE_CLASS_SIMPLE(CHudDamageIndicator, vgui::Panel);
 
 public:
-	CHudDamageIndicator( const char *pElementName );
-	void Init( void );
-	void Reset( void );
-	virtual bool ShouldDraw( void );
+	CHudDamageIndicator(const char* pElementName);
+	void Init(void);
+	void Reset(void);
+	virtual bool ShouldDraw(void);
 
 	// Handler for our message
-	void MsgFunc_Damage( bf_read &msg );
+	void MsgFunc_Damage(bf_read& msg);
 
 private:
 	virtual void Paint();
-	virtual void ApplySchemeSettings(vgui::IScheme *pScheme);
+	virtual void ApplySchemeSettings(vgui::IScheme* pScheme);
 
 private:
-	CPanelAnimationVarAliasType( float, m_flDmgX, "dmg_xpos", "10", "proportional_float" );
-	CPanelAnimationVarAliasType( float, m_flDmgY, "dmg_ypos", "80", "proportional_float" );
-	CPanelAnimationVarAliasType( float, m_flDmgWide, "dmg_wide", "30", "proportional_float" );
-	CPanelAnimationVarAliasType( float, m_flDmgTall1, "dmg_tall1", "300", "proportional_float" );
-	CPanelAnimationVarAliasType( float, m_flDmgTall2, "dmg_tall2", "240", "proportional_float" );
+	CPanelAnimationVarAliasType(float, m_flDmgX, "dmg_xpos", "10", "proportional_float");
+	CPanelAnimationVarAliasType(float, m_flDmgY, "dmg_ypos", "80", "proportional_float");
+	CPanelAnimationVarAliasType(float, m_flDmgWide, "dmg_wide", "30", "proportional_float");
+	CPanelAnimationVarAliasType(float, m_flDmgTall1, "dmg_tall1", "300", "proportional_float");
+	CPanelAnimationVarAliasType(float, m_flDmgTall2, "dmg_tall2", "240", "proportional_float");
 
-	CPanelAnimationVar( Color, m_DmgColorLeft, "DmgColorLeft", "255 0 0 0" );
-	CPanelAnimationVar( Color, m_DmgColorRight, "DmgColorRight", "255 0 0 0" );
+	CPanelAnimationVar(Color, m_DmgColorLeft, "DmgColorLeft", "255 0 0 0");
+	CPanelAnimationVar(Color, m_DmgColorRight, "DmgColorRight", "255 0 0 0");
 
-	CPanelAnimationVar( Color, m_DmgHighColorLeft, "DmgHighColorLeft", "255 0 0 0" );
-	CPanelAnimationVar( Color, m_DmgHighColorRight, "DmgHighColorRight", "255 0 0 0" );
+	CPanelAnimationVar(Color, m_DmgHighColorLeft, "DmgHighColorLeft", "255 0 0 0");
+	CPanelAnimationVar(Color, m_DmgHighColorRight, "DmgHighColorRight", "255 0 0 0");
 
-	CPanelAnimationVar( Color, m_DmgFullscreenColor, "DmgFullscreenColor", "255 0 0 0" );
+	CPanelAnimationVar(Color, m_DmgFullscreenColor, "DmgFullscreenColor", "255 0 0 0");
 
 	void DrawDamageIndicator(int side);
 	void DrawFullscreenDamageIndicator();
-	void GetDamagePosition( const Vector &vecDelta, float *flRotation );
+	void GetDamagePosition(const Vector& vecDelta, float* flRotation);
 
 	CMaterialReference m_WhiteAdditiveMaterial;
 };
 
-DECLARE_HUDELEMENT( CHudDamageIndicator );
-DECLARE_HUD_MESSAGE( CHudDamageIndicator, Damage );
+DECLARE_HUDELEMENT(CHudDamageIndicator);
+DECLARE_HUD_MESSAGE(CHudDamageIndicator, Damage);
 
 enum
 {
@@ -85,11 +85,11 @@ enum
 
 struct DamageAnimation_t
 {
-	const char *name;
+	const char* name;
 	int bitsDamage;
 	float angleMinimum;
 	float angleMaximum;
-	int damage; 
+	int damage;
 };
 
 //-----------------------------------------------------------------------------
@@ -106,7 +106,7 @@ static DamageAnimation_t g_DamageAnimations[] =
 	{ "HudTakeDamageHighLeft",	DMG_ANY,	45.0f,		135.0f,		DAMAGE_HIGH },
 	{ "HudTakeDamageHighRight",	DMG_ANY,	225.0f,		315.0f,		DAMAGE_HIGH },
 	{ "HudTakeDamageHigh",		DMG_ANY,	ANGLE_ANY,	ANGLE_ANY,	DAMAGE_HIGH },
-	
+
 	{ "HudTakeDamageLeft",		DMG_ANY,	45.0f,		135.0f,		DAMAGE_ANY },
 	{ "HudTakeDamageRight",		DMG_ANY,	225.0f,		315.0f,		DAMAGE_ANY },
 	{ "HudTakeDamageBehind",	DMG_ANY,	135.0f,		225.0f,		DAMAGE_ANY },
@@ -120,20 +120,20 @@ static DamageAnimation_t g_DamageAnimations[] =
 //-----------------------------------------------------------------------------
 // Purpose: Constructor
 //-----------------------------------------------------------------------------
-CHudDamageIndicator::CHudDamageIndicator( const char *pElementName ) : CHudElement( pElementName ), BaseClass(NULL, "HudDamageIndicator")
+CHudDamageIndicator::CHudDamageIndicator(const char* pElementName) : CHudElement(pElementName), BaseClass(NULL, "HudDamageIndicator")
 {
-	vgui::Panel *pParent = g_pClientMode->GetViewport();
-	SetParent( pParent );
+	vgui::Panel* pParent = g_pClientMode->GetViewport();
+	SetParent(pParent);
 
-	m_WhiteAdditiveMaterial.Init( "vgui/white_additive", TEXTURE_GROUP_VGUI ); 
-	
-	SetHiddenBits( HIDEHUD_HEALTH );
+	m_WhiteAdditiveMaterial.Init("vgui/white_additive", TEXTURE_GROUP_VGUI);
+
+	SetHiddenBits(HIDEHUD_HEALTH);
 }
 
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CHudDamageIndicator::Reset( void )
+void CHudDamageIndicator::Reset(void)
 {
 	m_DmgColorLeft[3] = 0;
 	m_DmgColorRight[3] = 0;
@@ -142,9 +142,9 @@ void CHudDamageIndicator::Reset( void )
 	m_DmgFullscreenColor[3] = 0;
 }
 
-void CHudDamageIndicator::Init( void )
+void CHudDamageIndicator::Init(void)
 {
-	HOOK_HUD_MESSAGE( CHudDamageIndicator, Damage );
+	HOOK_HUD_MESSAGE(CHudDamageIndicator, Damage);
 }
 
 //-----------------------------------------------------------------------------
@@ -152,15 +152,15 @@ void CHudDamageIndicator::Init( void )
 // costly traversal.  Called per frame, return true if thinking and 
 // painting need to occur.
 //-----------------------------------------------------------------------------
-bool CHudDamageIndicator::ShouldDraw( void )
+bool CHudDamageIndicator::ShouldDraw(void)
 {
-	bool bNeedsDraw = m_DmgColorLeft[3] || 
-						m_DmgColorRight[3] || 
-						m_DmgHighColorLeft[3] || 
-						m_DmgHighColorRight[3] ||
-						m_DmgFullscreenColor[3];
+	bool bNeedsDraw = m_DmgColorLeft[3] ||
+		m_DmgColorRight[3] ||
+		m_DmgHighColorLeft[3] ||
+		m_DmgHighColorRight[3] ||
+		m_DmgFullscreenColor[3];
 
-	return ( bNeedsDraw && CHudElement::ShouldDraw() );
+	return (bNeedsDraw && CHudElement::ShouldDraw());
 }
 
 //-----------------------------------------------------------------------------
@@ -168,11 +168,11 @@ bool CHudDamageIndicator::ShouldDraw( void )
 //-----------------------------------------------------------------------------
 void CHudDamageIndicator::DrawDamageIndicator(int side)
 {
-	CMatRenderContextPtr pRenderContext( materials );
-	IMesh *pMesh = pRenderContext->GetDynamicMesh( true, NULL, NULL, m_WhiteAdditiveMaterial );
+	CMatRenderContextPtr pRenderContext(materials);
+	IMesh* pMesh = pRenderContext->GetDynamicMesh(true, NULL, NULL, m_WhiteAdditiveMaterial);
 
 	CMeshBuilder meshBuilder;
-	meshBuilder.Begin( pMesh, MATERIAL_QUADS, 1 );
+	meshBuilder.Begin(pMesh, MATERIAL_QUADS, 1);
 
 	int insetY = static_cast<int>((m_flDmgTall1 - m_flDmgTall2) / 2);
 
@@ -193,7 +193,7 @@ void CHudDamageIndicator::DrawDamageIndicator(int side)
 
 	// see if we're high damage
 	bool bHighDamage = false;
-	if ( m_DmgHighColorRight[3] > m_DmgColorRight[3] || m_DmgHighColorLeft[3] > m_DmgColorLeft[3] )
+	if (m_DmgHighColorRight[3] > m_DmgColorRight[3] || m_DmgHighColorLeft[3] > m_DmgColorLeft[3])
 	{
 		// make more of the screen be covered by damage
 		x1 = static_cast<int>(GetWide() * 0.0f);
@@ -212,7 +212,7 @@ void CHudDamageIndicator::DrawDamageIndicator(int side)
 	int r, g, b, a;
 	if (side == 1)
 	{
-		if ( bHighDamage )
+		if (bHighDamage)
 		{
 			r = static_cast<int>(m_DmgHighColorRight[0]);
 			g = static_cast<int>(m_DmgHighColorRight[1]);
@@ -231,29 +231,29 @@ void CHudDamageIndicator::DrawDamageIndicator(int side)
 		x1 = GetWide() - x1;
 		x2 = GetWide() - x2;
 
-		meshBuilder.Color4ub( r, g, b, a * alpha[0]);
-		meshBuilder.TexCoord2f( 0,0,0 );
-		meshBuilder.Position3f( x1, y[0], 0 );
+		meshBuilder.Color4ub(r, g, b, a * alpha[0]);
+		meshBuilder.TexCoord2f(0, 0, 0);
+		meshBuilder.Position3f(x1, y[0], 0);
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub( r, g, b, a * alpha[3] );
-		meshBuilder.TexCoord2f( 0,0,1 );
-		meshBuilder.Position3f( x1, y[3], 0 );
+		meshBuilder.Color4ub(r, g, b, a * alpha[3]);
+		meshBuilder.TexCoord2f(0, 0, 1);
+		meshBuilder.Position3f(x1, y[3], 0);
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub( r, g, b, a * alpha[2] );
-		meshBuilder.TexCoord2f( 0,1,1 );
-		meshBuilder.Position3f( x2, y[2], 0 );
+		meshBuilder.Color4ub(r, g, b, a * alpha[2]);
+		meshBuilder.TexCoord2f(0, 1, 1);
+		meshBuilder.Position3f(x2, y[2], 0);
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub( r, g, b, a * alpha[1] );
-		meshBuilder.TexCoord2f( 0,1,0 );
-		meshBuilder.Position3f( x2, y[1], 0 );
+		meshBuilder.Color4ub(r, g, b, a * alpha[1]);
+		meshBuilder.TexCoord2f(0, 1, 0);
+		meshBuilder.Position3f(x2, y[1], 0);
 		meshBuilder.AdvanceVertex();
 	}
 	else
 	{
-		if ( bHighDamage )
+		if (bHighDamage)
 		{
 			r = static_cast<int>(m_DmgHighColorLeft[0]);
 			g = static_cast<int>(m_DmgHighColorLeft[1]);
@@ -268,24 +268,24 @@ void CHudDamageIndicator::DrawDamageIndicator(int side)
 			a = static_cast<int>(m_DmgColorLeft[3]);
 		}
 
-		meshBuilder.Color4ub( r, g, b, a * alpha[0] );
-		meshBuilder.TexCoord2f( 0,0,0 );
-		meshBuilder.Position3f( x1, y[0], 0 );
+		meshBuilder.Color4ub(r, g, b, a * alpha[0]);
+		meshBuilder.TexCoord2f(0, 0, 0);
+		meshBuilder.Position3f(x1, y[0], 0);
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub( r, g, b, a * alpha[1] );
-		meshBuilder.TexCoord2f( 0,1,0 );
-		meshBuilder.Position3f( x2, y[1], 0 );
+		meshBuilder.Color4ub(r, g, b, a * alpha[1]);
+		meshBuilder.TexCoord2f(0, 1, 0);
+		meshBuilder.Position3f(x2, y[1], 0);
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub( r, g, b, a * alpha[2] );
-		meshBuilder.TexCoord2f( 0,1,1 );
-		meshBuilder.Position3f( x2, y[2], 0 );
+		meshBuilder.Color4ub(r, g, b, a * alpha[2]);
+		meshBuilder.TexCoord2f(0, 1, 1);
+		meshBuilder.Position3f(x2, y[2], 0);
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub( r, g, b, a * alpha[3] );
-		meshBuilder.TexCoord2f( 0,0,1 );
-		meshBuilder.Position3f( x1, y[3], 0 );
+		meshBuilder.Color4ub(r, g, b, a * alpha[3]);
+		meshBuilder.TexCoord2f(0, 0, 1);
+		meshBuilder.Position3f(x1, y[3], 0);
 		meshBuilder.AdvanceVertex();
 	}
 
@@ -298,33 +298,33 @@ void CHudDamageIndicator::DrawDamageIndicator(int side)
 //-----------------------------------------------------------------------------
 void CHudDamageIndicator::DrawFullscreenDamageIndicator()
 {
-	CMatRenderContextPtr pRenderContext( materials );
-	IMesh *pMesh = pRenderContext->GetDynamicMesh( true, NULL, NULL, m_WhiteAdditiveMaterial );
+	CMatRenderContextPtr pRenderContext(materials);
+	IMesh* pMesh = pRenderContext->GetDynamicMesh(true, NULL, NULL, m_WhiteAdditiveMaterial);
 
 	CMeshBuilder meshBuilder;
-	meshBuilder.Begin( pMesh, MATERIAL_QUADS, 1 );
+	meshBuilder.Begin(pMesh, MATERIAL_QUADS, 1);
 	int r = m_DmgFullscreenColor[0], g = m_DmgFullscreenColor[1], b = m_DmgFullscreenColor[2], a = m_DmgFullscreenColor[3];
 
 	float wide = GetWide(), tall = GetTall();
 
-	meshBuilder.Color4ub( r, g, b, a );
-	meshBuilder.TexCoord2f( 0,0,0 );
-	meshBuilder.Position3f( 0.0f, 0.0f, 0 );
+	meshBuilder.Color4ub(r, g, b, a);
+	meshBuilder.TexCoord2f(0, 0, 0);
+	meshBuilder.Position3f(0.0f, 0.0f, 0);
 	meshBuilder.AdvanceVertex();
 
-	meshBuilder.Color4ub( r, g, b, a );
-	meshBuilder.TexCoord2f( 0,1,0 );
-	meshBuilder.Position3f( wide, 0.0f, 0 );
+	meshBuilder.Color4ub(r, g, b, a);
+	meshBuilder.TexCoord2f(0, 1, 0);
+	meshBuilder.Position3f(wide, 0.0f, 0);
 	meshBuilder.AdvanceVertex();
 
-	meshBuilder.Color4ub( r, g, b, a );
-	meshBuilder.TexCoord2f( 0,1,1 );
-	meshBuilder.Position3f( wide, tall, 0 );
+	meshBuilder.Color4ub(r, g, b, a);
+	meshBuilder.TexCoord2f(0, 1, 1);
+	meshBuilder.Position3f(wide, tall, 0);
 	meshBuilder.AdvanceVertex();
 
-	meshBuilder.Color4ub( r, g, b, a );
-	meshBuilder.TexCoord2f( 0,0,1 );
-	meshBuilder.Position3f( 0.0f, tall, 0 );
+	meshBuilder.Color4ub(r, g, b, a);
+	meshBuilder.TexCoord2f(0, 0, 1);
+	meshBuilder.Position3f(0.0f, tall, 0);
 	meshBuilder.AdvanceVertex();
 
 	meshBuilder.End();
@@ -347,7 +347,7 @@ void CHudDamageIndicator::Paint()
 //-----------------------------------------------------------------------------
 // Purpose: Message handler for Damage message
 //-----------------------------------------------------------------------------
-void CHudDamageIndicator::MsgFunc_Damage( bf_read &msg )
+void CHudDamageIndicator::MsgFunc_Damage(bf_read& msg)
 {
 	int armor = msg.ReadByte();	// armor
 	int damageTaken = msg.ReadByte();	// health
@@ -359,21 +359,67 @@ void CHudDamageIndicator::MsgFunc_Damage( bf_read &msg )
 	vecFrom.y = msg.ReadFloat();
 	vecFrom.z = msg.ReadFloat();
 
-	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
-	if ( !pPlayer )
+	C_BasePlayer* pPlayer = C_BasePlayer::GetLocalPlayer();
+	if (!pPlayer)
 		return;
 
-	// player has just died, return
-	if ( pPlayer->GetHealth() <= 0 )
+	// player has just died, just run the dead damage animation
+	if (pPlayer->GetHealth() <= 0)
 	{
+		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("HudPlayerDeath");
 		return;
 	}
 
-	if ( damageTaken > 0 || armor > 0 )
+	// ignore damage without direction
+	// this should never happen, unless it's drowning damage, 
+	// or the player is forcibly killed, handled above
+	if (vecFrom == vec3_origin && !(bitsDamage & DMG_DROWN))
+		return;
+
+	Vector vecDelta = (vecFrom - MainViewOrigin());
+	VectorNormalize(vecDelta);
+
+	int highDamage = DAMAGE_LOW;
+	if (damageTaken > 25)
 	{
+		highDamage = DAMAGE_HIGH;
+	}
+
+	// if we have no suit, all damage is high
+	if (!pPlayer->IsSuitEquipped())
+	{
+		highDamage = DAMAGE_HIGH;
+	}
+
+	if (damageTaken > 0 || armor > 0)
+	{
+		// see which quandrant the effect is in
+		float angle;
+		GetDamagePosition(vecDelta, &angle);
+
 		// see which effect to play
-		if (bitsDamage & DMG_BULLET || bitsDamage & DMG_SLASH || bitsDamage & DMG_CLUB) {
-			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("HudTakeDamageFront");
+		DamageAnimation_t* dmgAnim = g_DamageAnimations;
+		for (; dmgAnim->name != NULL; ++dmgAnim)
+		{
+			if (dmgAnim->bitsDamage && !(bitsDamage & dmgAnim->bitsDamage))
+				continue;
+
+			if (dmgAnim->angleMinimum && angle < dmgAnim->angleMinimum)
+				continue;
+
+			if (dmgAnim->angleMaximum && angle > dmgAnim->angleMaximum)
+				continue;
+
+			if (dmgAnim->damage && dmgAnim->damage != highDamage)
+				continue;
+
+			// we have a match, break
+			break;
+		}
+
+		if (dmgAnim->name)
+		{
+			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence(dmgAnim->name);
 		}
 	}
 }
@@ -381,7 +427,7 @@ void CHudDamageIndicator::MsgFunc_Damage( bf_read &msg )
 //-----------------------------------------------------------------------------
 // Purpose: Convert a damage position in world units to the screen's units
 //-----------------------------------------------------------------------------
-void CHudDamageIndicator::GetDamagePosition( const Vector &vecDelta, float *flRotation )
+void CHudDamageIndicator::GetDamagePosition(const Vector& vecDelta, float* flRotation)
 {
 	float flRadius = 360.0f;
 
@@ -389,11 +435,11 @@ void CHudDamageIndicator::GetDamagePosition( const Vector &vecDelta, float *flRo
 	Vector playerPosition = MainViewOrigin();
 	QAngle playerAngles = MainViewAngles();
 
-	Vector forward, right, up(0,0,1);
-	AngleVectors (playerAngles, &forward, NULL, NULL );
+	Vector forward, right, up(0, 0, 1);
+	AngleVectors(playerAngles, &forward, NULL, NULL);
 	forward.z = 0;
 	VectorNormalize(forward);
-	CrossProduct( up, forward, right );
+	CrossProduct(up, forward, right);
 	float front = DotProduct(vecDelta, forward);
 	float side = DotProduct(vecDelta, right);
 	float xpos = flRadius * -side;
@@ -404,9 +450,9 @@ void CHudDamageIndicator::GetDamagePosition( const Vector &vecDelta, float *flRo
 	*flRotation *= 180 / M_PI;
 
 	float yawRadians = -(*flRotation) * M_PI / 180.0f;
-	float ca = cos( yawRadians );
-	float sa = sin( yawRadians );
-				 
+	float ca = cos(yawRadians);
+	float sa = sin(yawRadians);
+
 	// Rotate it around the circle
 	xpos = (int)((GetWide() / 2) + (flRadius * sa));
 	ypos = (int)((GetTall() / 2) - (flRadius * ca));
@@ -415,17 +461,17 @@ void CHudDamageIndicator::GetDamagePosition( const Vector &vecDelta, float *flRo
 //-----------------------------------------------------------------------------
 // Purpose: hud scheme settings
 //-----------------------------------------------------------------------------
-void CHudDamageIndicator::ApplySchemeSettings(vgui::IScheme *pScheme)
+void CHudDamageIndicator::ApplySchemeSettings(vgui::IScheme* pScheme)
 {
 	BaseClass::ApplySchemeSettings(pScheme);
 	SetPaintBackgroundEnabled(false);
 
 	int vx, vy, vw, vh;
-	vgui::surface()->GetFullscreenViewport( vx, vy, vw, vh );
+	vgui::surface()->GetFullscreenViewport(vx, vy, vw, vh);
 
-	SetForceStereoRenderToFrameBuffer( true );
+	SetForceStereoRenderToFrameBuffer(true);
 
-	if( UseVR() )
+	if (UseVR())
 	{
 		m_flDmgY = 0.125f * (float)vh;
 		m_flDmgTall1 = 0.625f * (float)vh;

--- a/mp/src/game/client/hl2/hud_damageindicator.cpp
+++ b/mp/src/game/client/hl2/hud_damageindicator.cpp
@@ -33,45 +33,45 @@ using namespace vgui;
 //-----------------------------------------------------------------------------
 class CHudDamageIndicator : public CHudElement, public vgui::Panel
 {
-	DECLARE_CLASS_SIMPLE(CHudDamageIndicator, vgui::Panel);
+	DECLARE_CLASS_SIMPLE( CHudDamageIndicator, vgui::Panel );
 
 public:
-	CHudDamageIndicator(const char* pElementName);
-	void Init(void);
-	void Reset(void);
-	virtual bool ShouldDraw(void);
+	CHudDamageIndicator( const char *pElementName );
+	void Init( void );
+	void Reset( void );
+	virtual bool ShouldDraw( void );
 
 	// Handler for our message
-	void MsgFunc_Damage(bf_read& msg);
+	void MsgFunc_Damage( bf_read &msg );
 
 private:
 	virtual void Paint();
-	virtual void ApplySchemeSettings(vgui::IScheme* pScheme);
+	virtual void ApplySchemeSettings(vgui::IScheme *pScheme);
 
 private:
-	CPanelAnimationVarAliasType(float, m_flDmgX, "dmg_xpos", "10", "proportional_float");
-	CPanelAnimationVarAliasType(float, m_flDmgY, "dmg_ypos", "80", "proportional_float");
-	CPanelAnimationVarAliasType(float, m_flDmgWide, "dmg_wide", "30", "proportional_float");
-	CPanelAnimationVarAliasType(float, m_flDmgTall1, "dmg_tall1", "300", "proportional_float");
-	CPanelAnimationVarAliasType(float, m_flDmgTall2, "dmg_tall2", "240", "proportional_float");
+	CPanelAnimationVarAliasType( float, m_flDmgX, "dmg_xpos", "10", "proportional_float" );
+	CPanelAnimationVarAliasType( float, m_flDmgY, "dmg_ypos", "80", "proportional_float" );
+	CPanelAnimationVarAliasType( float, m_flDmgWide, "dmg_wide", "30", "proportional_float" );
+	CPanelAnimationVarAliasType( float, m_flDmgTall1, "dmg_tall1", "300", "proportional_float" );
+	CPanelAnimationVarAliasType( float, m_flDmgTall2, "dmg_tall2", "240", "proportional_float" );
 
-	CPanelAnimationVar(Color, m_DmgColorLeft, "DmgColorLeft", "255 0 0 0");
-	CPanelAnimationVar(Color, m_DmgColorRight, "DmgColorRight", "255 0 0 0");
+	CPanelAnimationVar( Color, m_DmgColorLeft, "DmgColorLeft", "255 0 0 0" );
+	CPanelAnimationVar( Color, m_DmgColorRight, "DmgColorRight", "255 0 0 0" );
 
-	CPanelAnimationVar(Color, m_DmgHighColorLeft, "DmgHighColorLeft", "255 0 0 0");
-	CPanelAnimationVar(Color, m_DmgHighColorRight, "DmgHighColorRight", "255 0 0 0");
+	CPanelAnimationVar( Color, m_DmgHighColorLeft, "DmgHighColorLeft", "255 0 0 0" );
+	CPanelAnimationVar( Color, m_DmgHighColorRight, "DmgHighColorRight", "255 0 0 0" );
 
-	CPanelAnimationVar(Color, m_DmgFullscreenColor, "DmgFullscreenColor", "255 0 0 0");
+	CPanelAnimationVar( Color, m_DmgFullscreenColor, "DmgFullscreenColor", "255 0 0 0" );
 
 	void DrawDamageIndicator(int side);
 	void DrawFullscreenDamageIndicator();
-	void GetDamagePosition(const Vector& vecDelta, float* flRotation);
+	void GetDamagePosition( const Vector &vecDelta, float *flRotation );
 
 	CMaterialReference m_WhiteAdditiveMaterial;
 };
 
-DECLARE_HUDELEMENT(CHudDamageIndicator);
-DECLARE_HUD_MESSAGE(CHudDamageIndicator, Damage);
+DECLARE_HUDELEMENT( CHudDamageIndicator );
+DECLARE_HUD_MESSAGE( CHudDamageIndicator, Damage );
 
 enum
 {
@@ -85,11 +85,11 @@ enum
 
 struct DamageAnimation_t
 {
-	const char* name;
+	const char *name;
 	int bitsDamage;
 	float angleMinimum;
 	float angleMaximum;
-	int damage;
+	int damage; 
 };
 
 //-----------------------------------------------------------------------------
@@ -106,7 +106,7 @@ static DamageAnimation_t g_DamageAnimations[] =
 	{ "HudTakeDamageHighLeft",	DMG_ANY,	45.0f,		135.0f,		DAMAGE_HIGH },
 	{ "HudTakeDamageHighRight",	DMG_ANY,	225.0f,		315.0f,		DAMAGE_HIGH },
 	{ "HudTakeDamageHigh",		DMG_ANY,	ANGLE_ANY,	ANGLE_ANY,	DAMAGE_HIGH },
-
+	
 	{ "HudTakeDamageLeft",		DMG_ANY,	45.0f,		135.0f,		DAMAGE_ANY },
 	{ "HudTakeDamageRight",		DMG_ANY,	225.0f,		315.0f,		DAMAGE_ANY },
 	{ "HudTakeDamageBehind",	DMG_ANY,	135.0f,		225.0f,		DAMAGE_ANY },
@@ -120,20 +120,20 @@ static DamageAnimation_t g_DamageAnimations[] =
 //-----------------------------------------------------------------------------
 // Purpose: Constructor
 //-----------------------------------------------------------------------------
-CHudDamageIndicator::CHudDamageIndicator(const char* pElementName) : CHudElement(pElementName), BaseClass(NULL, "HudDamageIndicator")
+CHudDamageIndicator::CHudDamageIndicator( const char *pElementName ) : CHudElement( pElementName ), BaseClass(NULL, "HudDamageIndicator")
 {
-	vgui::Panel* pParent = g_pClientMode->GetViewport();
-	SetParent(pParent);
+	vgui::Panel *pParent = g_pClientMode->GetViewport();
+	SetParent( pParent );
 
-	m_WhiteAdditiveMaterial.Init("vgui/white_additive", TEXTURE_GROUP_VGUI);
-
-	SetHiddenBits(HIDEHUD_HEALTH);
+	m_WhiteAdditiveMaterial.Init( "vgui/white_additive", TEXTURE_GROUP_VGUI ); 
+	
+	SetHiddenBits( HIDEHUD_HEALTH );
 }
 
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CHudDamageIndicator::Reset(void)
+void CHudDamageIndicator::Reset( void )
 {
 	m_DmgColorLeft[3] = 0;
 	m_DmgColorRight[3] = 0;
@@ -142,9 +142,9 @@ void CHudDamageIndicator::Reset(void)
 	m_DmgFullscreenColor[3] = 0;
 }
 
-void CHudDamageIndicator::Init(void)
+void CHudDamageIndicator::Init( void )
 {
-	HOOK_HUD_MESSAGE(CHudDamageIndicator, Damage);
+	HOOK_HUD_MESSAGE( CHudDamageIndicator, Damage );
 }
 
 //-----------------------------------------------------------------------------
@@ -152,15 +152,15 @@ void CHudDamageIndicator::Init(void)
 // costly traversal.  Called per frame, return true if thinking and 
 // painting need to occur.
 //-----------------------------------------------------------------------------
-bool CHudDamageIndicator::ShouldDraw(void)
+bool CHudDamageIndicator::ShouldDraw( void )
 {
-	bool bNeedsDraw = m_DmgColorLeft[3] ||
-		m_DmgColorRight[3] ||
-		m_DmgHighColorLeft[3] ||
-		m_DmgHighColorRight[3] ||
-		m_DmgFullscreenColor[3];
+	bool bNeedsDraw = m_DmgColorLeft[3] || 
+						m_DmgColorRight[3] || 
+						m_DmgHighColorLeft[3] || 
+						m_DmgHighColorRight[3] ||
+						m_DmgFullscreenColor[3];
 
-	return (bNeedsDraw && CHudElement::ShouldDraw());
+	return ( bNeedsDraw && CHudElement::ShouldDraw() );
 }
 
 //-----------------------------------------------------------------------------
@@ -168,11 +168,11 @@ bool CHudDamageIndicator::ShouldDraw(void)
 //-----------------------------------------------------------------------------
 void CHudDamageIndicator::DrawDamageIndicator(int side)
 {
-	CMatRenderContextPtr pRenderContext(materials);
-	IMesh* pMesh = pRenderContext->GetDynamicMesh(true, NULL, NULL, m_WhiteAdditiveMaterial);
+	CMatRenderContextPtr pRenderContext( materials );
+	IMesh *pMesh = pRenderContext->GetDynamicMesh( true, NULL, NULL, m_WhiteAdditiveMaterial );
 
 	CMeshBuilder meshBuilder;
-	meshBuilder.Begin(pMesh, MATERIAL_QUADS, 1);
+	meshBuilder.Begin( pMesh, MATERIAL_QUADS, 1 );
 
 	int insetY = static_cast<int>((m_flDmgTall1 - m_flDmgTall2) / 2);
 
@@ -193,7 +193,7 @@ void CHudDamageIndicator::DrawDamageIndicator(int side)
 
 	// see if we're high damage
 	bool bHighDamage = false;
-	if (m_DmgHighColorRight[3] > m_DmgColorRight[3] || m_DmgHighColorLeft[3] > m_DmgColorLeft[3])
+	if ( m_DmgHighColorRight[3] > m_DmgColorRight[3] || m_DmgHighColorLeft[3] > m_DmgColorLeft[3] )
 	{
 		// make more of the screen be covered by damage
 		x1 = static_cast<int>(GetWide() * 0.0f);
@@ -212,7 +212,7 @@ void CHudDamageIndicator::DrawDamageIndicator(int side)
 	int r, g, b, a;
 	if (side == 1)
 	{
-		if (bHighDamage)
+		if ( bHighDamage )
 		{
 			r = static_cast<int>(m_DmgHighColorRight[0]);
 			g = static_cast<int>(m_DmgHighColorRight[1]);
@@ -231,29 +231,29 @@ void CHudDamageIndicator::DrawDamageIndicator(int side)
 		x1 = GetWide() - x1;
 		x2 = GetWide() - x2;
 
-		meshBuilder.Color4ub(r, g, b, a * alpha[0]);
-		meshBuilder.TexCoord2f(0, 0, 0);
-		meshBuilder.Position3f(x1, y[0], 0);
+		meshBuilder.Color4ub( r, g, b, a * alpha[0]);
+		meshBuilder.TexCoord2f( 0,0,0 );
+		meshBuilder.Position3f( x1, y[0], 0 );
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub(r, g, b, a * alpha[3]);
-		meshBuilder.TexCoord2f(0, 0, 1);
-		meshBuilder.Position3f(x1, y[3], 0);
+		meshBuilder.Color4ub( r, g, b, a * alpha[3] );
+		meshBuilder.TexCoord2f( 0,0,1 );
+		meshBuilder.Position3f( x1, y[3], 0 );
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub(r, g, b, a * alpha[2]);
-		meshBuilder.TexCoord2f(0, 1, 1);
-		meshBuilder.Position3f(x2, y[2], 0);
+		meshBuilder.Color4ub( r, g, b, a * alpha[2] );
+		meshBuilder.TexCoord2f( 0,1,1 );
+		meshBuilder.Position3f( x2, y[2], 0 );
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub(r, g, b, a * alpha[1]);
-		meshBuilder.TexCoord2f(0, 1, 0);
-		meshBuilder.Position3f(x2, y[1], 0);
+		meshBuilder.Color4ub( r, g, b, a * alpha[1] );
+		meshBuilder.TexCoord2f( 0,1,0 );
+		meshBuilder.Position3f( x2, y[1], 0 );
 		meshBuilder.AdvanceVertex();
 	}
 	else
 	{
-		if (bHighDamage)
+		if ( bHighDamage )
 		{
 			r = static_cast<int>(m_DmgHighColorLeft[0]);
 			g = static_cast<int>(m_DmgHighColorLeft[1]);
@@ -268,24 +268,24 @@ void CHudDamageIndicator::DrawDamageIndicator(int side)
 			a = static_cast<int>(m_DmgColorLeft[3]);
 		}
 
-		meshBuilder.Color4ub(r, g, b, a * alpha[0]);
-		meshBuilder.TexCoord2f(0, 0, 0);
-		meshBuilder.Position3f(x1, y[0], 0);
+		meshBuilder.Color4ub( r, g, b, a * alpha[0] );
+		meshBuilder.TexCoord2f( 0,0,0 );
+		meshBuilder.Position3f( x1, y[0], 0 );
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub(r, g, b, a * alpha[1]);
-		meshBuilder.TexCoord2f(0, 1, 0);
-		meshBuilder.Position3f(x2, y[1], 0);
+		meshBuilder.Color4ub( r, g, b, a * alpha[1] );
+		meshBuilder.TexCoord2f( 0,1,0 );
+		meshBuilder.Position3f( x2, y[1], 0 );
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub(r, g, b, a * alpha[2]);
-		meshBuilder.TexCoord2f(0, 1, 1);
-		meshBuilder.Position3f(x2, y[2], 0);
+		meshBuilder.Color4ub( r, g, b, a * alpha[2] );
+		meshBuilder.TexCoord2f( 0,1,1 );
+		meshBuilder.Position3f( x2, y[2], 0 );
 		meshBuilder.AdvanceVertex();
 
-		meshBuilder.Color4ub(r, g, b, a * alpha[3]);
-		meshBuilder.TexCoord2f(0, 0, 1);
-		meshBuilder.Position3f(x1, y[3], 0);
+		meshBuilder.Color4ub( r, g, b, a * alpha[3] );
+		meshBuilder.TexCoord2f( 0,0,1 );
+		meshBuilder.Position3f( x1, y[3], 0 );
 		meshBuilder.AdvanceVertex();
 	}
 
@@ -298,33 +298,33 @@ void CHudDamageIndicator::DrawDamageIndicator(int side)
 //-----------------------------------------------------------------------------
 void CHudDamageIndicator::DrawFullscreenDamageIndicator()
 {
-	CMatRenderContextPtr pRenderContext(materials);
-	IMesh* pMesh = pRenderContext->GetDynamicMesh(true, NULL, NULL, m_WhiteAdditiveMaterial);
+	CMatRenderContextPtr pRenderContext( materials );
+	IMesh *pMesh = pRenderContext->GetDynamicMesh( true, NULL, NULL, m_WhiteAdditiveMaterial );
 
 	CMeshBuilder meshBuilder;
-	meshBuilder.Begin(pMesh, MATERIAL_QUADS, 1);
+	meshBuilder.Begin( pMesh, MATERIAL_QUADS, 1 );
 	int r = m_DmgFullscreenColor[0], g = m_DmgFullscreenColor[1], b = m_DmgFullscreenColor[2], a = m_DmgFullscreenColor[3];
 
 	float wide = GetWide(), tall = GetTall();
 
-	meshBuilder.Color4ub(r, g, b, a);
-	meshBuilder.TexCoord2f(0, 0, 0);
-	meshBuilder.Position3f(0.0f, 0.0f, 0);
+	meshBuilder.Color4ub( r, g, b, a );
+	meshBuilder.TexCoord2f( 0,0,0 );
+	meshBuilder.Position3f( 0.0f, 0.0f, 0 );
 	meshBuilder.AdvanceVertex();
 
-	meshBuilder.Color4ub(r, g, b, a);
-	meshBuilder.TexCoord2f(0, 1, 0);
-	meshBuilder.Position3f(wide, 0.0f, 0);
+	meshBuilder.Color4ub( r, g, b, a );
+	meshBuilder.TexCoord2f( 0,1,0 );
+	meshBuilder.Position3f( wide, 0.0f, 0 );
 	meshBuilder.AdvanceVertex();
 
-	meshBuilder.Color4ub(r, g, b, a);
-	meshBuilder.TexCoord2f(0, 1, 1);
-	meshBuilder.Position3f(wide, tall, 0);
+	meshBuilder.Color4ub( r, g, b, a );
+	meshBuilder.TexCoord2f( 0,1,1 );
+	meshBuilder.Position3f( wide, tall, 0 );
 	meshBuilder.AdvanceVertex();
 
-	meshBuilder.Color4ub(r, g, b, a);
-	meshBuilder.TexCoord2f(0, 0, 1);
-	meshBuilder.Position3f(0.0f, tall, 0);
+	meshBuilder.Color4ub( r, g, b, a );
+	meshBuilder.TexCoord2f( 0,0,1 );
+	meshBuilder.Position3f( 0.0f, tall, 0 );
 	meshBuilder.AdvanceVertex();
 
 	meshBuilder.End();
@@ -347,7 +347,7 @@ void CHudDamageIndicator::Paint()
 //-----------------------------------------------------------------------------
 // Purpose: Message handler for Damage message
 //-----------------------------------------------------------------------------
-void CHudDamageIndicator::MsgFunc_Damage(bf_read& msg)
+void CHudDamageIndicator::MsgFunc_Damage( bf_read &msg )
 {
 	int armor = msg.ReadByte();	// armor
 	int damageTaken = msg.ReadByte();	// health
@@ -359,67 +359,67 @@ void CHudDamageIndicator::MsgFunc_Damage(bf_read& msg)
 	vecFrom.y = msg.ReadFloat();
 	vecFrom.z = msg.ReadFloat();
 
-	C_BasePlayer* pPlayer = C_BasePlayer::GetLocalPlayer();
-	if (!pPlayer)
+	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+	if ( !pPlayer )
 		return;
 
 	// player has just died, just run the dead damage animation
-	if (pPlayer->GetHealth() <= 0)
+	if ( pPlayer->GetHealth() <= 0 )
 	{
-		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("HudPlayerDeath");
+		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HudPlayerDeath" );
 		return;
 	}
 
 	// ignore damage without direction
 	// this should never happen, unless it's drowning damage, 
 	// or the player is forcibly killed, handled above
-	if (vecFrom == vec3_origin && !(bitsDamage & DMG_DROWN))
+	if ( vecFrom == vec3_origin && !(bitsDamage & DMG_DROWN))
 		return;
 
 	Vector vecDelta = (vecFrom - MainViewOrigin());
-	VectorNormalize(vecDelta);
+	VectorNormalize( vecDelta );
 
 	int highDamage = DAMAGE_LOW;
-	if (damageTaken > 25)
+	if ( damageTaken > 25 )
 	{
 		highDamage = DAMAGE_HIGH;
 	}
 
 	// if we have no suit, all damage is high
-	if (!pPlayer->IsSuitEquipped())
+	if ( !pPlayer->IsSuitEquipped() )
 	{
 		highDamage = DAMAGE_HIGH;
 	}
 
-	if (damageTaken > 0 || armor > 0)
+	if ( damageTaken > 0 || armor > 0 )
 	{
 		// see which quandrant the effect is in
 		float angle;
-		GetDamagePosition(vecDelta, &angle);
+		GetDamagePosition( vecDelta, &angle );
 
 		// see which effect to play
-		DamageAnimation_t* dmgAnim = g_DamageAnimations;
-		for (; dmgAnim->name != NULL; ++dmgAnim)
+		DamageAnimation_t *dmgAnim = g_DamageAnimations;
+		for ( ; dmgAnim->name != NULL; ++dmgAnim )
 		{
-			if (dmgAnim->bitsDamage && !(bitsDamage & dmgAnim->bitsDamage))
+			if ( dmgAnim->bitsDamage && !(bitsDamage & dmgAnim->bitsDamage) )
 				continue;
 
-			if (dmgAnim->angleMinimum && angle < dmgAnim->angleMinimum)
+			if ( dmgAnim->angleMinimum && angle < dmgAnim->angleMinimum )
 				continue;
 
-			if (dmgAnim->angleMaximum && angle > dmgAnim->angleMaximum)
+			if ( dmgAnim->angleMaximum && angle > dmgAnim->angleMaximum )
 				continue;
 
-			if (dmgAnim->damage && dmgAnim->damage != highDamage)
+			if ( dmgAnim->damage && dmgAnim->damage != highDamage )
 				continue;
 
 			// we have a match, break
 			break;
 		}
 
-		if (dmgAnim->name)
+		if ( dmgAnim->name )
 		{
-			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence(dmgAnim->name);
+			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( dmgAnim->name );
 		}
 	}
 }
@@ -427,7 +427,7 @@ void CHudDamageIndicator::MsgFunc_Damage(bf_read& msg)
 //-----------------------------------------------------------------------------
 // Purpose: Convert a damage position in world units to the screen's units
 //-----------------------------------------------------------------------------
-void CHudDamageIndicator::GetDamagePosition(const Vector& vecDelta, float* flRotation)
+void CHudDamageIndicator::GetDamagePosition( const Vector &vecDelta, float *flRotation )
 {
 	float flRadius = 360.0f;
 
@@ -435,11 +435,11 @@ void CHudDamageIndicator::GetDamagePosition(const Vector& vecDelta, float* flRot
 	Vector playerPosition = MainViewOrigin();
 	QAngle playerAngles = MainViewAngles();
 
-	Vector forward, right, up(0, 0, 1);
-	AngleVectors(playerAngles, &forward, NULL, NULL);
+	Vector forward, right, up(0,0,1);
+	AngleVectors (playerAngles, &forward, NULL, NULL );
 	forward.z = 0;
 	VectorNormalize(forward);
-	CrossProduct(up, forward, right);
+	CrossProduct( up, forward, right );
 	float front = DotProduct(vecDelta, forward);
 	float side = DotProduct(vecDelta, right);
 	float xpos = flRadius * -side;
@@ -450,9 +450,9 @@ void CHudDamageIndicator::GetDamagePosition(const Vector& vecDelta, float* flRot
 	*flRotation *= 180 / M_PI;
 
 	float yawRadians = -(*flRotation) * M_PI / 180.0f;
-	float ca = cos(yawRadians);
-	float sa = sin(yawRadians);
-
+	float ca = cos( yawRadians );
+	float sa = sin( yawRadians );
+				 
 	// Rotate it around the circle
 	xpos = (int)((GetWide() / 2) + (flRadius * sa));
 	ypos = (int)((GetTall() / 2) - (flRadius * ca));
@@ -461,17 +461,17 @@ void CHudDamageIndicator::GetDamagePosition(const Vector& vecDelta, float* flRot
 //-----------------------------------------------------------------------------
 // Purpose: hud scheme settings
 //-----------------------------------------------------------------------------
-void CHudDamageIndicator::ApplySchemeSettings(vgui::IScheme* pScheme)
+void CHudDamageIndicator::ApplySchemeSettings(vgui::IScheme *pScheme)
 {
 	BaseClass::ApplySchemeSettings(pScheme);
 	SetPaintBackgroundEnabled(false);
 
 	int vx, vy, vw, vh;
-	vgui::surface()->GetFullscreenViewport(vx, vy, vw, vh);
+	vgui::surface()->GetFullscreenViewport( vx, vy, vw, vh );
 
-	SetForceStereoRenderToFrameBuffer(true);
+	SetForceStereoRenderToFrameBuffer( true );
 
-	if (UseVR())
+	if( UseVR() )
 	{
 		m_flDmgY = 0.125f * (float)vh;
 		m_flDmgTall1 = 0.625f * (float)vh;

--- a/mp/src/game/client/neo/ui/neo_hud_damage_indicator.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_damage_indicator.cpp
@@ -1,0 +1,205 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose: 
+//
+//=============================================================================//
+
+#include "cbase.h"
+#include "hud.h"
+#include "text_message.h"
+#include "hud_macros.h"
+#include "iclientmode.h"
+#include "view.h"
+#include <KeyValues.h>
+#include <vgui_controls/AnimationController.h>
+#include <vgui/ISurface.h>
+#include "VGuiMatSurface/IMatSystemSurface.h"
+#include "materialsystem/imaterial.h"
+#include "materialsystem/imesh.h"
+#include "materialsystem/imaterialvar.h"
+#include "IEffects.h"
+#include "hudelement.h"
+#include "clienteffectprecachesystem.h"
+#include "sourcevr/isourcevirtualreality.h"
+
+using namespace vgui;
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: HDU Damage indication
+//-----------------------------------------------------------------------------
+class CNEOHudDamageIndicator : public CHudElement, public vgui::Panel
+{
+	DECLARE_CLASS_SIMPLE(CNEOHudDamageIndicator, vgui::Panel);
+
+public:
+	CNEOHudDamageIndicator(const char* pElementName);
+	void Init(void);
+	void Reset(void);
+	virtual bool ShouldDraw(void);
+
+	// Handler for our message
+	void MsgFunc_Damage(bf_read& msg);
+
+private:
+	virtual void Paint();
+	virtual void ApplySchemeSettings(vgui::IScheme* pScheme);
+
+private:
+	CPanelAnimationVarAliasType(float, m_flDmgX, "dmg_xpos", "10", "proportional_float");
+	CPanelAnimationVarAliasType(float, m_flDmgY, "dmg_ypos", "80", "proportional_float");
+	CPanelAnimationVarAliasType(float, m_flDmgWide, "dmg_wide", "30", "proportional_float");
+	CPanelAnimationVarAliasType(float, m_flDmgTall1, "dmg_tall1", "300", "proportional_float");
+	CPanelAnimationVarAliasType(float, m_flDmgTall2, "dmg_tall2", "240", "proportional_float");
+
+	CPanelAnimationVar(Color, m_DmgFullscreenColor, "DmgFullscreenColor", "255 88 0 25");
+
+	void DrawFullscreenDamageIndicator();
+
+	CMaterialReference m_WhiteAdditiveMaterial;
+};
+
+DECLARE_HUDELEMENT(CNEOHudDamageIndicator);
+DECLARE_HUD_MESSAGE(CNEOHudDamageIndicator, Damage);
+
+struct DamageAnimation_t
+{
+	const char* name;
+	int bitsDamage;
+	int damage;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Constructor
+//-----------------------------------------------------------------------------
+CNEOHudDamageIndicator::CNEOHudDamageIndicator(const char* pElementName) : CHudElement(pElementName), BaseClass(NULL, "HudDamageIndicator")
+{
+	vgui::Panel* pParent = g_pClientMode->GetViewport();
+	SetParent(pParent);
+
+	m_WhiteAdditiveMaterial.Init("vgui/white_additive", TEXTURE_GROUP_VGUI);
+
+	SetHiddenBits(HIDEHUD_HEALTH);
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CNEOHudDamageIndicator::Reset(void)
+{
+	m_DmgFullscreenColor[3] = 0;
+}
+
+void CNEOHudDamageIndicator::Init(void)
+{
+	HOOK_HUD_MESSAGE(CNEOHudDamageIndicator, Damage);
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Save CPU cycles by letting the HUD system early cull
+// costly traversal.  Called per frame, return true if thinking and 
+// painting need to occur.
+//-----------------------------------------------------------------------------
+bool CNEOHudDamageIndicator::ShouldDraw(void)
+{
+	bool bNeedsDraw = m_DmgFullscreenColor[3];
+
+	return (bNeedsDraw && CHudElement::ShouldDraw());
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Draws full screen damage fade
+//-----------------------------------------------------------------------------
+void CNEOHudDamageIndicator::DrawFullscreenDamageIndicator()
+{
+	CMatRenderContextPtr pRenderContext(materials);
+	IMesh* pMesh = pRenderContext->GetDynamicMesh(true, NULL, NULL, m_WhiteAdditiveMaterial);
+
+	CMeshBuilder meshBuilder;
+	meshBuilder.Begin(pMesh, MATERIAL_QUADS, 1);
+	int r = m_DmgFullscreenColor[0], g = m_DmgFullscreenColor[1], b = m_DmgFullscreenColor[2], a = m_DmgFullscreenColor[3];
+
+	float wide = GetWide(), tall = GetTall();
+
+	meshBuilder.Color4ub(r, g, b, a);
+	meshBuilder.TexCoord2f(0, 0, 0);
+	meshBuilder.Position3f(0.0f, 0.0f, 0);
+	meshBuilder.AdvanceVertex();
+
+	meshBuilder.Color4ub(r, g, b, a);
+	meshBuilder.TexCoord2f(0, 1, 0);
+	meshBuilder.Position3f(wide, 0.0f, 0);
+	meshBuilder.AdvanceVertex();
+
+	meshBuilder.Color4ub(r, g, b, a);
+	meshBuilder.TexCoord2f(0, 1, 1);
+	meshBuilder.Position3f(wide, tall, 0);
+	meshBuilder.AdvanceVertex();
+
+	meshBuilder.Color4ub(r, g, b, a);
+	meshBuilder.TexCoord2f(0, 0, 1);
+	meshBuilder.Position3f(0.0f, tall, 0);
+	meshBuilder.AdvanceVertex();
+
+	meshBuilder.End();
+	pMesh->Draw();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Paints the damage display
+//-----------------------------------------------------------------------------
+void CNEOHudDamageIndicator::Paint()
+{
+	// draw fullscreen damage indicators
+	DrawFullscreenDamageIndicator();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Message handler for Damage message
+//-----------------------------------------------------------------------------
+void CNEOHudDamageIndicator::MsgFunc_Damage(bf_read& msg)
+{
+	int armor = msg.ReadByte();	// armor
+	int damageTaken = msg.ReadByte();	// health
+	long bitsDamage = msg.ReadLong(); // damage bits
+
+	C_BasePlayer* pPlayer = C_BasePlayer::GetLocalPlayer();
+	if (!pPlayer)
+		return;
+
+	if (pPlayer->GetHealth() <= 0)
+		return;
+
+	if (damageTaken > 0 || armor > 0)
+	{
+		// see which effect to play
+		if (bitsDamage & DMG_BULLET || bitsDamage & DMG_SLASH || bitsDamage & DMG_CLUB)
+			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("HudTakeDamageFront");
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: hud scheme settings
+//-----------------------------------------------------------------------------
+void CNEOHudDamageIndicator::ApplySchemeSettings(vgui::IScheme* pScheme)
+{
+	BaseClass::ApplySchemeSettings(pScheme);
+	SetPaintBackgroundEnabled(false);
+
+	int vx, vy, vw, vh;
+	vgui::surface()->GetFullscreenViewport(vx, vy, vw, vh);
+
+	SetForceStereoRenderToFrameBuffer(true);
+
+	if (UseVR())
+	{
+		m_flDmgY = 0.125f * (float)vh;
+		m_flDmgTall1 = 0.625f * (float)vh;
+		m_flDmgTall2 = 0.4f * (float)vh;
+		m_flDmgWide = 0.1f * (float)vw;
+	}
+
+	SetSize(vw, vh);
+}

--- a/mp/src/game/shared/multiplay_gamerules.cpp
+++ b/mp/src/game/shared/multiplay_gamerules.cpp
@@ -174,7 +174,11 @@ int	CMultiplayRules::Damage_GetShouldGibCorpse( void )
 //-----------------------------------------------------------------------------
 int CMultiplayRules::Damage_GetShowOnHud( void )
 {
+#ifdef NEO
+	int iDamage = (DMG_BULLET | DMG_POISON | DMG_ACID | DMG_DROWN | DMG_BURN | DMG_SLOWBURN | DMG_NERVEGAS | DMG_RADIATION | DMG_SHOCK);
+#else
 	int iDamage = ( DMG_POISON | DMG_ACID | DMG_DROWN | DMG_BURN | DMG_SLOWBURN | DMG_NERVEGAS | DMG_RADIATION | DMG_SHOCK );
+#endif
 	return iDamage;
 }
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Correct hud damage indicators. Haven't checked more exotic damage types like getting hit by a car or plasma gun or poison. Original red colour in the 2013 sdk seemed a bit too red, the red defined in the default burn damage overlay with an initial opacity of 25 seems very close to the original. One second for the opacity to linearly decay to 0 seems correct from the recordings I've taken also.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #528
- fixes #119

