### PR TITLE
Allow player respawning during the first three seconds of the server

### DIFF
--- a/mp/src/game/server/neo/neo_client.cpp
+++ b/mp/src/game/server/neo/neo_client.cpp
@@ -349,7 +349,7 @@ bool RespawnWithRet( CBaseEntity *pEdict, bool fCopyCorpse )
 
 	if ( pPlayer )
 	{
-		if ( gpGlobals->curtime > pPlayer->GetDeathTime() + DEATH_ANIMATION_TIME )
+		if ( (gpGlobals->curtime > pPlayer->GetDeathTime() + DEATH_ANIMATION_TIME) || pPlayer->GetDeathTime() == 0.f)
 		{
 			if (NEORules()->FPlayerCanRespawn(pPlayer))
 			{


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
check if player death time is the default death time when respawning, only applies during the first three seconds of the server

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #644