### PR TITLE
Throwables origin clipping into ground workaround

### DIFF
--- a/mp/src/game/shared/neo/weapons/weapon_detpack.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_detpack.cpp
@@ -84,6 +84,7 @@ CWeaponDetpack::CWeaponDetpack()
 #ifdef GAME_DLL
 	m_pDetpack = NULL;
 #endif
+	SetViewOffset(Vector(0, 0, 1.0));
 }
 
 void CWeaponDetpack::Precache(void)

--- a/mp/src/game/shared/neo/weapons/weapon_grenade.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_grenade.cpp
@@ -70,6 +70,7 @@ PRECACHE_WEAPON_REGISTER(weapon_grenade);
 CWeaponGrenade::CWeaponGrenade()
 {
 	m_bRedraw = false;
+	SetViewOffset(Vector(0, 0, 1.0));
 }
 
 void CWeaponGrenade::Precache(void)

--- a/mp/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
@@ -48,6 +48,7 @@ PRECACHE_WEAPON_REGISTER(weapon_smokegrenade);
 CWeaponSmokeGrenade::CWeaponSmokeGrenade()
 {
 	m_bRedraw = false;
+	SetViewOffset(Vector(0, 0, 1.0));
 }
 
 void CWeaponSmokeGrenade::Precache(void)


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
give viewoffset so origin always appears above ground when dropped when performing a cansee calculation

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #233