### PR TITLE
Workaround for Linux shaders breakage

### DIFF
--- a/mp/src/game/client/CMakeLists.txt
+++ b/mp/src/game/client/CMakeLists.txt
@@ -1482,6 +1482,8 @@ target_sources_grouped(
     neo/c_neo_player.h
     neo/c_neo_te_tocflash.cpp
     neo/c_neo_te_tocflash.h
+    neo/neo_fixup_glshaders.cpp
+    neo/neo_fixup_glshaders.h
 )
 
 target_sources_grouped(

--- a/mp/src/game/client/cdll_client_int.cpp
+++ b/mp/src/game/client/cdll_client_int.cpp
@@ -895,7 +895,9 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 		return false;
 	}
 #ifdef NEO
+#ifdef LINUX
 	FixupGlShaders(filesystem);
+#endif
 #endif
 	if ( (engine = (IVEngineClient *)appSystemFactory( VENGINE_CLIENT_INTERFACE_VERSION, NULL )) == NULL )
 		return false;

--- a/mp/src/game/client/cdll_client_int.cpp
+++ b/mp/src/game/client/cdll_client_int.cpp
@@ -174,6 +174,11 @@ extern vgui::IInputInternal *g_InputInternal;
 #include "neo_version.h"
 #include "neo_mount_original.h"
 extern bool NeoRootCaptureESC();
+
+#ifdef LINUX
+#include "neo_fixup_glshaders.h"
+#endif
+
 #endif
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -885,6 +890,13 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 
 	// We aren't happy unless we get all of our interfaces.
 	// please don't collapse this into one monolithic boolean expression (impossible to debug)
+	if ( (filesystem = (IFileSystem *)appSystemFactory(FILESYSTEM_INTERFACE_VERSION, NULL)) == NULL )
+	{
+		return false;
+	}
+#ifdef NEO
+	FixupGlShaders(filesystem);
+#endif
 	if ( (engine = (IVEngineClient *)appSystemFactory( VENGINE_CLIENT_INTERFACE_VERSION, NULL )) == NULL )
 		return false;
 	if ( (modelrender = (IVModelRender *)appSystemFactory( VENGINE_HUDMODEL_INTERFACE_VERSION, NULL )) == NULL )
@@ -914,8 +926,6 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 	if ( (staticpropmgr = (IStaticPropMgrClient *)appSystemFactory(INTERFACEVERSION_STATICPROPMGR_CLIENT, NULL)) == NULL )
 		return false;
 	if ( (enginesound = (IEngineSound *)appSystemFactory(IENGINESOUND_CLIENT_INTERFACE_VERSION, NULL)) == NULL )
-		return false;
-	if ( (filesystem = (IFileSystem *)appSystemFactory(FILESYSTEM_INTERFACE_VERSION, NULL)) == NULL )
 		return false;
 	if ( (random = (IUniformRandomStream *)appSystemFactory(VENGINE_CLIENT_RANDOM_INTERFACE_VERSION, NULL)) == NULL )
 		return false;

--- a/mp/src/game/client/cdll_client_int.cpp
+++ b/mp/src/game/client/cdll_client_int.cpp
@@ -890,15 +890,6 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 
 	// We aren't happy unless we get all of our interfaces.
 	// please don't collapse this into one monolithic boolean expression (impossible to debug)
-	if ( (filesystem = (IFileSystem *)appSystemFactory(FILESYSTEM_INTERFACE_VERSION, NULL)) == NULL )
-	{
-		return false;
-	}
-#ifdef NEO
-#ifdef LINUX
-	FixupGlShaders(filesystem);
-#endif
-#endif
 	if ( (engine = (IVEngineClient *)appSystemFactory( VENGINE_CLIENT_INTERFACE_VERSION, NULL )) == NULL )
 		return false;
 	if ( (modelrender = (IVModelRender *)appSystemFactory( VENGINE_HUDMODEL_INTERFACE_VERSION, NULL )) == NULL )
@@ -928,6 +919,8 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 	if ( (staticpropmgr = (IStaticPropMgrClient *)appSystemFactory(INTERFACEVERSION_STATICPROPMGR_CLIENT, NULL)) == NULL )
 		return false;
 	if ( (enginesound = (IEngineSound *)appSystemFactory(IENGINESOUND_CLIENT_INTERFACE_VERSION, NULL)) == NULL )
+		return false;
+	if ( (filesystem = (IFileSystem *)appSystemFactory(FILESYSTEM_INTERFACE_VERSION, NULL)) == NULL )
 		return false;
 	if ( (random = (IUniformRandomStream *)appSystemFactory(VENGINE_CLIENT_RANDOM_INTERFACE_VERSION, NULL)) == NULL )
 		return false;
