### PR TITLE
Enforce con_enable 1 and multiple fixes for keybind handling

### DIFF
--- a/mp/src/game/client/cdll_client_int.cpp
+++ b/mp/src/game/client/cdll_client_int.cpp
@@ -1226,6 +1226,10 @@ void MusicVol_ChangeCallback(IConVar *cvar, const char *pOldVal, float flOldVal)
 	UpdateBgm((ConVar*)cvar);
 }
 
+#ifdef NEO
+extern void NeoToggleConsoleEnforce();
+#endif
+
 //-----------------------------------------------------------------------------
 // Purpose: Called after client & server DLL are loaded and all systems initialized
 //-----------------------------------------------------------------------------
@@ -1266,14 +1270,7 @@ void CHLClient::PostInit()
 		Assert(false);
 	}
 
-	// Rebind ` from toggleconsole to neo_toggleconsole
-	const auto toggleConsoleBind = gameuifuncs->GetButtonCodeForBind("toggleconsole");
-	if (toggleConsoleBind == KEY_BACKQUOTE)
-	{
-		char cmdStr[128];
-		V_sprintf_safe(cmdStr, "bind \"`\" \"neo_toggleconsole\"\n");
-		engine->ClientCmd_Unrestricted(cmdStr);
-	}
+	NeoToggleConsoleEnforce();
 #endif
 }
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Enforce con_enable 1 to fix console toggle issue
* Instead always enforce the "legacy" toggleconsole, because internally it requires con_enable to be set anyway, although the legacy menu toggles this.
* Basically means the support for legacy menu on this is an unsupported thing anyway
* Write the command file on save
* Fix attempts to write empty keys
* Unbind duplicate key

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #586

