### PR TITLE
Fix possible crash on exit - NeoLoading

### DIFF
--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -317,7 +317,7 @@ ClientModeShared::~ClientModeShared()
 #ifdef NEO
 	if (g_pNeoLoading)
 	{
-		delete g_pNeoLoading;
+		g_pNeoLoading->MarkForDeletion();
 		g_pNeoLoading = nullptr;
 	}
 #endif


### PR DESCRIPTION
Sometimes it can crash on exit due to a direct delete. Even then it kind of doesnt even matter much if delete or not since the lifetime of this is practically once whole session and OS cleans up on exit anyway.