@@ -1057,6 +1050,10 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 	{
 		return false;
 	}
+
+#ifdef LINUX
+    FixupGlShaders(filesystem, g_pCVar);
+#endif
 #endif
 
 	modemanager->Init( );

--- a/mp/src/game/client/neo/neo_fixup_glshaders.cpp
+++ b/mp/src/game/client/neo/neo_fixup_glshaders.cpp
@@ -17,7 +17,7 @@
 // For details, see: https://github.com/NeotokyoRebuild/neo/pull/587
 void FixupGlShaders(IFileSystem* filesystem)
 {
-	constexpr auto filename = "glshaders.cfg";
+	constexpr char filename[] = "glshaders.cfg";
 	constexpr auto pathID = "MOD";
 	if (filesystem->FileExists(filename, pathID))
 	{

--- a/mp/src/game/client/neo/neo_fixup_glshaders.cpp
+++ b/mp/src/game/client/neo/neo_fixup_glshaders.cpp
@@ -5,6 +5,9 @@
 #include "filesystem.h"
 #include "icvar.h"
 
+// Stdlib
+#include <source_location>
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
@@ -13,7 +16,8 @@
 void FixupGlShaders(IFileSystem* filesystem, ICvar* cvar)
 {
 	constexpr auto filename = "glshaders.cfg",
-		pathID = "MOD";
+		pathID = "MOD",
+		funcName = std::source_location::current().function_name();
 
 	// This prevents the game from generating the problematic file on exit.
 	// There's also a "mat_autoload_glshaders", but it seems by the time we load,
@@ -24,7 +28,7 @@ void FixupGlShaders(IFileSystem* filesystem, ICvar* cvar)
 	ConVar* autosaveGlShaders;
 	if (!(autosaveGlShaders = cvar->FindVar(cvarname)))
 	{
-		Warning("%s: cvar %s not found\n", __func__, cvarname);
+		Warning("%s: cvar %s not found\n", funcName, cvarname);
 		return;
 	}
 	autosaveGlShaders->SetValue(false);
@@ -43,7 +47,7 @@ void FixupGlShaders(IFileSystem* filesystem, ICvar* cvar)
 	if (filesystem->IsDirectory(filename, pathID))
 	{
 		Warning("%s: Expected to find a file at %s path %s, but it was a dir\n",
-			__func__, pathID, filename);
+			funcName, pathID, filename);
 		return;
 	}
 

--- a/mp/src/game/client/neo/neo_fixup_glshaders.cpp
+++ b/mp/src/game/client/neo/neo_fixup_glshaders.cpp
@@ -2,50 +2,47 @@
 #ifdef LINUX
 
 // Engine
-#include "dbg.h"
 #include "filesystem.h"
-#include "strtools.h"
-
-// Linux
-#include <errno.h>
-#include <sys/stat.h>
+#include "icvar.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
 // NEO HACK (Rain): This is a hack around a vision shaders corruption on Linux.
 // For details, see: https://github.com/NeotokyoRebuild/neo/pull/587
-void FixupGlShaders(IFileSystem* filesystem)
+void FixupGlShaders(IFileSystem* filesystem, ICvar* cvar)
 {
 	constexpr char filename[] = "glshaders.cfg";
 	constexpr auto pathID = "MOD";
-	if (filesystem->FileExists(filename, pathID))
+
+	// This prevents the game from generating the problematic file on exit.
+	// There's also a "mat_autoload_glshaders", but it seems by the time we load,
+	// it's too late for that to take an effect, at least via this route.
+	// The client can still override this by including a command in their autoexec,
+	// if they really want to.
+	auto autosaveGlShaders = cvar->FindVar("mat_autosave_glshaders");
+	if (autosaveGlShaders != nullptr)
+	{
+		autosaveGlShaders->SetValue(false);
+		Assert(!autosaveGlShaders->GetBool());
+	}
+
+	// If the problematic file doesn't exist, we're done.
+	if (!filesystem->FileExists(filename, pathID))
 	{
 		return;
 	}
 
-	char path[MAX_PATH]{0};
-	filesystem->RelativePathToFullPath("", pathID, path, ARRAYSIZE(path));
-	const int pathLenBeforeFile = V_strlen(path);
-	constexpr int maxPathLenBeforeFile = ARRAYSIZE(path) - ARRAYSIZE(filename);
-	if (pathLenBeforeFile >= maxPathLenBeforeFile)
+	// But if it does, we're too late to fix it for this launch...
+	// However, we can delete the file, which together with the convar set above
+	// should prevent it from being created again on successive restarts of the game.
+
+	// This should never happen, but just in case the relative mod path lookup somehow fails.
+	if (filesystem->IsDirectory(filename, pathID))
 	{
-		Warning("%s: Relative path too long to fixup %s: \"%s\"\nExpected max path length of %d, but got %d\n",
-				__func__, filename, path, maxPathLenBeforeFile, pathLenBeforeFile);
 		return;
 	}
-	V_strcat_safe(path, filename);
 
-	constexpr const char contents[] = "glshadercachev002\n{\n}";
-	auto fh = filesystem->Open(filename, "wt", pathID);
-	filesystem->Write(contents, ARRAYSIZE(contents)-1, fh); // -1 to exclude the null terminator from output
-	filesystem->Flush(fh);
-	filesystem->Close(fh);
-
-	constexpr auto readonly = S_IRUSR|S_IRGRP|S_IROTH;
-	if (chmod(path, readonly) == -1)
-	{
-		Warning("%s: File chmod failed with error code %d\nfor path: \"%s\"\n", __func__, errno, path);
-	}
+	filesystem->RemoveFile(filename, pathID);
 }
 #endif // LINUX

--- a/mp/src/game/client/neo/neo_fixup_glshaders.cpp
+++ b/mp/src/game/client/neo/neo_fixup_glshaders.cpp
@@ -1,0 +1,50 @@
+#include "neo_fixup_glshaders.h"
+#ifdef LINUX
+
+// Engine
+#include "dbg.h"
+#include "filesystem.h"
+#include "strtools.h"
+
+// Linux
+#include <errno.h>
+#include <sys/stat.h>
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+// NEO HACK (Rain): This is a hack around a vision shaders corruption on Linux.
+// For details, see: https://github.com/NeotokyoRebuild/neo/pull/587
+void FixupGlShaders(IFileSystem* filesystem)
+{
+	constexpr auto filename = "glshaders.cfg";
+	constexpr auto pathID = "MOD";
+	if (filesystem->FileExists(filename, pathID))
+	{
+		return;
+	}
+
+	char path[MAX_PATH]{0};
+	filesystem->RelativePathToFullPath("", pathID, path, sizeof(path));
+	constexpr int maxPathLen = sizeof(path)-(1+sizeof(filename));
+	if (V_strlen(path) >= maxPathLen)
+	{
+		Warning("%s: Relative path too long to fixup %s: \"%s\"\nExpected max path length of %d, but got %d\n",
+				__func__, filename, path, maxPathLen, V_strlen(path));
+		return;
+	}
+	V_strcat_safe(path, filename);
+
+	constexpr const char contents[] = "glshadercachev002\n{\n}";
+	auto fh = filesystem->Open(filename, "wt", pathID);
+	filesystem->Write(contents, sizeof(contents)-1, fh); // don't write the null terminator to file
+	filesystem->Flush(fh);
+	filesystem->Close(fh);
+
+	constexpr auto readonly = S_IRUSR|S_IRGRP|S_IROTH;
+	if (chmod(path, readonly) == -1)
+	{
+		Warning("%s: File chmod failed with error code %d\nfor path: \"%s\"\n", __func__, errno, path);
+	}
+}
+#endif // LINUX

--- a/mp/src/game/client/neo/neo_fixup_glshaders.cpp
+++ b/mp/src/game/client/neo/neo_fixup_glshaders.cpp
@@ -20,12 +20,14 @@ void FixupGlShaders(IFileSystem* filesystem, ICvar* cvar)
 	// it's too late for that to take an effect, at least via this route.
 	// The client can still override this by including a command in their autoexec,
 	// if they really want to.
-	auto autosaveGlShaders = cvar->FindVar("mat_autosave_glshaders");
-	if (autosaveGlShaders != nullptr)
+	constexpr auto cvarname = "mat_autosave_glshaders";
+	ConVar* autosaveGlShaders;
+	if (!(autosaveGlShaders = cvar->FindVar(cvarname)))
 	{
-		autosaveGlShaders->SetValue(false);
-		Assert(!autosaveGlShaders->GetBool());
+		Warning("%s: cvar %s not found\n", __func__, cvarname);
+		return;
 	}
+	autosaveGlShaders->SetValue(false);
 
 	// If the problematic file doesn't exist, we're done.
 	if (!filesystem->FileExists(filename, pathID))
@@ -40,6 +42,8 @@ void FixupGlShaders(IFileSystem* filesystem, ICvar* cvar)
 	// This should never happen, but just in case the relative mod path lookup somehow fails.
 	if (filesystem->IsDirectory(filename, pathID))
 	{
+		Warning("%s: Expected to find a file at %s path %s, but it was a dir\n",
+			__func__, pathID, filename);
 		return;
 	}
 

--- a/mp/src/game/client/neo/neo_fixup_glshaders.cpp
+++ b/mp/src/game/client/neo/neo_fixup_glshaders.cpp
@@ -12,8 +12,8 @@
 // For details, see: https://github.com/NeotokyoRebuild/neo/pull/587
 void FixupGlShaders(IFileSystem* filesystem, ICvar* cvar)
 {
-	constexpr char filename[] = "glshaders.cfg";
-	constexpr auto pathID = "MOD";
+	constexpr auto filename = "glshaders.cfg",
+		pathID = "MOD";
 
 	// This prevents the game from generating the problematic file on exit.
 	// There's also a "mat_autoload_glshaders", but it seems by the time we load,

--- a/mp/src/game/client/neo/neo_fixup_glshaders.cpp
+++ b/mp/src/game/client/neo/neo_fixup_glshaders.cpp
@@ -25,19 +25,20 @@ void FixupGlShaders(IFileSystem* filesystem)
 	}
 
 	char path[MAX_PATH]{0};
-	filesystem->RelativePathToFullPath("", pathID, path, sizeof(path));
-	constexpr int maxPathLen = sizeof(path)-(1+sizeof(filename));
-	if (V_strlen(path) >= maxPathLen)
+	filesystem->RelativePathToFullPath("", pathID, path, ARRAYSIZE(path));
+	const int pathLenBeforeFile = V_strlen(path);
+	constexpr int maxPathLenBeforeFile = ARRAYSIZE(path) - ARRAYSIZE(filename);
+	if (pathLenBeforeFile >= maxPathLenBeforeFile)
 	{
 		Warning("%s: Relative path too long to fixup %s: \"%s\"\nExpected max path length of %d, but got %d\n",
-				__func__, filename, path, maxPathLen, V_strlen(path));
+				__func__, filename, path, maxPathLenBeforeFile, pathLenBeforeFile);
 		return;
 	}
 	V_strcat_safe(path, filename);
 
 	constexpr const char contents[] = "glshadercachev002\n{\n}";
 	auto fh = filesystem->Open(filename, "wt", pathID);
-	filesystem->Write(contents, sizeof(contents)-1, fh); // don't write the null terminator to file
+	filesystem->Write(contents, ARRAYSIZE(contents)-1, fh); // -1 to exclude the null terminator from output
 	filesystem->Flush(fh);
 	filesystem->Close(fh);
 

--- a/mp/src/game/client/neo/neo_fixup_glshaders.h
+++ b/mp/src/game/client/neo/neo_fixup_glshaders.h
@@ -5,9 +5,10 @@
 #endif
 #ifdef LINUX
 
+class ICvar;
 class IFileSystem;
 
-void FixupGlShaders(IFileSystem* filesystem);
+void FixupGlShaders(IFileSystem* filesystem, ICvar* cvar);
 
 #endif // LINUX
 #endif // NEO_FIXUP_GLSHADERS_H

--- a/mp/src/game/client/neo/neo_fixup_glshaders.h
+++ b/mp/src/game/client/neo/neo_fixup_glshaders.h
@@ -1,0 +1,13 @@
+#ifndef NEO_FIXUP_GLSHADERS_H
+#define NEO_FIXUP_GLSHADERS_H
+#ifdef _WIN32
+#pragma once
+#endif
+#ifdef LINUX
+
+class IFileSystem;
+
+void FixupGlShaders(IFileSystem* filesystem);
+
+#endif // LINUX
+#endif // NEO_FIXUP_GLSHADERS_H


### PR DESCRIPTION
## Description
This is a hack around the vision mode shaders sporadically breaking on Linux builds.

It seems that for whatever reason, the shader state cached at the `glshaders.cfg` file somehow leads to the corruption upon successive runs of the game, and write-protecting the file offers a simple way to avoid that breakage.

Ideally, we should figure out  what's really going wrong here at the shader system and/or precaching level, but this should suffice for avoiding the bug.

~~I opted to implement this as a CMakeLists step rather than submit the glshaders file itself, because to my understanding git does not version control the "read-only" file permissions required to keep the game from modifying the file.~~

edit: The hack is now done at runtime, because doing it in the CMake scripts won't carry over to users [as pointed out by nullsystem](https://github.com/NeotokyoRebuild/neo/pull/587#issuecomment-2351554803), and we can't version control the file, because the filesystem specific metadata required for the read-only state won't carry over.

For more discussion, see: https://github.com/NeotokyoRebuild/neo/issues/438#issuecomment-2351068151

### Steps to repro the bug
* Use Linux
* Build the game from master (or test with a recent release)
* Launch the game
* Check whether visions modes are broken for any of the 3 classes
* If they're *not* broken, close the game, relaunch it, and check again
* If you have the bug, you should be seeing shader corruption within a few tries

### Steps to test this patch
* The aforementioned corruption no longer occurs

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native [Mint 21.3 Cinnamon + (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0]
- cmake version 3.30.3

## Linked Issues
- Fix #438

