### PR TITLE
Adjust Uplink element for larger resolutions

### DIFF
--- a/mp/src/game/client/neo/ui/neo_hud_ghost_uplink_state.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_uplink_state.cpp
@@ -51,7 +51,10 @@ void CNEOHud_GhostUplinkState::ApplySchemeSettings(vgui::IScheme* pScheme)
 	surface()->GetScreenSize(screenWidth, screenHeight);
 	int centerX = screenWidth / 2;
 	int textureXPos = centerX - (m_iUplinkTextureWidth / 2);
-	static constexpr int COMPASS_HEIGHT_PLUS_MARGINS = 30;
+	//NEOJANK <1440p resolutions have the uplink element clip into compass (Bryson)
+	static int COMPASS_HEIGHT_PLUS_MARGINS = 30;
+	if (screenHeight > 1440)
+		COMPASS_HEIGHT_PLUS_MARGINS = 45;
 	int textureYPos = screenHeight - m_iUplinkTextureHeight - COMPASS_HEIGHT_PLUS_MARGINS;
 	SetBounds(textureXPos, textureYPos, m_iUplinkTextureWidth, m_iUplinkTextureHeight);
 	SetFgColor(COLOR_TRANSPARENT);

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_uplink_state.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_uplink_state.cpp
@@ -51,7 +51,7 @@ void CNEOHud_GhostUplinkState::ApplySchemeSettings(vgui::IScheme* pScheme)
 	surface()->GetScreenSize(screenWidth, screenHeight);
 	int centerX = screenWidth / 2;
 	int textureXPos = centerX - (m_iUplinkTextureWidth / 2);
-	//NEOJANK <1440p resolutions have the uplink element clip into compass (Bryson)
+	//NEOJANK >=1440p resolutions have the uplink element clip into compass (Bryson)
 	static int COMPASS_HEIGHT_PLUS_MARGINS = 30;
 	if (screenHeight > 1440)
 		COMPASS_HEIGHT_PLUS_MARGINS = 45;

--- a/mp/src/game/client/neo/ui/neo_hud_ghost_uplink_state.cpp
+++ b/mp/src/game/client/neo/ui/neo_hud_ghost_uplink_state.cpp
@@ -21,8 +21,6 @@ CNEOHud_GhostUplinkState::CNEOHud_GhostUplinkState(const char *pElementName, vgu
 {
 	SetAutoDelete(true);
 
-	SetScheme("ClientScheme.res");
-
 	if (parent) {
 		SetParent(parent);
 	}
@@ -47,20 +45,21 @@ CNEOHud_GhostUplinkState::CNEOHud_GhostUplinkState(const char *pElementName, vgu
 
 void CNEOHud_GhostUplinkState::ApplySchemeSettings(vgui::IScheme* pScheme)
 {
+	BaseClass::ApplySchemeSettings(pScheme);
+
 	int screenWidth, screenHeight;
 	surface()->GetScreenSize(screenWidth, screenHeight);
 	int centerX = screenWidth / 2;
 	int textureXPos = centerX - (m_iUplinkTextureWidth / 2);
-	//NEOJANK >=1440p resolutions have the uplink element clip into compass (Bryson)
-	static int COMPASS_HEIGHT_PLUS_MARGINS = 30;
-	if (screenHeight > 1440)
-		COMPASS_HEIGHT_PLUS_MARGINS = 45;
-	int textureYPos = screenHeight - m_iUplinkTextureHeight - COMPASS_HEIGHT_PLUS_MARGINS;
+	// Calculate margin between compass + material
+	// NEO FIXME: Find a way to get 'HudLayout.res' -> 'NHudCompass' -> 'y_bottom_pos' value dynamically
+	int iCompassMargin = (screenHeight / 480) * 3;
+	vgui::HFont m_hFont = pScheme->GetFont("NHudOCRSmall");
+	int iFontHeight = vgui::surface()->GetFontTall(m_hFont);
+	int textureYPos = screenHeight - m_iUplinkTextureHeight - iFontHeight - ( 2 * iCompassMargin);
 	SetBounds(textureXPos, textureYPos, m_iUplinkTextureWidth, m_iUplinkTextureHeight);
 	SetFgColor(COLOR_TRANSPARENT);
 	SetBgColor(COLOR_TRANSPARENT);
-
-	BaseClass::ApplySchemeSettings(pScheme);
 }
 
 void CNEOHud_GhostUplinkState::UpdateStateForNeoHudElementDraw()


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
Currently, any resolution exceeding 1440 pixels horizontally will result in the uplink icon clipping below the compass rose on the HUD. This aims to mitigate this issue for up to 4K (my max resolution).

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

4K (3840x2160) before changes
![image](https://github.com/user-attachments/assets/31914907-c3e3-4067-b991-35382c858504)


4K (3840x2160) after changes
![Preview of 4K (3840x2160) after changes](https://github.com/user-attachments/assets/bb4ad243-90e8-4c2b-af9b-604b7f70531a)

## Notes
I have also tested swapping resolutions and watching the `vgui_drawtree` highlight to see if it stays consistent. Not sure if there are any other scenarios I might need to try out but it seems fine.