### PR TITLE
End reload sound when switching with fast switch enabled

### DIFF
--- a/mp/src/game/client/hl2/hud_weaponselection.cpp
+++ b/mp/src/game/client/hl2/hud_weaponselection.cpp
@@ -1340,6 +1340,9 @@ void CHudWeaponSelection::FastWeaponSwitch( int iWeaponSlot )
 	{
 		// select the new weapon
 		::input->MakeWeaponSelection( pNextWeapon );
+#ifdef NEO
+		pPlayer->EmitSound("Player.WeaponSelected");
+#endif
 	}
 	else if ( pNextWeapon != pActiveWeapon )
 	{


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Plays WeaponSelected if weapon was succesfully selected using FastWeaponSwitch. Semantically makes sense to play WeaponSelected where DenyWeaponSelection is already played if FastWeaponSwitch returns false, however although the sound WeaponSelected is already played for the other weapon selection methods, it is never audible as in all other cases CloseWeaponSelection is played afterwards in the same channel, overwriting this sound.

If the same sound should be heard regardless of weapon selection method then either the sound added here should be replaced with CloseWeaponSelection which is audibly much louder to the player, is not heard ever when using the default weapon switch method in the original, and is a sound closely associated with the source engine (and perhaps should therefore be avoided). The alternative therefore would be to remove the CloseWeaponSelection sound from the other weapon selection methods, which would make the WeaponSelected sound that is also played in those instances audible.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes  #606
