### PR TITLE
Cloaked players not cloaked in thermals

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -630,7 +630,7 @@ int C_NEO_Player::DrawModel(int flags)
 		}
 	}
 	
-	if (IsCloaked())
+	if (IsCloaked() && !(pLocalPlayer && pLocalPlayer->GetClass() == NEO_CLASS_SUPPORT && pLocalPlayer->IsInVision()))
 	{
 		IMaterial* pass = materials->FindMaterial("dev/toc_cloakpass", TEXTURE_GROUP_CLIENT_EFFECTS);
 		Assert(pass && !pass->IsErrorMaterial());


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Check whether local player is in thermals

Should probably have a discussion about modifying this default behavior. I imagine in the original game this change was made intentionally as otherwise with how dark the rest of the map is in thermals cloaked players would be near impossible to locate when looking at them through thermals. If it is easier to discern features of the maps in the current thermals then maybe more leeway can be given to making cloaked players harder to spot in thermals. 

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #672