### PR TITLE
NeoUI - Custom loading screen, wrapped text

### DIFF
--- a/mp/src/game/client/CMakeLists.txt
+++ b/mp/src/game/client/CMakeLists.txt
@@ -1516,6 +1516,8 @@ target_sources_grouped(
     neo/ui/neo_root_serverbrowser.h
     neo/ui/neo_root_settings.cpp
     neo/ui/neo_root_settings.h
+    neo/ui/neo_loading.cpp
+    neo/ui/neo_loading.h
     neo/ui/neo_ui.cpp
     neo/ui/neo_ui.h
     neo/ui/IOverrideInterface.h

--- a/mp/src/game/client/cdll_client_int.cpp
+++ b/mp/src/game/client/cdll_client_int.cpp
@@ -173,7 +173,9 @@ extern vgui::IInputInternal *g_InputInternal;
 #ifdef NEO
 #include "neo_version.h"
 #include "neo_mount_original.h"
+#include "ui/neo_loading.h"
 extern bool NeoRootCaptureESC();
+extern CNeoLoading *g_pNeoLoading;
 
 #ifdef LINUX
 #include "neo_fixup_glshaders.h"
@@ -1769,6 +1771,10 @@ void CHLClient::LevelInitPostEntity( )
 	IGameSystem::LevelInitPostEntityAllSystems();
 	C_PhysPropClientside::RecreateAll();
 	internalCenterPrint->Clear();
+
+#ifdef NEO
+	g_pNeoLoading->m_wszLoadingMap[0] = L'\0';
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/mp/src/game/client/neo/ui/neo_loading.cpp
+++ b/mp/src/game/client/neo/ui/neo_loading.cpp
@@ -1,0 +1,214 @@
+#include "neo_loading.h"
+
+#include "cbase.h"
+#include "ienginevgui.h"
+#include "ui/neo_root.h"
+#include "vgui/ISurface.h"
+#include "vgui_controls/ProgressBar.h"
+#include "vgui_controls/Label.h"
+#include "vgui_controls/TextImage.h"
+#include "vgui_controls/Frame.h"
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+CNeoLoading::CNeoLoading()
+	: vgui::EditablePanel(nullptr, "NeoLoadingPanel")
+{
+	SetParent(enginevgui->GetPanel(PANEL_GAMEUIDLL));
+	InvalidateLayout(false, true);
+	SetVisible(false);
+	MakePopup(false);
+
+	vgui::HScheme neoscheme = vgui::scheme()->LoadSchemeFromFileEx(
+		enginevgui->GetPanel(PANEL_CLIENTDLL), "resource/ClientScheme.res", "ClientScheme");
+	SetScheme(neoscheme);
+
+	SetMouseInputEnabled(true);
+	// NEO TODO (nullsystem): Don't need to handle KB input since ESC already does that
+	// Unless console controller the concern?
+	//SetKeyBoardInputEnabled(true);
+
+	vgui::IScheme *pScheme = vgui::scheme()->GetIScheme(neoscheme);
+	ApplySchemeSettings(pScheme);
+}
+
+void CNeoLoading::ApplySchemeSettings(vgui::IScheme *pScheme)
+{
+	BaseClass::ApplySchemeSettings(pScheme);
+
+	int wide, tall;
+	vgui::surface()->GetScreenSize(wide, tall);
+	SetSize(wide, tall);
+	SetFgColor(COLOR_TRANSPARENT);
+	SetBgColor(COLOR_TRANSPARENT);
+
+	static constexpr const char *FONT_NAMES[NeoUI::FONT__TOTAL] = {
+		"NeoUINormal", "NHudOCR", "NHudOCRSmallNoAdditive", "ClientTitleFont",
+		"NeoUILarge"
+	};
+	for (int i = 0; i < NeoUI::FONT__TOTAL; ++i)
+	{
+		m_uiCtx.fonts[i].hdl = pScheme->GetFont(FONT_NAMES[i], true);
+	}
+
+	// In 1080p, g_uiCtx.iRowTall == 40, g_uiCtx.iMarginX = 10, g_iAvatar = 64,
+	// other resolution scales up/down from it
+	m_uiCtx.iRowTall = tall / 27;
+	m_iRowsInScreen = (tall * 0.85f) / m_uiCtx.iRowTall;
+	m_uiCtx.iMarginX = wide / 192;
+	m_uiCtx.iMarginY = tall / 108;
+	m_uiCtx.selectBgColor = COLOR_NEOPANELACCENTBG;
+	const float flWide = static_cast<float>(wide);
+	float flWideAs43 = static_cast<float>(tall) * (4.0f / 3.0f);
+	if (flWideAs43 > flWide) flWideAs43 = flWide;
+	m_iRootSubPanelWide = static_cast<int>(flWideAs43 * 0.9f);
+}
+
+void CNeoLoading::OnMessage(const KeyValues *params, vgui::VPANEL fromPanel)
+{
+	BaseClass::OnMessage(params, fromPanel);
+	const char *pSzMsgName = params->GetName();
+	if (V_strcmp(pSzMsgName, "Activate") == 0)
+	{
+		FetchGameUIPanels();
+		g_pNeoRoot->m_bOnLoadingScreen = true;
+	}
+	else if (V_strcmp(pSzMsgName, "deactivate") == 0)
+	{
+		g_pNeoRoot->m_bOnLoadingScreen = false;
+	}
+}
+
+void CNeoLoading::FetchGameUIPanels()
+{
+	m_bValidGameUIPanels = false;
+	vgui::VPANEL basePanel = vgui::INVALID_PANEL;
+	vgui::VPANEL rootPanel = enginevgui->GetPanel(PANEL_GAMEUIDLL);
+	const int iRootChildren = vgui::ipanel()->GetChildCount(rootPanel);
+	for (int i = 0; i < iRootChildren; ++i)
+	{
+		const vgui::VPANEL curBasePanel = vgui::ipanel()->GetChild(rootPanel, i);
+		const char *curBasePanelName = vgui::ipanel()->GetName(curBasePanel);
+		if (V_strcmp(curBasePanelName, "BaseGameUIPanel") == 0)
+		{
+			basePanel = curBasePanel;
+			break;
+		}
+	}
+	if (basePanel == vgui::INVALID_PANEL)
+	{
+		return;
+	}
+
+	vgui::VPANEL loadingPanel = vgui::INVALID_PANEL;
+	const int iBaseChildren = vgui::ipanel()->GetChildCount(basePanel);
+	for (int i = 0; i < iBaseChildren; ++i)
+	{
+		const vgui::VPANEL curLoadingPanel = vgui::ipanel()->GetChild(basePanel, i);
+		const char *curLoadingPanelName = vgui::ipanel()->GetName(curLoadingPanel);
+		if (V_strcmp(curLoadingPanelName, "LoadingDialog") == 0)
+		{
+			loadingPanel = curLoadingPanel;
+			break;
+		}
+	}
+	if (loadingPanel == vgui::INVALID_PANEL)
+	{
+		return;
+	}
+
+	m_pLoadingPanel = static_cast<vgui::Frame *>(vgui::ipanel()->GetPanel(loadingPanel, "GAMEUI"));
+
+	m_aStrIdxMap[LOADINGSTATE_LOADING] = g_pVGuiLocalize->FindIndex("GameUI_Loading");
+	m_aStrIdxMap[LOADINGSTATE_DISCONNECTED] = g_pVGuiLocalize->FindIndex("GameUI_Disconnected");
+
+	// Hide loading panel
+	vgui::ipanel()->SetParent(loadingPanel, 0);
+	m_bValidGameUIPanels = true;
+	const int iLoadingChildren = vgui::ipanel()->GetChildCount(loadingPanel);
+	for (int i = 0; i < iLoadingChildren; ++i)
+	{
+		const vgui::VPANEL curLoadChPanel = vgui::ipanel()->GetChild(loadingPanel, i);
+		const char *curLoadChPanelName = vgui::ipanel()->GetName(curLoadChPanel);
+		const char *curLoadChPanelClass = vgui::ipanel()->GetClassName(curLoadChPanel);
+		Panel *pPanel = vgui::ipanel()->GetPanel(curLoadChPanel, "GAMEUI");
+		if (!pPanel)
+		{
+			continue;
+		}
+		if (V_strcmp(curLoadChPanelName, "Progress") == 0)
+		{
+			Assert(V_strcmp(curLoadChPanelClass, "ProgressBar") == 0);
+			m_pProgressBarMain = static_cast<vgui::ProgressBar *>(pPanel);
+		}
+		else if (V_strcmp(curLoadChPanelName, "InfoLabel") == 0)
+		{
+			Assert(V_strcmp(curLoadChPanelClass, "Label") == 0);
+			m_pLabelInfo = static_cast<vgui::Label *>(pPanel);
+		}
+		// NEO NOTE (nullsystem): Unused panels:
+		//    "Progress2" - Don't seem utilized
+		//    "TimeRemainingLabel" - Don't seem utilized
+		//    "CancelButton" - Can't do mouse input proper/workaround doesn't work well
+	}
+}
+
+void CNeoLoading::Paint()
+{
+	OnMainLoop(NeoUI::MODE_PAINT);
+}
+
+void CNeoLoading::OnMainLoop(const NeoUI::Mode eMode)
+{
+	static constexpr int BOTTOM_ROWS = 3;
+
+	int wide, tall;
+	GetSize(wide, tall);
+	m_uiCtx.dPanel.x = (wide / 2) - (m_iRootSubPanelWide / 2);
+	m_uiCtx.dPanel.wide = m_iRootSubPanelWide;
+	m_uiCtx.dPanel.tall = (m_iRowsInScreen - BOTTOM_ROWS) * m_uiCtx.iRowTall;
+	m_uiCtx.dPanel.y = (tall / 2) - ((m_iRowsInScreen * m_uiCtx.iRowTall) / 2);
+	m_uiCtx.bgColor = COLOR_TRANSPARENT;
+
+	// NEO JANK (nullsystem): Since we don't have proper access to loading internals,
+	// determining by localization text index should be good enough to differ between
+	// loading and disconnect state.
+	vgui::TextImage *pTITitle = m_pLoadingPanel ? m_pLoadingPanel->TITitlePtr() : nullptr;
+	const StringIndex_t iStrIdx = pTITitle ? pTITitle->GetUnlocalizedTextSymbol() : INVALID_LOCALIZE_STRING_INDEX;
+	NeoUI::BeginContext(&m_uiCtx, eMode, pTITitle ? pTITitle->GetUText() : L"Loading...", "NeoLoadingMainCtx");
+	if (iStrIdx == m_aStrIdxMap[LOADINGSTATE_LOADING])
+	{
+		NeoUI::BeginSection();
+		{
+			m_uiCtx.eFont = NeoUI::FONT_NTLARGE;
+			NeoUI::Label(m_wszLoadingMap);
+			m_uiCtx.eFont = NeoUI::FONT_NTNORMAL;
+		}
+		NeoUI::EndSection();
+		m_uiCtx.dPanel.y += m_uiCtx.dPanel.tall;
+		m_uiCtx.dPanel.tall = BOTTOM_ROWS * m_uiCtx.iRowTall;
+		m_uiCtx.bgColor = COLOR_NEOPANELFRAMEBG;
+		NeoUI::BeginSection(true);
+		{
+			NeoUI::Label(L"Press ESC to cancel");
+			if (m_pLabelInfo) NeoUI::Label(m_pLabelInfo->GetTextImage()->GetUText());
+			if (m_pProgressBarMain) NeoUI::Progress(m_pProgressBarMain->GetProgress(), 0.0f, 1.0f);
+		}
+		NeoUI::EndSection();
+	}
+	else if (iStrIdx == m_aStrIdxMap[LOADINGSTATE_DISCONNECTED])
+	{
+		m_uiCtx.dPanel.tall = (m_iRowsInScreen / 2) * m_uiCtx.iRowTall;
+		m_uiCtx.dPanel.y = (tall / 2) - (m_uiCtx.dPanel.tall / 2);
+		m_uiCtx.bgColor = COLOR_NEOPANELFRAMEBG;
+		NeoUI::BeginSection(true);
+		{
+			if (m_pLabelInfo) NeoUI::LabelWrap(m_pLabelInfo->GetTextImage()->GetUText());
+			NeoUI::Pad();
+			NeoUI::Label(L"Press ESC to go back");
+		}
+		NeoUI::EndSection();
+	}
+	NeoUI::EndContext();
+}

--- a/mp/src/game/client/neo/ui/neo_loading.h
+++ b/mp/src/game/client/neo/ui/neo_loading.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "ui/neo_ui.h"
+#include <vgui_controls/EditablePanel.h>
+
+/*
+ * Override loading screen
+ *
+ * Based on: https://developer.valvesoftware.com/wiki/Custom_loading_screen by Maestra Fenix
+ * Although goes beyond and tries to re-route text and progress into NeoUI
+ */
+
+class CNeoLoading : public vgui::EditablePanel
+{
+	DECLARE_CLASS_SIMPLE(CNeoLoading, vgui::EditablePanel);
+public:
+	CNeoLoading();
+	wchar_t m_wszLoadingMap[256] = {};
+
+	void ApplySchemeSettings(vgui::IScheme *pScheme) final;
+	void OnMessage(const KeyValues *params, vgui::VPANEL fromPanel) final;
+	void FetchGameUIPanels();
+
+	void Paint() final;
+	void OnMainLoop(const NeoUI::Mode eMode);
+
+	NeoUI::Context m_uiCtx;
+	int m_iRowsInScreen = 0;
+	int m_iRootSubPanelWide = 0;
+
+	bool m_bValidGameUIPanels = false;
+	vgui::Frame *m_pLoadingPanel = nullptr;
+	vgui::ProgressBar *m_pProgressBarMain = nullptr;
+	vgui::Label *m_pLabelInfo = nullptr;
+
+	enum ELoadingState
+	{
+		LOADINGSTATE_LOADING = 0,
+		LOADINGSTATE_DISCONNECTED,
+
+		LOADINGSTATE__TOTAL,
+	};
+	unsigned long m_aStrIdxMap[LOADINGSTATE__TOTAL] = {};
+};

--- a/mp/src/game/client/neo/ui/neo_root.h
+++ b/mp/src/game/client/neo/ui/neo_root.h
@@ -188,6 +188,8 @@ public:
 
 	vgui::FileOpenDialog *m_pFileIODialog = nullptr;
 	MESSAGE_FUNC_CHARPTR(OnFileSelected, "FileSelected", fullpath);
+
+	bool m_bOnLoadingScreen = false;
 };
 
 extern CNeoRoot *g_pNeoRoot;

--- a/mp/src/game/client/neo/ui/neo_ui.h
+++ b/mp/src/game/client/neo/ui/neo_ui.h
@@ -142,7 +142,7 @@ struct Context
 	int iLayoutX;
 	int iLayoutY;
 	int iWgXPos;
-	int iYOffset[MAX_SECTIONS];
+	int iYOffset[MAX_SECTIONS] = {};
 
 	int iHorizontalWidth;
 	int iHorizontalMargin;
@@ -151,14 +151,14 @@ struct Context
 	TextStyle eLabelTextStyle;
 	bool bTextEditIsPassword;
 
-	FontInfo fonts[FONT__TOTAL];
+	FontInfo fonts[FONT__TOTAL] = {};
 	EFont eFont = FONT_NTNORMAL;
 
 	// Input management
 	int iWidget; // Always increments per widget use
 	int iSection;
 	int iCanActives; // Only increment if widget can be activated
-	int iSectionCanActive[MAX_SECTIONS];
+	int iSectionCanActive[MAX_SECTIONS] = {};
 
 	int iHot;
 	int iHotSection;
@@ -189,6 +189,7 @@ struct Context
 void GCtxDrawFilledRectXtoX(const int x1, const int y1, const int x2, const int y2);
 void GCtxDrawFilledRectXtoX(const int x1, const int x2);
 void GCtxDrawSetTextPos(const int x, const int y);
+void GCtxSkipActive();
 
 void BeginContext(NeoUI::Context *ctx, const NeoUI::Mode eMode, const wchar_t *wszTitle, const char *pSzCtxName);
 void EndContext();
@@ -209,6 +210,7 @@ struct RetButton
 	bool bMouseDoublePressed;
 };
 void Pad();
+void LabelWrap(const wchar_t *wszText);
 void Label(const wchar_t *wszText);
 void Label(const wchar_t *wszLabel, const wchar_t *wszText);
 void Tabs(const wchar_t **wszLabelsList, const int iLabelsSize, int *iIndex);
@@ -216,6 +218,7 @@ RetButton Button(const wchar_t *wszText);
 RetButton Button(const wchar_t *wszLeftLabel, const wchar_t *wszText);
 void RingBoxBool(const wchar_t *wszLeftLabel, bool *bChecked);
 void RingBox(const wchar_t *wszLeftLabel, const wchar_t **wszLabelsList, const int iLabelsSize, int *iIndex);
+void Progress(const float flValue, const float flMin, const float flMax);
 void Slider(const wchar_t *wszLeftLabel, float *flValue, const float flMin, const float flMax,
 			const int iDp = 2, const float flStep = 1.0f, const wchar_t *wszSpecialText = nullptr);
 void SliderInt(const wchar_t *wszLeftLabel, int *iValue, const int iMin, const int iMax, const int iStep = 1,

--- a/mp/src/public/vgui_controls/Frame.h
+++ b/mp/src/public/vgui_controls/Frame.h
@@ -133,6 +133,10 @@ public:
 	// Temporarily enables or disables the fade effect rather than zeroing the fade times as done in DisableFadeEffect
 	void SetFadeEffectDisableOverride( bool disabled );
 
+#ifdef NEO
+	TextImage *TITitlePtr() { return _title; }
+#endif
+
 protected:
 	// Respond to mouse presses
 	virtual void OnMousePressed(MouseCode code);


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Re-route the old VGUI text/progress into NeoUI
* Loading vs disconnect states by title locale index
* Single-progress bar as 2nd one not used
* Preload map name if known (serverlist + new game)
* `NeoUI::LabelWrap` for a wrapped version of a label
* `NeoUI::Progress` a read-only progress bar
* No mouse input since it doesn't work properly/workarounds doesn't work well

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #603

