### PR TITLE
Revert "team based blocking and options"

### DIFF
--- a/mp/src/game/shared/gamemovement.cpp
+++ b/mp/src/game/shared/gamemovement.cpp
@@ -801,20 +801,6 @@ Vector CGameMovement::GetPlayerViewOffset( bool ducked ) const
 #endif
 }
 
-inline void UTIL_TraceRayMovement( const Ray_t &ray, unsigned int mask,
-						  const IHandleEntity *ignore, int collisionGroup, trace_t *ptr, ShouldHitFunc_t pExtraShouldHitCheckFn = NULL )
-{
-	CTraceFilterSimple traceFilter( ignore, collisionGroup, pExtraShouldHitCheckFn );
-	traceFilter.m_bIgnoreNeoCollide = false;
-
-	enginetrace->TraceRay( ray, mask, &traceFilter, ptr );
-
-	if( r_visualizetraces.GetBool() )
-	{
-		DebugDrawLine( ptr->startpos, ptr->endpos, 255, 0, 0, true, -1.0f );
-	}
-}
-
 #if 0
 //-----------------------------------------------------------------------------
 // Traces player movement + position
@@ -833,7 +819,7 @@ CBaseHandle CGameMovement::TestPlayerPosition( const Vector& pos, int collisionG
 {
 	Ray_t ray;
 	ray.Init( pos, pos, GetPlayerMins(), GetPlayerMaxs() );
-	UTIL_TraceRayMovement( ray, PlayerSolidMask(), mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
+	UTIL_TraceRay( ray, PlayerSolidMask(), mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
 	if ( (pm.contents & PlayerSolidMask()) && pm.m_pEnt )
 	{
 		return pm.m_pEnt->GetRefEHandle();
@@ -3754,7 +3740,7 @@ void TracePlayerBBoxForGround( const Vector& start, const Vector& end, const Vec
 	mins = minsSrc;
 	maxs.Init( MIN( 0, maxsSrc.x ), MIN( 0, maxsSrc.y ), maxsSrc.z );
 	ray.Init( start, end, mins, maxs );
-	UTIL_TraceRayMovement( ray, fMask, player, collisionGroup, &pm );
+	UTIL_TraceRay( ray, fMask, player, collisionGroup, &pm );
 	if ( pm.m_pEnt && pm.plane.normal[2] >= 0.7)
 	{
 		pm.fraction = fraction;
@@ -3766,7 +3752,7 @@ void TracePlayerBBoxForGround( const Vector& start, const Vector& end, const Vec
 	mins.Init( MAX( 0, minsSrc.x ), MAX( 0, minsSrc.y ), minsSrc.z );
 	maxs = maxsSrc;
 	ray.Init( start, end, mins, maxs );
-	UTIL_TraceRayMovement( ray, fMask, player, collisionGroup, &pm );
+	UTIL_TraceRay( ray, fMask, player, collisionGroup, &pm );
 	if ( pm.m_pEnt && pm.plane.normal[2] >= 0.7)
 	{
 		pm.fraction = fraction;
@@ -3778,7 +3764,7 @@ void TracePlayerBBoxForGround( const Vector& start, const Vector& end, const Vec
 	mins.Init( minsSrc.x, MAX( 0, minsSrc.y ), minsSrc.z );
 	maxs.Init( MIN( 0, maxsSrc.x ), maxsSrc.y, maxsSrc.z );
 	ray.Init( start, end, mins, maxs );
-	UTIL_TraceRayMovement( ray, fMask, player, collisionGroup, &pm );
+	UTIL_TraceRay( ray, fMask, player, collisionGroup, &pm );
 	if ( pm.m_pEnt && pm.plane.normal[2] >= 0.7)
 	{
 		pm.fraction = fraction;
@@ -3790,7 +3776,7 @@ void TracePlayerBBoxForGround( const Vector& start, const Vector& end, const Vec
 	mins.Init( MAX( 0, minsSrc.x ), minsSrc.y, minsSrc.z );
 	maxs.Init( maxsSrc.x, MIN( 0, maxsSrc.y ), maxsSrc.z );
 	ray.Init( start, end, mins, maxs );
-	UTIL_TraceRayMovement( ray, fMask, player, collisionGroup, &pm );
+	UTIL_TraceRay( ray, fMask, player, collisionGroup, &pm );
 	if ( pm.m_pEnt && pm.plane.normal[2] >= 0.7)
 	{
 		pm.fraction = fraction;
@@ -5125,7 +5111,7 @@ void CGameMovement::TracePlayerBBox( const Vector& start, const Vector& end, uns
 
 	Ray_t ray;
 	ray.Init( start, end, GetPlayerMins(), GetPlayerMaxs() );
-	UTIL_TraceRayMovement( ray, fMask, mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
+	UTIL_TraceRay( ray, fMask, mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
 
 }
 
@@ -5140,6 +5126,6 @@ void  CGameMovement::TryTouchGround( const Vector& start, const Vector& end, con
 
 	Ray_t ray;
 	ray.Init( start, end, mins, maxs );
-	UTIL_TraceRayMovement( ray, fMask, mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
+	UTIL_TraceRay( ray, fMask, mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
 }
 

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -94,17 +94,6 @@ ConVar neo_sv_readyup_autointermission("neo_sv_readyup_autointermission", "0", F
 // Both CLIENT_DLL + GAME_DLL, but server-side setting so it's replicated onto client to read the values
 ConVar neo_sv_readyup_lobby("neo_sv_readyup_lobby", "0", FCVAR_REPLICATED, "If enabled, players would need to ready up and match the players total requirements to start a game.", true, 0.0f, true, 1.0f);
 
-enum ENeoCollision
-{
-	NEOCOLLISION_NONE = 0,
-	NEOCOLLISION_TEAM,
-	NEOCOLLISION_ALL,
-
-	NEOCOLLISION__TOTAL,
-};
-
-ConVar neo_sv_collision("neo_sv_collision", "0", FCVAR_REPLICATED, "0 = No collision (default), 1 = Team-based collision, 2 = All player collision", true, 0.0f, true, NEOCOLLISION__TOTAL - 1);
-
 REGISTER_GAMERULES_CLASS( CNEORules );
 
 BEGIN_NETWORK_TABLE_NOBASE( CNEORules, DT_NEORules )
@@ -481,18 +470,22 @@ int CNEORules::DefaultFOV(void)
 #endif
 }
 
-bool CNEORules::ShouldCollide(const CBaseEntity *ent0, const CBaseEntity *ent1) const
+bool CNEORules::ShouldCollide(int collisionGroup0, int collisionGroup1)
 {
-	const int ent0Group = ent0->GetCollisionGroup();
-	const int ent1Group = ent1->GetCollisionGroup();
-	const int iNeoCol = neo_sv_collision.GetInt();
-	if (iNeoCol != NEOCOLLISION_ALL && ent0Group == COLLISION_GROUP_PLAYER && ent1Group == COLLISION_GROUP_PLAYER)
+	if (collisionGroup0 > collisionGroup1)
 	{
-		return (iNeoCol == NEOCOLLISION_TEAM) ?
-					(static_cast<const CNEO_Player *>(ent0)->GetTeamNumber() != static_cast<const CNEO_Player *>(ent1)->GetTeamNumber()) :
-					false;
+		// swap so that lowest is always first
+		V_swap(collisionGroup0, collisionGroup1);
 	}
-	return const_cast<CNEORules *>(this)->CTeamplayRules::ShouldCollide(ent0Group, ent1Group);
+
+	if ((collisionGroup0 == COLLISION_GROUP_PLAYER || collisionGroup0 == COLLISION_GROUP_PLAYER_MOVEMENT) &&
+		(collisionGroup1 == COLLISION_GROUP_PROJECTILE || collisionGroup1 == COLLISION_GROUP_WEAPON ||
+		 collisionGroup1 == COLLISION_GROUP_PLAYER || collisionGroup1 == COLLISION_GROUP_PLAYER_MOVEMENT))
+	{
+		return false;
+	}
+
+	return CTeamplayRules::ShouldCollide(collisionGroup0, collisionGroup1);
 }
 
 extern ConVar mp_chattime;

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -138,7 +138,7 @@ public:
 
 	virtual void ClientDisconnected(edict_t* pClient) OVERRIDE;
 #endif
-	bool ShouldCollide(const CBaseEntity *ent0, const CBaseEntity *ent1) const;
+	virtual bool ShouldCollide( int collisionGroup0, int collisionGroup1 ) OVERRIDE;
 
 	virtual const char* GetGameName() { return NEO_GAME_NAME; }
 

--- a/mp/src/game/shared/util_shared.cpp
+++ b/mp/src/game/shared/util_shared.cpp
@@ -34,10 +34,6 @@
 bool NPC_CheckBrushExclude( CBaseEntity *pEntity, CBaseEntity *pBrush );
 #endif
 
-#ifdef NEO
-#include "neo_gamerules.h"
-#endif
-
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -278,9 +274,6 @@ bool StandardFilterRules( IHandleEntity *pHandleEntity, int fContentsMask )
 CTraceFilterSimple::CTraceFilterSimple( const IHandleEntity *passedict, int collisionGroup,
 									   ShouldHitFunc_t pExtraShouldHitFunc )
 {
-#ifdef NEO
-	m_bIgnoreNeoCollide = true;
-#endif
 	m_pPassEnt = passedict;
 	m_collisionGroup = collisionGroup;
 	m_pExtraShouldHitCheckFunction = pExtraShouldHitFunc;
@@ -308,24 +301,8 @@ bool CTraceFilterSimple::ShouldHitEntity( IHandleEntity *pHandleEntity, int cont
 		return false;
 	if ( !pEntity->ShouldCollide( m_collisionGroup, contentsMask ) )
 		return false;
-#ifdef NEO
-	if (!m_bIgnoreNeoCollide && m_pPassEnt)
-	{
-		const CBaseEntity *pThisEntity = EntityFromEntityHandle(m_pPassEnt);
-		if (pEntity && pThisEntity && !static_cast<CNEORules *>(g_pGameRules)->ShouldCollide(pThisEntity, pEntity))
-		{
-			return false;
-		}
-	}
-	else
-	{
-		if ( pEntity && !g_pGameRules->ShouldCollide( m_collisionGroup, pEntity->GetCollisionGroup() ) )
-			return false;
-	}
-#else
 	if ( pEntity && !g_pGameRules->ShouldCollide( m_collisionGroup, pEntity->GetCollisionGroup() ) )
 		return false;
-#endif
 	if ( m_pExtraShouldHitCheckFunction &&
 		(! ( m_pExtraShouldHitCheckFunction( pHandleEntity, contentsMask ) ) ) )
 		return false;

--- a/mp/src/game/shared/util_shared.h
+++ b/mp/src/game/shared/util_shared.h
@@ -124,9 +124,6 @@ public:
 	virtual void SetCollisionGroup( int iCollisionGroup ) { m_collisionGroup = iCollisionGroup; }
 
 	const IHandleEntity *GetPassEntity( void ){ return m_pPassEnt;}
-#ifdef NEO
-	bool m_bIgnoreNeoCollide;
-#endif
 
 private:
 	const IHandleEntity *m_pPassEnt;


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Revert bb49e49ce31cc7b65198232410c111bfa023dfc4.
* Revert 82df07f62ec019b9d1fe67fa002b88eafc4baa31.
* It doesn't work properly with actual players (only bots/LAN dedicated), and instead caused a "soft" blocking?
* Not gonna bother anymore, it's mixed up with the tracing stuff. If team-based blocking couldn't be done properly like this then might as well go back to the previous no-blocking code which worked fine for quite a long time anyway

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Issues
* fixes #704

