### PR TITLE
Fix crash at Neo menu constructors

### DIFF
--- a/mp/src/game/client/neo/game_controls/neo_classmenu.h
+++ b/mp/src/game/client/neo/game_controls/neo_classmenu.h
@@ -57,7 +57,7 @@ public:
 
     virtual Color GetBlackBarColor( void ) { return Color(0, 0, 0, 196); }
 
-    virtual const char *GetResFile(void)
+    const char *GetResFile(void) const
     {
         return "resource/neo_ui/Neo_ClassMenu.res";
     }

--- a/mp/src/game/client/neo/game_controls/neo_loadoutmenu.h
+++ b/mp/src/game/client/neo/game_controls/neo_loadoutmenu.h
@@ -39,7 +39,7 @@ public:
 
 	virtual void OnMousePressed(vgui::MouseCode code);
 
-	virtual const char *GetResFile(void)
+	const char *GetResFile(void) const
 	{
 		return "resource/neo_ui/Neo_LoadoutMenu_Dev.res";
 	}

--- a/mp/src/game/client/neo/game_controls/neo_teammenu.h
+++ b/mp/src/game/client/neo/game_controls/neo_teammenu.h
@@ -54,7 +54,7 @@ public:
 
     virtual Color GetBlackBarColor( void ) { return Color(0, 0, 0, 196); }
 
-    virtual const char *GetResFile(void)
+    const char *GetResFile(void) const
     {
         return "resource/neo_ui/Neo_TeamMenu.res";
     }


### PR DESCRIPTION
## Description
Based on a crash dump. We can't safely call this virtual method from the constructor, so converting it to non-virtual. As we aren't overriding a function, and we're not being overridden, this shouldn't have any effect to other systems.

## Toolchain
- Linux GCC Distro Native [Mint 21.3 Cinnamon, gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0]

## Linked Issues
None
