### PR TITLE
Revert "replace weapon_switch with ClientCommand (#570)"

### DIFF
--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -2491,22 +2491,21 @@ void CNEO_Player::GiveDefaultItems(void)
 		GiveNamedItem("weapon_knife");
 		GiveNamedItem("weapon_milso");
 		if (this->m_iXP >= 4) { GiveDet(this); }
-		engine->ClientCommand(edict(), "slot2");
+		Weapon_Switch(Weapon_OwnsThisType("weapon_milso"));
 		break;
 	case NEO_CLASS_ASSAULT:
 		GiveNamedItem("weapon_knife");
 		GiveNamedItem("weapon_tachi");
 		GiveNamedItem("weapon_grenade");
-		engine->ClientCommand(edict(), "slot2");
+		Weapon_Switch(Weapon_OwnsThisType("weapon_tachi"));
 		break;
 	case NEO_CLASS_SUPPORT:
 		GiveNamedItem("weapon_kyla");
 		GiveNamedItem("weapon_smokegrenade");
-		engine->ClientCommand(edict(), "slot2");
+		Weapon_Switch(Weapon_OwnsThisType("weapon_kyla"));
 		break;
 	default:
 		GiveNamedItem("weapon_knife");
-		engine->ClientCommand(edict(), "slot3");
 		break;
 	}
 }
@@ -2559,7 +2558,7 @@ void CNEO_Player::GiveLoadoutWeapon(void)
 				RemoveAllItems(false);
 				GiveDefaultItems();
 				pEnt->Touch(this);
-				engine->ClientCommand(edict(), "slot1");
+				Weapon_Switch(Weapon_OwnsThisType(szWep));
 			}
 		}
 		else
@@ -2590,7 +2589,7 @@ void CNEO_Player::GiveAllItems(void)
 
 	GiveNamedItem("weapon_tachi");
 	GiveNamedItem("weapon_zr68s");
-	engine->ClientCommand(edict(), "slot1");
+	Weapon_Switch(Weapon_OwnsThisType("weapon_zr68s"));
 }
 
 // Purpose: For Neotokyo, we could use this engine method


### PR DESCRIPTION
## Description

When spawning in a round, the primary weapon you choose does not automatically activate like it should. This breaks both weapon selections for players, but seems to affect bots too. The player is left in the pistol animation without any weapon selected, and pressing `+attack` does nothing in this state.

This is a regression from d209d44b; the parent commit 51a1ef42 does not observe this behaviour.

I propose we revert #570 (commit d209d44b), because it was intended to fix #569 but doesn't, so it's only introducing new bugs currently.

## To reproduce the problem

* Join a server
* Join a team
* Choose a class
* Choose a loadout

## Expected behaviour
* Your chosen loadout is activated as you spawn in.
* Bots will also spawn with their primary weapon active.

## Actual behaviour
* You spawn empty-handed, until you manually select your weapon.
* Bots also spawn empty-handed.

## Additional context

### Weapon selection behaviour before the bug

This is the behaviour before commit d209d44b. Notice how the weapon is readied as soon as the player spawns, and the same holds true for bots:

[wepselect1.webm](https://github.com/user-attachments/assets/bdeb428c-aa31-4e53-ad38-a7a97f9f2a05)

### Weapon selection behaviour after the bug

Weapon does not become active after spawning, until the player manually selects it:

[wepselect-regression-1.webm](https://github.com/user-attachments/assets/af6cf41b-1f56-42db-971e-f25f515201d9)

Here's a third person view of a player spawning in empty-handed:

[wepselect-regression-2.webm](https://github.com/user-attachments/assets/8af8ca6a-1e83-446a-b43e-6746c6441752)

Here's a bot spawning in empty-handed. There's also the T pose bug #569 occurring here, but that is unrelated to the bugs described here:

[wepselect-regression-3.webm](https://github.com/user-attachments/assets/fbe553d8-3c99-49a9-b428-fbe97ab1a797)

## Linked Issues
- related #569, #570
