### PR TITLE
Fix collision (knife, bullet, blood) by limiting NT collide check to only movement

### DIFF
--- a/mp/src/game/shared/gamemovement.cpp
+++ b/mp/src/game/shared/gamemovement.cpp
@@ -801,6 +801,20 @@ Vector CGameMovement::GetPlayerViewOffset( bool ducked ) const
 #endif
 }
 
+inline void UTIL_TraceRayMovement( const Ray_t &ray, unsigned int mask,
+						  const IHandleEntity *ignore, int collisionGroup, trace_t *ptr, ShouldHitFunc_t pExtraShouldHitCheckFn = NULL )
+{
+	CTraceFilterSimple traceFilter( ignore, collisionGroup, pExtraShouldHitCheckFn );
+	traceFilter.m_bIgnoreNeoCollide = false;
+
+	enginetrace->TraceRay( ray, mask, &traceFilter, ptr );
+
+	if( r_visualizetraces.GetBool() )
+	{
+		DebugDrawLine( ptr->startpos, ptr->endpos, 255, 0, 0, true, -1.0f );
+	}
+}
+
 #if 0
 //-----------------------------------------------------------------------------
 // Traces player movement + position
@@ -819,7 +833,7 @@ CBaseHandle CGameMovement::TestPlayerPosition( const Vector& pos, int collisionG
 {
 	Ray_t ray;
 	ray.Init( pos, pos, GetPlayerMins(), GetPlayerMaxs() );
-	UTIL_TraceRay( ray, PlayerSolidMask(), mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
+	UTIL_TraceRayMovement( ray, PlayerSolidMask(), mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
 	if ( (pm.contents & PlayerSolidMask()) && pm.m_pEnt )
 	{
 		return pm.m_pEnt->GetRefEHandle();
@@ -3738,7 +3752,7 @@ void TracePlayerBBoxForGround( const Vector& start, const Vector& end, const Vec
 	mins = minsSrc;
 	maxs.Init( MIN( 0, maxsSrc.x ), MIN( 0, maxsSrc.y ), maxsSrc.z );
 	ray.Init( start, end, mins, maxs );
-	UTIL_TraceRay( ray, fMask, player, collisionGroup, &pm );
+	UTIL_TraceRayMovement( ray, fMask, player, collisionGroup, &pm );
 	if ( pm.m_pEnt && pm.plane.normal[2] >= 0.7)
 	{
 		pm.fraction = fraction;
@@ -3750,7 +3764,7 @@ void TracePlayerBBoxForGround( const Vector& start, const Vector& end, const Vec
 	mins.Init( MAX( 0, minsSrc.x ), MAX( 0, minsSrc.y ), minsSrc.z );
 	maxs = maxsSrc;
 	ray.Init( start, end, mins, maxs );
-	UTIL_TraceRay( ray, fMask, player, collisionGroup, &pm );
+	UTIL_TraceRayMovement( ray, fMask, player, collisionGroup, &pm );
 	if ( pm.m_pEnt && pm.plane.normal[2] >= 0.7)
 	{
 		pm.fraction = fraction;
@@ -3762,7 +3776,7 @@ void TracePlayerBBoxForGround( const Vector& start, const Vector& end, const Vec
 	mins.Init( minsSrc.x, MAX( 0, minsSrc.y ), minsSrc.z );
 	maxs.Init( MIN( 0, maxsSrc.x ), maxsSrc.y, maxsSrc.z );
 	ray.Init( start, end, mins, maxs );
-	UTIL_TraceRay( ray, fMask, player, collisionGroup, &pm );
+	UTIL_TraceRayMovement( ray, fMask, player, collisionGroup, &pm );
 	if ( pm.m_pEnt && pm.plane.normal[2] >= 0.7)
 	{
 		pm.fraction = fraction;
@@ -3774,7 +3788,7 @@ void TracePlayerBBoxForGround( const Vector& start, const Vector& end, const Vec
 	mins.Init( MAX( 0, minsSrc.x ), minsSrc.y, minsSrc.z );
 	maxs.Init( maxsSrc.x, MIN( 0, maxsSrc.y ), maxsSrc.z );
 	ray.Init( start, end, mins, maxs );
-	UTIL_TraceRay( ray, fMask, player, collisionGroup, &pm );
+	UTIL_TraceRayMovement( ray, fMask, player, collisionGroup, &pm );
 	if ( pm.m_pEnt && pm.plane.normal[2] >= 0.7)
 	{
 		pm.fraction = fraction;
@@ -5109,7 +5123,7 @@ void CGameMovement::TracePlayerBBox( const Vector& start, const Vector& end, uns
 
 	Ray_t ray;
 	ray.Init( start, end, GetPlayerMins(), GetPlayerMaxs() );
-	UTIL_TraceRay( ray, fMask, mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
+	UTIL_TraceRayMovement( ray, fMask, mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
 
 }
 
@@ -5124,6 +5138,6 @@ void  CGameMovement::TryTouchGround( const Vector& start, const Vector& end, con
 
 	Ray_t ray;
 	ray.Init( start, end, mins, maxs );
-	UTIL_TraceRay( ray, fMask, mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
+	UTIL_TraceRayMovement( ray, fMask, mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
 }
 

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -477,9 +477,7 @@ bool CNEORules::ShouldCollide(const CBaseEntity *ent0, const CBaseEntity *ent1) 
 	const int ent0Group = ent0->GetCollisionGroup();
 	const int ent1Group = ent1->GetCollisionGroup();
 	const int iNeoCol = neo_sv_collision.GetInt();
-	if (iNeoCol != NEOCOLLISION_ALL &&
-			(ent0Group == COLLISION_GROUP_PLAYER || ent0Group == COLLISION_GROUP_PLAYER_MOVEMENT) &&
-			(ent1Group == COLLISION_GROUP_PLAYER || ent1Group == COLLISION_GROUP_PLAYER_MOVEMENT))
+	if (iNeoCol != NEOCOLLISION_ALL && ent0Group == COLLISION_GROUP_PLAYER && ent1Group == COLLISION_GROUP_PLAYER)
 	{
 		return (iNeoCol == NEOCOLLISION_TEAM) ?
 					(static_cast<const CNEO_Player *>(ent0)->GetTeamNumber() != static_cast<const CNEO_Player *>(ent1)->GetTeamNumber()) :

--- a/mp/src/game/shared/util_shared.cpp
+++ b/mp/src/game/shared/util_shared.cpp
@@ -278,6 +278,9 @@ bool StandardFilterRules( IHandleEntity *pHandleEntity, int fContentsMask )
 CTraceFilterSimple::CTraceFilterSimple( const IHandleEntity *passedict, int collisionGroup,
 									   ShouldHitFunc_t pExtraShouldHitFunc )
 {
+#ifdef NEO
+	m_bIgnoreNeoCollide = true;
+#endif
 	m_pPassEnt = passedict;
 	m_collisionGroup = collisionGroup;
 	m_pExtraShouldHitCheckFunction = pExtraShouldHitFunc;
@@ -306,7 +309,7 @@ bool CTraceFilterSimple::ShouldHitEntity( IHandleEntity *pHandleEntity, int cont
 	if ( !pEntity->ShouldCollide( m_collisionGroup, contentsMask ) )
 		return false;
 #ifdef NEO
-	if (m_pPassEnt)
+	if (!m_bIgnoreNeoCollide && m_pPassEnt)
 	{
 		const CBaseEntity *pThisEntity = EntityFromEntityHandle(m_pPassEnt);
 		if (pEntity && pThisEntity && !static_cast<CNEORules *>(g_pGameRules)->ShouldCollide(pThisEntity, pEntity))

--- a/mp/src/game/shared/util_shared.h
+++ b/mp/src/game/shared/util_shared.h
@@ -124,6 +124,9 @@ public:
 	virtual void SetCollisionGroup( int iCollisionGroup ) { m_collisionGroup = iCollisionGroup; }
 
 	const IHandleEntity *GetPassEntity( void ){ return m_pPassEnt;}
+#ifdef NEO
+	bool m_bIgnoreNeoCollide;
+#endif
 
 private:
 	const IHandleEntity *m_pPassEnt;


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Fix the collision detection which went too far. It should only be dealing with movement

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

