### PR TITLE
Recon aux regen rate halved when sprinting

### DIFF
--- a/mp/src/game/server/hl2/hl2_player.cpp
+++ b/mp/src/game/server/hl2/hl2_player.cpp
@@ -422,6 +422,10 @@ static inline float GetAuxChargeRate(CBaseCombatCharacter *player)
 	switch (neoPlayer->GetClass())
 	{
 	case NEO_CLASS_RECON:
+		if (neoPlayer->IsSprinting())
+		{
+			return 2.5f;	// 100 units in 40 seconds
+		}
 		return 5.0f;	// 100 units in 20 seconds
 	case NEO_CLASS_ASSAULT:
 		return 2.5f;	// 100 units in 40 seconds


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #593 
