### PR TITLE
Add ready up mechanic to start a match, allow non-auto-intermission

### DIFF
--- a/mp/src/game/client/neo/ui/neo_hud_round_state.h
+++ b/mp/src/game/client/neo/ui/neo_hud_round_state.h
@@ -65,7 +65,8 @@ private:
 	wchar_t m_wszLeftTeamScore[3] = {};
 	wchar_t m_wszRightTeamScore[3] = {};
 	wchar_t m_wszPlayersAliveUnicode[9] = {};
-	wchar_t m_wszStatusUnicode[24] = {};
+	const wchar_t *m_pWszStatusUnicode = nullptr;
+	int m_iStatusUnicodeSize = 0;
 	wchar_t m_wszGameTypeDescription[MAX_GAME_TYPE_OBJECTIVE_LENGTH] = {};
 	char szGameTypeDescription[MAX_GAME_TYPE_OBJECTIVE_LENGTH] = {};
 

--- a/mp/src/game/server/client.cpp
+++ b/mp/src/game/server/client.cpp
@@ -47,6 +47,7 @@
 
 #ifdef NEO
 #include "neo_player.h"
+#include "neo_gamerules.h"
 #endif
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -276,6 +277,10 @@ void Host_Say( edict_t *pEdict, const CCommand &args, bool teamonly )
 
 	Q_strncat( text, p, sizeof( text ), COPY_ALL_CHARACTERS );
 	Q_strncat( text, "\n", sizeof( text ), COPY_ALL_CHARACTERS );
+
+#ifdef NEO
+	static_cast<CNEORules *>(g_pGameRules)->CheckChatCommand(static_cast<CNEO_Player *>(pPlayer), p);
+#endif
  
 	// loop through all players
 	// Start with the first player.

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -225,6 +225,17 @@ public:
 	bool IsRoundOver() const;
 #ifdef GAME_DLL
 	void GatherGameTypeVotes();
+
+	struct ReadyPlayers
+	{
+		int array[TEAM__TOTAL];
+	};
+	void CheckChatCommand(CNEO_Player *pNeoPlayer, const char *pSzChat);
+	ReadyPlayers FetchReadyPlayers() const;
+	CUtlHashtable<AccountID_t> m_readyAccIDs;
+	bool m_bIgnoreOverThreshold = false;
+	bool ReadyUpPlayerIsReady(CNEO_Player *pNeoPlayer) const;
+
 	void StartNextRound();
 
 	virtual const char* GetChatFormat(bool bTeamOnly, CBasePlayer* pPlayer) OVERRIDE;


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* A (not enabled by default) ready up mechanic that will only start a game if the players ready match the defined threshold (default to 5v5)
* Allows to override the limit if desired, although for either scenarios will still require equal amount of players between Jinrai and NSF
* New native player commands to set/unset ready state, configure override limit, and check players not ready
* The override limit will reset to false when players drops below threshold
* Automatic intermission can be turned off with the ready-up feature on
* HUD round state fixed to just directly take the const wchar_t strings and therefore no need for ANSI->WCHAR conversions
* Make sure round wins and XPs are resetting on non-intermission/idle/warmup to ready
* Player commands
    * !ready - For the player to signal they're ready to play
    * !unready - For the player to signal they're not ready to play
    * !overridelimit - A player to signal in behalf of everyone that they'll be playing over the stated limit
    * !playersnotready - Prints the players that are not ready and give info on why it's not starting
    * !help - Prints the help text which usually just showing those commands
* ConVars
    * neo_sv_readyup_lobby - 0 by default, toggles the ready-up feature
    * neo_sv_readyup_teamplayersthres - 5 by default, the exact amount of players to ready-up and participate to start a game
    * neo_sv_readyup_skipwarmup - 1 by default, if ready-up feature is on and this is enabled, skip warmup state
    * neo_sv_readyup_autointermission - 0 by default, if disabled will not automatically enter intermission when the match ends

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #218
* fixes #222

