### PR TITLE
Supa7 use Slugs with no primary ammo

### DIFF
--- a/mp/src/game/shared/neo/weapons/weapon_supa7.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_supa7.cpp
@@ -398,7 +398,7 @@ void CWeaponSupa7::ItemPostFrame(void)
 		else if (m_flNextPrimaryAttack <= gpGlobals->curtime)
 		{
 			// If out of ammo end reload
-			if (m_iPrimaryAmmoCount <= 0 || m_bSlugLoaded || m_iClip1 >= GetMaxClip1())
+			if (!m_bSlugDelayed && ( m_iPrimaryAmmoCount <= 0 || m_bSlugLoaded || m_iClip1 >= GetMaxClip1()))
 			{
 				FinishReload();
 			}

--- a/mp/src/game/shared/neo/weapons/weapon_supa7.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_supa7.cpp
@@ -397,20 +397,20 @@ void CWeaponSupa7::ItemPostFrame(void)
 		}
 		else if (m_flNextPrimaryAttack <= gpGlobals->curtime)
 		{
-			// If out of ammo end reload
-			if (!m_bSlugDelayed && ( m_iPrimaryAmmoCount <= 0 || m_bSlugLoaded || m_iClip1 >= GetMaxClip1()))
+			// If we're supposed to have a slug loaded, load it
+			if (m_bSlugDelayed)
 			{
-				FinishReload();
+				if (!ReloadSlug())
+				{
+					m_bSlugDelayed.GetForModify() = false;
+				}
 			}
 			else
 			{
-				// If we're supposed to have a slug loaded, load it
-				if (m_bSlugDelayed)
+				// If out of ammo end reload
+				if ((m_iPrimaryAmmoCount <= 0 || m_bSlugLoaded || m_iClip1 >= GetMaxClip1()))
 				{
-					if (!ReloadSlug())
-					{
-						m_bSlugDelayed.GetForModify() = false;
-					}
+					FinishReload();
 				}
 				else
 				{


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

As Agiel pointed out, Supa7's ItemPostFrame was Finishing the reload before a slug could be loaded if there was no primary ammo in the gun

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #576

