### PR TITLE
NeoUI - Console toggle key rebind, intended for non-` key layouts

### DIFF
--- a/mp/src/game/client/neo/ui/neo_root.cpp
+++ b/mp/src/game/client/neo/ui/neo_root.cpp
@@ -372,6 +372,21 @@ void CNeoRoot::FireGameEvent(IGameEvent *event)
 
 void CNeoRoot::OnRelayedKeyCodeTyped(vgui::KeyCode code)
 {
+	if (m_ns.keys.bcConsole <= KEY_NONE)
+	{
+		m_ns.keys.bcConsole = gameuifuncs->GetButtonCodeForBind("neo_toggleconsole");
+	}
+
+	if (code == m_ns.keys.bcConsole && code != KEY_BACKQUOTE)
+	{
+		// NEO JANK (nullsystem): Prevent toggle being handled twice causing it to not really open.
+		// This can happen if using the default ` due to the engine enacting this all the time, however calling
+		// NeoToggleconsole here is required for non-` keys that is toggled while the root panel is opened. The
+		// engine will call non-` keys by itself it it's in game and the root panel is not opened, or the console is
+		// opened which generally doesn't endup calling OnRelayedKeyCodeTyped anyway.
+		NeoToggleconsole();
+		return;
+	}
 	g_uiCtx.eCode = code;
 	OnMainLoop(NeoUI::MODE_KEYPRESSED);
 }

--- a/mp/src/game/client/neo/ui/neo_root_settings.h
+++ b/mp/src/game/client/neo/ui/neo_root_settings.h
@@ -33,6 +33,9 @@ struct NeoSettings
 		};
 		Bind vBinds[64];
 		int iBindsSize = 0;
+
+		// Will be checked often so cached
+		ButtonCode_t bcConsole;
 	};
 
 	struct Mouse


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* To workaround console not working for non-BACKQUOTE key layouts, allow the rebinding of the console to any key the user wants. This is also beneficial for people who also just want to put console to a separate key.
* Non-BACKQUOTE keys however requires the root menu to handle the key and toggleconsole itself, whereas BACKQUOTE key will always envoke. The root menu will handle it if it's active without a console opened. Otherwise the engine will envoke it even for non-BACKQUOTE itself if you're in-game without the root menu opened or the console is already opened.
* Nevra, who uses FR AZERTY confirmed this works well for him

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #620

