### PR TITLE
Detpack correct sounds

### DIFF
--- a/mp/src/game/server/neo/neo_detpack.cpp
+++ b/mp/src/game/server/neo/neo_detpack.cpp
@@ -283,10 +283,10 @@ int CNEODeployedDetpack::OnTakeDamage(const CTakeDamageInfo& inputInfo)
 void CNEODeployedDetpack::InputRemoteDetonate(inputdata_t& inputdata)
 {
 	ExplosionCreate(GetAbsOrigin() + Vector(0, 0, 16), GetAbsAngles(), GetThrower(), GetDamage(), GetDamageRadius(),
-					SF_ENVEXPLOSION_NOSPARKS | SF_ENVEXPLOSION_NODLIGHTS | SF_ENVEXPLOSION_NOSMOKE, 0.0f, this);
+					SF_ENVEXPLOSION_NOSPARKS | SF_ENVEXPLOSION_NODLIGHTS | SF_ENVEXPLOSION_NOSMOKE | SF_ENVEXPLOSION_NOSOUND, 0.0f, this);
 	m_hasBeenTriggeredToDetonate = true;
 	DevMsg("CNEODeployedDetpack::InputRemoteDetonate triggered\n");
-	EmitSound("BaseGrenade.Explode");
+	EmitSound("weapon_remotedet.npc_single");
 	UTIL_Remove(this);
 }
 

--- a/mp/src/public/const.h
+++ b/mp/src/public/const.h
@@ -424,7 +424,7 @@ enum Collision_Group_t
 
 #include "basetypes.h"
 
-#define SOUND_NORMAL_CLIP_DIST	1000.0f
+#define SOUND_NORMAL_CLIP_DIST	10000.0f
 
 // How many networked area portals do we allow?
 #define MAX_AREA_STATE_BYTES		32

--- a/mp/src/public/const.h
+++ b/mp/src/public/const.h
@@ -423,9 +423,11 @@ enum Collision_Group_t
 };
 
 #include "basetypes.h"
-
+#ifdef NEO
 #define SOUND_NORMAL_CLIP_DIST	10000.0f
-
+#else
+#define SOUND_NORMAL_CLIP_DIST	1000.0f
+#endif
 // How many networked area portals do we allow?
 #define MAX_AREA_STATE_BYTES		32
 #define MAX_AREA_PORTAL_STATE_BYTES 24


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Increase main sound cut-off point, use correct explosion sound for detpack

Sounds in the original game can be heard from up to 10k hu away. This is 10 times larger than the current sound cutoff point.

Currently the detpack also uses an explosion sound with a special parameter that switches to a weaker distant explosion in the sounds right channel when the character is a set distance away from the explosion. The original detpack's explosion sound doesn't change much even out to 10k hu.

https://github.com/user-attachments/assets/64dacc92-6c44-4c82-915e-d6a361849581

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #584