### PR TITLE
NeoUI - Change normal font to from neuropol2 to green mountain

### DIFF
--- a/mp/game/neo/resource/ClientScheme.res
+++ b/mp/game/neo/resource/ClientScheme.res
@@ -1569,6 +1569,108 @@ Scheme
 				//"additive"	"1"
 			}
 		}
+		NeoUINormal
+		{
+			"1"
+			{
+				"name"		"Green Mountain 3"
+				"tall"		"16"
+				"weight"	"900"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"480 599"
+				//"additive"	"1"
+			}
+			"2"
+			{
+				"name"		"Green Mountain 3"
+				"tall"		"18"
+				"weight"	"900"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"600 767"
+				//"additive"	"1"
+			}
+			"3"
+			{
+				"name"		"Green Mountain 3"
+				"tall"		"22"
+				"weight"	"900"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"768 1023"
+				"antialias"	"1"
+				//"additive"	"1"
+			}
+			"4"
+			{
+				"name"		"Green Mountain 3"
+				"tall"		"24"
+				"weight"	"900"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1024 1199"
+				"antialias"	"1"
+				//"additive"	"1"
+			}
+			"5"
+			{
+				"name"		"Green Mountain 3"
+				"tall"		"26"
+				"weight"	"900"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1200 6000"
+				"antialias"	"1"
+				//"additive"	"1"
+			}
+		}
+		NeoUILarge
+		{
+			"1"
+			{
+				"name"		"Green Mountain 3"
+				"tall"		"22"
+				"weight"	"900"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"480 599"
+				//"additive"	"1"
+			}
+			"2"
+			{
+				"name"		"Green Mountain 3"
+				"tall"		"25"
+				"weight"	"900"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"600 767"
+				//"additive"	"1"
+			}
+			"3"
+			{
+				"name"		"Green Mountain 3"
+				"tall"		"32"
+				"weight"	"900"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"768 1023"
+				"antialias"	"1"
+				//"additive"	"1"
+			}
+			"4"
+			{
+				"name"		"Green Mountain 3"
+				"tall"		"35"
+				"weight"	"900"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1024 1199"
+				"antialias"	"1"
+				//"additive"	"1"
+			}
+			"5"
+			{
+				"name"		"Green Mountain 3"
+				"tall"		"38"
+				"weight"	"900"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1200 6000"
+				"antialias"	"1"
+				//"additive"	"1"
+			}
+		}
 		MVP
 		{
 			"1"

--- a/mp/src/game/client/neo/ui/neo_root.cpp
+++ b/mp/src/game/client/neo/ui/neo_root.cpp
@@ -251,7 +251,8 @@ void CNeoRoot::ApplySchemeSettings(IScheme *pScheme)
 	SetBgColor(COLOR_TRANSPARENT);
 
 	static constexpr const char *FONT_NAMES[NeoUI::FONT__TOTAL] = {
-		"NHudOCRSmallNoAdditive", "NHudOCR", "ClientTitleFont"
+		"NeoUINormal", "NHudOCR", "NHudOCRSmallNoAdditive", "ClientTitleFont",
+		"NeoUILarge"
 	};
 	for (int i = 0; i < NeoUI::FONT__TOTAL; ++i)
 	{
@@ -379,8 +380,8 @@ void CNeoRoot::OnMainLoop(const NeoUI::Mode eMode)
 		// Draw version info (bottom left corner) - Always
 		surface()->DrawSetTextColor(COLOR_NEOPANELTEXTBRIGHT);
 		int textWidth, textHeight;
-		surface()->DrawSetTextFont(g_uiCtx.fonts[NeoUI::FONT_NTSMALL].hdl);
-		surface()->GetTextSize(g_uiCtx.fonts[NeoUI::FONT_NTSMALL].hdl, BUILD_DISPLAY, textWidth, textHeight);
+		surface()->DrawSetTextFont(g_uiCtx.fonts[NeoUI::FONT_NTNORMAL].hdl);
+		surface()->GetTextSize(g_uiCtx.fonts[NeoUI::FONT_NTNORMAL].hdl, BUILD_DISPLAY, textWidth, textHeight);
 
 		surface()->DrawSetTextPos(g_uiCtx.iMarginX, tall - textHeight - g_uiCtx.iMarginY);
 		surface()->DrawPrintText(BUILD_DISPLAY, *BUILD_DISPLAY_SIZE);
@@ -469,7 +470,7 @@ void CNeoRoot::MainLoopRoot(const MainLoopParam param)
 		surface()->DrawSetTextColor(COLOR_NEOTITLE);
 		surface()->DrawSetTextPos(iBtnPlaceXMid - (m_iTitleWidth / 2), yTopPos - m_iTitleHeight);
 		surface()->DrawPrintText(WSZ_GAME_TITLE, SZWSZ_LEN(WSZ_GAME_TITLE));
-		surface()->DrawSetTextFont(g_uiCtx.fonts[NeoUI::FONT_NTSMALL].hdl);
+		surface()->DrawSetTextFont(g_uiCtx.fonts[NeoUI::FONT_NTNORMAL].hdl);
 
 		surface()->DrawSetTextColor(COLOR_NEOPANELTEXTBRIGHT);
 		ISteamUser *steamUser = steamapicontext->SteamUser();
@@ -499,8 +500,8 @@ void CNeoRoot::MainLoopRoot(const MainLoopParam param)
 			g_pVGuiLocalize->ConvertANSIToUnicode(szTextBuf, wszTextBuf, sizeof(wszTextBuf));
 
 			int iMainTextWidth, iMainTextHeight;
-			surface()->DrawSetTextFont(g_uiCtx.fonts[NeoUI::FONT_NTNORMAL].hdl);
-			surface()->GetTextSize(g_uiCtx.fonts[NeoUI::FONT_NTNORMAL].hdl, wszTextBuf, iMainTextWidth, iMainTextHeight);
+			surface()->DrawSetTextFont(g_uiCtx.fonts[NeoUI::FONT_NTHEADING].hdl);
+			surface()->GetTextSize(g_uiCtx.fonts[NeoUI::FONT_NTHEADING].hdl, wszTextBuf, iMainTextWidth, iMainTextHeight);
 
 			const int iMainTextStartPosX = g_uiCtx.iMarginX + g_iAvatar + g_uiCtx.iMarginX;
 			surface()->DrawSetTextPos(iSteamPlaceXStart + iMainTextStartPosX, iRightSideYStart + g_uiCtx.iMarginY);
@@ -512,8 +513,8 @@ void CNeoRoot::MainLoopRoot(const MainLoopParam param)
 				g_pVGuiLocalize->ConvertANSIToUnicode(szTextBuf, wszTextBuf, sizeof(wszTextBuf));
 
 				int iSteamSubTextWidth, iSteamSubTextHeight;
-				surface()->DrawSetTextFont(g_uiCtx.fonts[NeoUI::FONT_NTSMALL].hdl);
-				surface()->GetTextSize(g_uiCtx.fonts[NeoUI::FONT_NTSMALL].hdl, wszTextBuf, iSteamSubTextWidth, iSteamSubTextHeight);
+				surface()->DrawSetTextFont(g_uiCtx.fonts[NeoUI::FONT_NTNORMAL].hdl);
+				surface()->GetTextSize(g_uiCtx.fonts[NeoUI::FONT_NTNORMAL].hdl, wszTextBuf, iSteamSubTextWidth, iSteamSubTextHeight);
 
 				const int iRightOfNicknameXPos = iSteamPlaceXStart + iMainTextStartPosX + iMainTextWidth + g_uiCtx.iMarginX;
 				// If we have space on the right, set it, otherwise on top of nickname
@@ -540,8 +541,8 @@ void CNeoRoot::MainLoopRoot(const MainLoopParam param)
 				const int iStatusTextStartPosY = g_uiCtx.iMarginY + iMainTextHeight + g_uiCtx.iMarginY;
 
 				[[maybe_unused]] int iStatusWide;
-				surface()->DrawSetTextFont(g_uiCtx.fonts[NeoUI::FONT_NTSMALL].hdl);
-				surface()->GetTextSize(g_uiCtx.fonts[NeoUI::FONT_NTSMALL].hdl, wszState, iStatusWide, iStatusTall);
+				surface()->DrawSetTextFont(g_uiCtx.fonts[NeoUI::FONT_NTNORMAL].hdl);
+				surface()->GetTextSize(g_uiCtx.fonts[NeoUI::FONT_NTNORMAL].hdl, wszState, iStatusWide, iStatusTall);
 				surface()->DrawSetTextPos(iSteamPlaceXStart + iMainTextStartPosX,
 										  iRightSideYStart + iStatusTextStartPosY);
 				surface()->DrawPrintText(wszState, V_wcslen(wszState));
@@ -568,9 +569,9 @@ void CNeoRoot::MainLoopRoot(const MainLoopParam param)
 		else
 		{
 			// Show the news
-			NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
+			NeoUI::SwapFont(NeoUI::FONT_NTHEADING);
 			NeoUI::Label(L"News");
-			NeoUI::SwapFont(NeoUI::FONT_NTSMALL);
+			NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 
 			// Write some headlines
 			static constexpr const wchar_t *WSZ_NEWS_HEADLINES[] = {
@@ -626,6 +627,7 @@ void CNeoRoot::MainLoopSettings(const MainLoopParam param)
 		g_uiCtx.dPanel.tall = g_uiCtx.iRowTall;
 		NeoUI::BeginSection();
 		{
+			NeoUI::SwapFont(NeoUI::FONT_NTHORIZSIDES);
 			NeoUI::BeginHorizontal(g_uiCtx.dPanel.wide / 5);
 			{
 				if (NeoUI::Button(L"Back (ESC)").bPressed || NeoUI::Bind(KEY_ESCAPE))
@@ -650,6 +652,7 @@ void CNeoRoot::MainLoopSettings(const MainLoopParam param)
 				}
 			}
 			NeoUI::EndHorizontal();
+			NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 		}
 		NeoUI::EndSection();
 	}
@@ -702,6 +705,7 @@ void CNeoRoot::MainLoopNewGame(const MainLoopParam param)
 		g_uiCtx.dPanel.tall = g_uiCtx.iRowTall;
 		NeoUI::BeginSection();
 		{
+			NeoUI::SwapFont(NeoUI::FONT_NTHORIZSIDES);
 			NeoUI::BeginHorizontal(g_uiCtx.dPanel.wide / 5);
 			{
 				if (NeoUI::Button(L"Back (ESC)").bPressed || NeoUI::Bind(KEY_ESCAPE))
@@ -738,6 +742,7 @@ void CNeoRoot::MainLoopNewGame(const MainLoopParam param)
 				}
 			}
 			NeoUI::EndHorizontal();
+			NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 		}
 		NeoUI::EndSection();
 	}
@@ -899,6 +904,7 @@ void CNeoRoot::MainLoopServerBrowser(const MainLoopParam param)
 		if (m_bShowFilterPanel) g_uiCtx.dPanel.tall += g_uiCtx.iRowTall * FILTER_ROWS;
 		NeoUI::BeginSection();
 		{
+			NeoUI::SwapFont(NeoUI::FONT_NTHORIZSIDES);
 			NeoUI::BeginHorizontal(g_uiCtx.dPanel.wide / 6);
 			{
 				if (NeoUI::Button(L"Back (ESC)").bPressed || NeoUI::Bind(KEY_ESCAPE))
@@ -972,6 +978,7 @@ void CNeoRoot::MainLoopServerBrowser(const MainLoopParam param)
 				}
 			}
 			NeoUI::EndHorizontal();
+			NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 			if (m_bShowFilterPanel)
 			{
 				NeoUI::RingBoxBool(L"Server not full", &m_sbFilters.bServerNotFull);
@@ -1013,6 +1020,7 @@ void CNeoRoot::MainLoopMapList(const MainLoopParam param)
 		g_uiCtx.dPanel.tall = g_uiCtx.iRowTall;
 		NeoUI::BeginSection();
 		{
+			NeoUI::SwapFont(NeoUI::FONT_NTHORIZSIDES);
 			NeoUI::BeginHorizontal(g_uiCtx.dPanel.wide / 5);
 			{
 				if (NeoUI::Button(L"Back (ESC)").bPressed || NeoUI::Bind(KEY_ESCAPE))
@@ -1021,6 +1029,7 @@ void CNeoRoot::MainLoopMapList(const MainLoopParam param)
 				}
 			}
 			NeoUI::EndHorizontal();
+			NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 		}
 		NeoUI::EndSection();
 	}
@@ -1082,6 +1091,7 @@ void CNeoRoot::MainLoopServerDetails(const MainLoopParam param)
 		g_uiCtx.dPanel.tall = g_uiCtx.iRowTall;
 		NeoUI::BeginSection();
 		{
+			NeoUI::SwapFont(NeoUI::FONT_NTHORIZSIDES);
 			NeoUI::BeginHorizontal(g_uiCtx.dPanel.wide / 5);
 			{
 				if (NeoUI::Button(L"Back (ESC)").bPressed || NeoUI::Bind(KEY_ESCAPE))
@@ -1090,6 +1100,7 @@ void CNeoRoot::MainLoopServerDetails(const MainLoopParam param)
 				}
 			}
 			NeoUI::EndHorizontal();
+			NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 		}
 		NeoUI::EndSection();
 	}
@@ -1138,6 +1149,7 @@ void CNeoRoot::MainLoopPlayerList(const MainLoopParam param)
 			g_uiCtx.dPanel.tall = g_uiCtx.iRowTall;
 			NeoUI::BeginSection();
 			{
+				NeoUI::SwapFont(NeoUI::FONT_NTHORIZSIDES);
 				NeoUI::BeginHorizontal(g_uiCtx.dPanel.wide / 5);
 				{
 					if (NeoUI::Button(L"Back (ESC)").bPressed || NeoUI::Bind(KEY_ESCAPE))
@@ -1146,6 +1158,7 @@ void CNeoRoot::MainLoopPlayerList(const MainLoopParam param)
 					}
 				}
 				NeoUI::EndHorizontal();
