### PR TITLE
Don't drain AUX in underwater, don't tie drowning to AUX in underwater

### DIFF
--- a/mp/src/game/server/hl2/hl2_player.cpp
+++ b/mp/src/game/server/hl2/hl2_player.cpp
@@ -2257,6 +2257,7 @@ void CHL2_Player::CheckFlashlight( void )
 //-----------------------------------------------------------------------------
 void CHL2_Player::SetPlayerUnderwater( bool state )
 {
+#ifndef NEO
 	if ( state )
 	{
 		SuitPower_AddDevice( SuitDeviceBreather );
@@ -2265,6 +2266,7 @@ void CHL2_Player::SetPlayerUnderwater( bool state )
 	{
 		SuitPower_RemoveDevice( SuitDeviceBreather );
 	}
+#endif
 
 	BaseClass::SetPlayerUnderwater( state );
 }

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -149,6 +149,8 @@ public:
 	void CloakPower_Charge(float flPower);
 	float CloakPower_Cap() const;
 
+	bool CanBreatheUnderwater() const override { return false; }
+
 	float GetNormSpeed_WithActiveWepEncumberment(void) const;
 	float GetCrouchSpeed_WithActiveWepEncumberment(void) const;
 	float GetWalkSpeed_WithActiveWepEncumberment(void) const;


### PR DESCRIPTION

<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
* Just a quick ifndef out the device that starts/ends the drain
* Also override `CanBreatheUnderwater` so it doesn't depends on AUX = 0 to drown, just being in water long enough just drowns now
* NOTE: Might want to really separate "NT aux" from "suit power" in the future, but this is good enough for now

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #529
* fixes #530

