### PR TITLE
Fix client integrity due to neo_version_info.h change

### DIFF
--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -1321,7 +1321,7 @@ bool CNEORules::ClientConnected(edict_t *pEntity, const char *pszName, const cha
 			DevWarning("Client debug build integrity check bypass! Client: %s | Server: %s\n", clientGitHash, GIT_LONGHASH);
 		}
 		// NEO NOTE (nullsystem): Due to debug builds, if we're to match exactly, we'll have to mask out final bit first
-		char cmpClientGitHash[sizeof(GIT_LONGHASH) + 1];
+		char cmpClientGitHash[GIT_LONGHASH_SIZE + 1];
 		V_strcpy_safe(cmpClientGitHash, clientGitHash);
 		cmpClientGitHash[0] &= 0b0111'1111;
 		if (!dbgBuildSkip && V_strcmp(cmpClientGitHash, GIT_LONGHASH))

--- a/mp/src/game/shared/neo/neo_version.cpp
+++ b/mp/src/game/shared/neo/neo_version.cpp
@@ -45,7 +45,7 @@ ConVar __neo_cl_git_hash("__neo_cl_git_hash", GIT_LONGHASH,
 #if defined(CLIENT_DLL) && defined(DEBUG)
 void InitializeDbgNeoClGitHashEdit()
 {
-	static char static_dbgHash[sizeof(GIT_LONGHASH) + 1];
+	static char static_dbgHash[GIT_LONGHASH_SIZE];
 	V_strcpy_safe(static_dbgHash, GIT_LONGHASH);
 	static_dbgHash[0] = static_dbgHash[0] | 0b1000'0000;
 	__neo_cl_git_hash.SetDefault(static_dbgHash);

--- a/mp/src/game/shared/neo/neo_version_info.h
+++ b/mp/src/game/shared/neo/neo_version_info.h
@@ -4,6 +4,7 @@ extern const char* BUILD_DATE_SHORT;
 extern const char* BUILD_DATE_LONG;
 extern const char* GIT_HASH;
 extern const char* GIT_LONGHASH;
+static constexpr int GIT_LONGHASH_SIZE = 41;
 extern const char* OS_BUILD;
 extern const char* COMPILER_ID;
 extern const char* COMPILER_VERSION;


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* It can no longer use sizeof(GIT_LONGHASH) as that turned from an array into a pointer now so it returns 8 instead of ~40

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14