+				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 			}
 			NeoUI::EndSection();
 		}
@@ -1181,21 +1194,20 @@ void CNeoRoot::MainLoopPopup(const MainLoopParam param)
 		NeoUI::BeginSection(true);
 		{
 			g_uiCtx.eLabelTextStyle = NeoUI::TEXTSTYLE_CENTER;
+			NeoUI::SwapFont(NeoUI::FONT_NTLARGE);
 			switch (m_state)
 			{
 			case STATE_KEYCAPTURE:
 			{
-				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 				NeoUI::Label(m_wszBindingText);
-				NeoUI::SwapFont(NeoUI::FONT_NTSMALL);
+				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 				NeoUI::Label(L"Press ESC to cancel or DEL to remove keybind");
 			}
 			break;
 			case STATE_CONFIRMSETTINGS:
 			{
-				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 				NeoUI::Label(L"Settings changed: Do you want to apply the settings?");
-				NeoUI::SwapFont(NeoUI::FONT_NTSMALL);
+				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 				NeoUI::BeginHorizontal(g_uiCtx.dPanel.wide / 3);
 				{
 					if (NeoUI::Button(L"Save (Enter)").bPressed || NeoUI::Bind(KEY_ENTER))
@@ -1214,9 +1226,8 @@ void CNeoRoot::MainLoopPopup(const MainLoopParam param)
 			break;
 			case STATE_QUIT:
 			{
-				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 				NeoUI::Label(L"Do you want to quit the game?");
-				NeoUI::SwapFont(NeoUI::FONT_NTSMALL);
+				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 				NeoUI::BeginHorizontal(g_uiCtx.dPanel.wide / 3);
 				{
 					if (NeoUI::Button(L"Quit (Enter)").bPressed || NeoUI::Bind(KEY_ENTER))
@@ -1234,9 +1245,8 @@ void CNeoRoot::MainLoopPopup(const MainLoopParam param)
 			break;
 			case STATE_SERVERPASSWORD:
 			{
-				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 				NeoUI::Label(L"Enter the server password");
-				NeoUI::SwapFont(NeoUI::FONT_NTSMALL);
+				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 				g_uiCtx.bTextEditIsPassword = true;
 				NeoUI::TextEdit(L"Password:", m_wszServerPassword, SZWSZ_LEN(m_wszServerPassword));
 				g_uiCtx.bTextEditIsPassword = false;

--- a/mp/src/game/client/neo/ui/neo_ui.cpp
+++ b/mp/src/game/client/neo/ui/neo_ui.cpp
@@ -128,9 +128,9 @@ void BeginContext(NeoUI::Context *ctx, const NeoUI::Mode eMode, const wchar_t *w
 
 		if (wszTitle)
 		{
-			SwapFont(FONT_NTNORMAL);
+			SwapFont(FONT_NTHEADING);
 			surface()->DrawSetTextColor(COLOR_NEOPANELTEXTBRIGHT);
-			GCtxDrawSetTextPos(g_pCtx->iMarginX, -g_pCtx->iRowTall + g_pCtx->fonts[FONT_NTNORMAL].iYOffset);
+			GCtxDrawSetTextPos(g_pCtx->iMarginX, -g_pCtx->iRowTall + g_pCtx->fonts[FONT_NTHEADING].iYOffset);
 			surface()->DrawPrintText(wszTitle, V_wcslen(wszTitle));
 		}
 		break;
@@ -142,7 +142,7 @@ void BeginContext(NeoUI::Context *ctx, const NeoUI::Mode eMode, const wchar_t *w
 		break;
 	}
 
-	SwapFont(FONT_NTSMALL);
+	SwapFont(FONT_NTNORMAL);
 	surface()->DrawSetTextColor(COLOR_NEOPANELTEXTNORMAL);
 }
 
@@ -571,6 +571,7 @@ void RingBox(const wchar_t *wszLeftLabel, const wchar_t **wszLabelsList, const i
 
 void Tabs(const wchar_t **wszLabelsList, const int iLabelsSize, int *iIndex)
 {
+	SwapFont(FONT_NTHORIZSIDES);
 	// This is basically a ringbox but different UI
 	if (g_pCtx->iWidget == g_pCtx->iActive && g_pCtx->iSection == g_pCtx->iActiveSection) g_pCtx->iActive += g_pCtx->iActiveDirection;
 	const auto wdgState = InternalGetMouseinFocused();
@@ -649,6 +650,7 @@ void Tabs(const wchar_t **wszLabelsList, const int iLabelsSize, int *iIndex)
 	}
 
 	InternalUpdatePartitionState(wdgState);
+	SwapFont(FONT_NTNORMAL);
 }
 
 static float ClampAndLimitDp(const float curValue, const float flMin, const float flMax, const int iDp)

--- a/mp/src/game/client/neo/ui/neo_ui.h
+++ b/mp/src/game/client/neo/ui/neo_ui.h
@@ -96,9 +96,11 @@ struct FontInfo
 
 enum EFont
 {
-	FONT_NTSMALL,
 	FONT_NTNORMAL,
+	FONT_NTHEADING,
+	FONT_NTHORIZSIDES,
 	FONT_LOGO,
+	FONT_NTLARGE,
 
 	FONT__TOTAL,
 };
@@ -148,7 +150,7 @@ struct Context
 	bool bTextEditIsPassword;
 
 	FontInfo fonts[FONT__TOTAL];
-	EFont eFont = FONT_NTSMALL;
+	EFont eFont = FONT_NTNORMAL;
 
 	// Input management
 	int iWidget; // Always increments per widget use


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Now the normal font is green mountain for readability
* This is applied to main sections and popups
* Neuropol2 is kept for title, tabs, main menu steam/news, and bottom sections
* Refactored the naming of the fonts enums

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

* fixes #591

## Screenshot
![2024-09-18T000903_screen](https://github.com/user-attachments/assets/71fa9a26-fcf5-4af5-9217-f54656d2937b)

