### PR TITLE
Correct UpdatePlayerName to use maxClients instead of MAX_PLAYERS

### DIFF
--- a/mp/src/game/client/c_playerresource.cpp
+++ b/mp/src/game/client/c_playerresource.cpp
@@ -127,7 +127,7 @@ void C_PlayerResource::OnDataChanged(DataUpdateType_t updateType)
 
 void C_PlayerResource::UpdatePlayerName( int slot )
 {
-	if ( slot < 1 || slot > MAX_PLAYERS )
+	if ( slot < 1 || slot > gpGlobals->maxClients )
 	{
 		Error( "UpdatePlayerName with bogus slot %d\n", slot );
 		return;
@@ -149,8 +149,7 @@ void C_PlayerResource::UpdatePlayerName( int slot )
 void C_PlayerResource::ClientThink()
 {
 	BaseClass::ClientThink();
-
-	for ( int i = 1; i <= gpGlobals->maxClients; ++i )
+	for ( int i = 1; i <= gpGlobals->maxClients; i++ )
 	{
 		UpdatePlayerName( i );
 	}


### PR DESCRIPTION
## Description
Fixes client crash when server's `-maxplayers` value matches `MAX_PLAYERS` (or is clamped to that value) and SourceTV is enabled.

## Toolchain

- Windows MSVC VS2022

## Linked Issues
- fixes #133
- fixes #134
