### PR TITLE
Fix -neopath for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Another way is just add the `-game` option to "Source SDK Base 2013 Multiplayer"
 ```
 
 ### `-neopath` - Pointing to a non-default original NEOTOKYO directory
-NOTE: This doesn't work on linux when running the mod from Steam.
 
 This is generally isn't necessary if NEOTOKYO is installed at a default location. However,
 if you have it installed at a different location, adding `-neopath` to the launch option

--- a/mp/src/game/shared/neo/neo_mount_original.h
+++ b/mp/src/game/shared/neo/neo_mount_original.h
@@ -351,7 +351,7 @@ void FixIncompatibleNeoAssets(IFileSystem* filesystem, bool restoreInstead)
 	const bool callerIsClientDll = false; // always server here. should refactor this stuff later.
 
 	// The NeotokyoSource root asset folder should exist (or be symlinked) to one of these paths,
-	// or be specified with the NEO_PATH_PARM_CMD parm (which is currently broken on Linux, see below).
+	// or be specified with the NEO_PATH_PARM_CMD parm.
 	// We look in the order described below, and stop looking at the first matching path.
 	char neoLinuxPath_LocalSteam[MAX_PATH]{ 0 };
 	char neoLinuxPath_LocalShare[MAX_PATH]{ 0 };
@@ -370,10 +370,8 @@ void FixIncompatibleNeoAssets(IFileSystem* filesystem, bool restoreInstead)
 	// Third lookup path: machine's share directory.
 	const char* neoLinuxPath_UsrShare = "/usr/share/neotokyo/NeotokyoSource/";
 
-	// NEO FIXME (Rain): getting this ParmValue from Steam Linux client seems to be broken(?),
-	// we always fall back to hardcoded pDefaultVal.
 	V_strcpy_safe(neoPath,
-		CommandLine()->ParmValue(NEO_PATH_PARM_CMD, neoLinuxPath_LocalSteam));
+		CommandLine()->ParmValue(&NEO_PATH_PARM_CMD[0], neoLinuxPath_LocalSteam));
 
 	const bool isUsingCustomParm = (Q_stricmp(neoPath, neoLinuxPath_LocalSteam) != 0);
 
@@ -480,7 +478,7 @@ inline bool FindOriginalNeotokyoAssets(IFileSystem *filesystem, const bool calle
 	// NEO TODO (Rain): this linux path get code is repeated; should turn into a function for brevity.
 
 	// The NeotokyoSource root asset folder should exist (or be symlinked) to one of these paths,
-	// or be specified with the NEO_PATH_PARM_CMD parm (which is currently broken on Linux, see below).
+	// or be specified with the NEO_PATH_PARM_CMD parm.
     // We look in the order described below, and stop looking at the first matching path.
     char neoLinuxPath_LocalSteam[MAX_PATH] { 0 };
     char neoLinuxPath_LocalShare[MAX_PATH] { 0 };
@@ -499,10 +497,8 @@ inline bool FindOriginalNeotokyoAssets(IFileSystem *filesystem, const bool calle
     // Third lookup path: machine's share directory.
     const char *neoLinuxPath_UsrShare = "/usr/share/neotokyo/NeotokyoSource/";
 
-	// NEO FIXME (Rain): getting this ParmValue from Steam Linux client seems to be broken(?),
-	// we always fall back to hardcoded pDefaultVal.
 	V_strcpy_safe(neoPath,
-        CommandLine()->ParmValue(NEO_PATH_PARM_CMD, neoLinuxPath_LocalSteam));
+        CommandLine()->ParmValue(&NEO_PATH_PARM_CMD[0], neoLinuxPath_LocalSteam));
 
     const bool isUsingCustomParm = (Q_stricmp(neoPath, neoLinuxPath_LocalSteam) != 0);
 


### PR DESCRIPTION
## Description
Make the `-neopath` launch argument work on Linux.

## Toolchain
- Linux GCC Distro Native [Mint 21.3 Cinnamon, gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0]

## Steps to reproduce the bug
* Launch the game with `-neopath "/your/custom/path/here"` Steam advanced launch parameter
* See that it doesn't use the parameter.

## After this patch
* The parameter is used correctly.
    * Main menu game console reports: `Client using custom -neopath: /your/custom/path/here`
    * Game correctly errors for invalid `-neopath` values

## Linked Issues
None
