### PR TITLE
Fix grenade bugs

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1058,12 +1058,7 @@ void C_NEO_Player::PostThink(void)
 		}
 		else if (m_afButtonPressed & IN_AIM)
 		{
-			// Binds hack: we want grenade secondary attack to trigger on aim (mouse button 2)
-			if (pNeoWep->GetNeoWepBits() & NEO_WEP_THROWABLE)
-			{
-				pNeoWep->SecondaryAttack();
-			}
-			else if (!CanSprint() || !(m_nButtons & IN_SPEED))
+			if (!CanSprint() || !(m_nButtons & IN_SPEED))
 			{
 				Weapon_AimToggle(pNeoWep, clientAimHold ? NEO_TOGGLE_FORCE_AIM : NEO_TOGGLE_DEFAULT);
 			}

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1016,12 +1016,7 @@ void CNEO_Player::PostThink(void)
 		}
 		else if (m_afButtonPressed & IN_AIM)
 		{
-			// Binds hack: we want grenade secondary attack to trigger on aim (mouse button 2)
-			if (pNeoWep->GetNeoWepBits() & NEO_WEP_THROWABLE)
-			{
-				pNeoWep->SecondaryAttack();
-			}
-			else if (!CanSprint() || !(m_nButtons & IN_SPEED))
+			if (!CanSprint() || !(m_nButtons & IN_SPEED))
 			{
 				Weapon_AimToggle(pNeoWep, clientAimHold ? NEO_TOGGLE_FORCE_AIM : NEO_TOGGLE_DEFAULT);
 			}

--- a/mp/src/game/shared/neo/weapons/weapon_detpack.h
+++ b/mp/src/game/shared/neo/weapons/weapon_detpack.h
@@ -39,7 +39,6 @@ public:
 
 	void	Precache(void);
 	void	PrimaryAttack(void);
-	void	SecondaryAttack(void) { }
 	void	DecrementAmmo(CBaseCombatCharacter* pOwner);
 	void	ItemPostFrame(void);
 
@@ -51,6 +50,7 @@ public:
 	virtual float GetSpeedScale(void) const { return 1.0; }
 
 	bool	CanDrop(void) OVERRIDE;
+	virtual bool CanPerformSecondaryAttack() const override final { return false; }
 
 #ifndef CLIENT_DLL
 	void Operator_HandleAnimEvent(animevent_t* pEvent, CBaseCombatCharacter* pOperator);

--- a/mp/src/game/shared/neo/weapons/weapon_grenade.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_grenade.cpp
@@ -23,8 +23,6 @@
 
 ConVar sv_neo_infinite_frag_grenades("sv_neo_infinite_frag_grenades", "0", FCVAR_REPLICATED | FCVAR_CHEAT, "Should frag grenades use up ammo.", true, 0.0, true, 1.0);
 ConVar sv_neo_grenade_throw_intensity("sv_neo_grenade_throw_intensity", "900.0", FCVAR_REPLICATED | FCVAR_CHEAT, "How strong should regular grenade throws be.", true, 0.0, true, 9999.9); // 750 is the original NT impulse. Seems incorrect though, weight or phys difference?
-ConVar sv_neo_grenade_lob_intensity("sv_neo_grenade_lob_intensity", "375.0", FCVAR_REPLICATED | FCVAR_CHEAT, "How strong should underhand grenade lobs be.", true, 0.0, true, 9999.9); // No such thing in original, but chose half of 750
-ConVar sv_neo_grenade_roll_intensity("sv_neo_grenade_roll_intensity", "375.0", FCVAR_REPLICATED | FCVAR_CHEAT, "How strong should underhand grenade rolls be.", true, 0.0, true, 9999.9);
 ConVar sv_neo_grenade_blast_damage("sv_neo_grenade_blast_damage", "200.0", FCVAR_REPLICATED | FCVAR_CHEAT, "How much damage should a grenade blast deal.", true, 0.0, true, 999.9);
 ConVar sv_neo_grenade_blast_radius("sv_neo_grenade_blast_radius", "250.0", FCVAR_REPLICATED | FCVAR_CHEAT, "How large should the grenade blast radius be.", true, 0.0, true, 9999.9);
 ConVar sv_neo_grenade_fuse_timer("sv_neo_grenade_fuse_timer", "2.16", FCVAR_REPLICATED | FCVAR_CHEAT, "How long in seconds until a frag grenade explodes.", true, 0.1, true, 60.0); // Measured as 2.15999... in NT, ie. < 2.16
@@ -119,42 +117,6 @@ bool CWeaponGrenade::Reload(void)
 	return true;
 }
 
-void CWeaponGrenade::SecondaryAttack(void)
-{
-	if (ShootingIsPrevented())
-	{
-		return;
-	}
-
-	if (m_bRedraw || !HasPrimaryAmmo())
-	{
-		return;
-	}
-
-	auto pPlayer = ToBasePlayer(GetOwner());
-	if (!pPlayer)
-	{
-		return;
-	}
-
-	if (m_flNextSecondaryAttack > gpGlobals->curtime)
-	{
-		return;
-	}
-
-	if (m_AttackPaused != GRENADE_PAUSED_SECONDARY)
-	{
-		// Note that this is a secondary attack and prepare the grenade attack to pause.
-		m_AttackPaused = GRENADE_PAUSED_SECONDARY;
-		SendWeaponAnim(ACT_VM_PULLPIN);
-
-		// Don't let weapon idle interfere in the middle of a throw!
-		m_flTimeWeaponIdle = FLT_MAX;
-		m_flNextSecondaryAttack = gpGlobals->curtime + RETHROW_DELAY;
-		m_bDrawbackFinished = false;
-	}
-}
-
 void CWeaponGrenade::PrimaryAttack(void)
 {
 	if (ShootingIsPrevented())
@@ -233,30 +195,6 @@ void CWeaponGrenade::ItemPostFrame(void)
 					ThrowGrenade(pOwner);
 
 					SendWeaponAnim(ACT_VM_THROW);
-					m_flNextPrimaryAttack = m_flNextSecondaryAttack = m_flTimeWeaponIdle = gpGlobals->curtime + SequenceDuration();
-					m_bDrawbackFinished = false;
-					m_AttackPaused = GRENADE_PAUSED_NO;
-				}
-				break;
-
-			case GRENADE_PAUSED_SECONDARY:
-				if (!(pOwner->m_nButtons & IN_AIM))
-				{
-					//See if we're ducking
-					if (pOwner->m_nButtons & IN_DUCK)
-					{
-						RollGrenade(pOwner);
-						//Send the weapon animation
-						SendWeaponAnim(ACT_VM_THROW);
-					}
-					else
-					{
-						LobGrenade(pOwner);
-						//Send the weapon animation
-						SendWeaponAnim(ACT_VM_THROW);
-					}
-
-					pOwner->DoAnimationEvent(PLAYERANIMEVENT_ATTACK_PRIMARY);
 					m_flNextPrimaryAttack = m_flNextSecondaryAttack = m_flTimeWeaponIdle = gpGlobals->curtime + SequenceDuration();
 					m_bDrawbackFinished = false;
 					m_AttackPaused = GRENADE_PAUSED_NO;
@@ -350,107 +288,6 @@ void CWeaponGrenade::ThrowGrenade(CNEO_Player *pPlayer, bool isAlive, CBaseEntit
 	m_bRedraw = true;
 }
 
-void CWeaponGrenade::LobGrenade(CNEO_Player *pPlayer)
-{
-	// Binds hack: we want grenade secondary attack to trigger on aim, not the attack2 bind.
-	if (pPlayer->m_afButtonPressed & IN_AIM)
-	{
-		return;
-	}
-	else if (!sv_neo_infinite_frag_grenades.GetBool())
-	{
-		Assert(HasPrimaryAmmo());
-		DecrementAmmo(pPlayer);
-	}
-
-#ifndef CLIENT_DLL
-	Vector	vecEye = pPlayer->EyePosition();
-	Vector	vForward, vRight;
-
-	pPlayer->EyeVectors(&vForward, &vRight, NULL);
-	Vector vecSrc = vecEye + vForward * 2.0f + Vector(0, 0, -8);
-	CheckThrowPosition(pPlayer, vecEye, vecSrc);
-
-	Vector vecThrow;
-	pPlayer->GetVelocity(&vecThrow, NULL);
-	vecThrow += vForward * sv_neo_grenade_lob_intensity.GetFloat() + Vector(0, 0, 50);
-	CBaseGrenade *pGrenade = NEOFraggrenade_Create(vecSrc, vec3_angle, vecThrow, AngularImpulse(200, random->RandomInt(-600, 600), 0), pPlayer, sv_neo_grenade_fuse_timer.GetFloat(), false);
-
-	if (pGrenade)
-	{
-		pGrenade->SetDamage(sv_neo_grenade_blast_damage.GetFloat());
-		pGrenade->SetDamageRadius(sv_neo_grenade_blast_radius.GetFloat());
-	}
-#endif
-
-	WeaponSound(WPN_DOUBLE);
-
-	// player "shoot" animation
-	pPlayer->DoAnimationEvent(PLAYERANIMEVENT_ATTACK_PRIMARY);
-
-	m_bRedraw = true;
-}
-
-void CWeaponGrenade::RollGrenade(CNEO_Player *pPlayer)
-{
-	// Binds hack: we want grenade secondary attack to trigger on aim, not the attack2 bind.
-	if (pPlayer->m_afButtonPressed & IN_AIM)
-	{
-		return;
-	}
-	else if (!sv_neo_infinite_frag_grenades.GetBool())
-	{
-		Assert(HasPrimaryAmmo());
-		DecrementAmmo(pPlayer);
-	}
-
-#ifndef CLIENT_DLL
-	// BUGBUG: Hardcoded grenade width of 4 - better not change the model :)
-	Vector vecSrc;
-	pPlayer->CollisionProp()->NormalizedToWorldSpace(Vector(0.5f, 0.5f, 0.0f), &vecSrc);
-	vecSrc.z += GRENADE_RADIUS;
-
-	Vector vecFacing = pPlayer->BodyDirection2D();
-	// no up/down direction
-	vecFacing.z = 0;
-	VectorNormalize(vecFacing);
-	trace_t tr;
-	UTIL_TraceLine(vecSrc, vecSrc - Vector(0, 0, 16), MASK_PLAYERSOLID, pPlayer, COLLISION_GROUP_NONE, &tr);
-	if (tr.fraction != 1.0)
-	{
-		// compute forward vec parallel to floor plane and roll grenade along that
-		Vector tangent;
-		CrossProduct(vecFacing, tr.plane.normal, tangent);
-		CrossProduct(tr.plane.normal, tangent, vecFacing);
-	}
-	vecSrc += (vecFacing * 2.0);
-	CheckThrowPosition(pPlayer, pPlayer->WorldSpaceCenter(), vecSrc);
-
-	Vector vecThrow;
-	pPlayer->GetVelocity(&vecThrow, NULL);
-	vecThrow += vecFacing * sv_neo_grenade_roll_intensity.GetFloat();
-	// put it on its side
-	QAngle orientation(0, pPlayer->GetLocalAngles().y, -90);
-	// roll it
-	AngularImpulse rotSpeed(0, 0, 720);
-	CBaseGrenade *pGrenade = NEOFraggrenade_Create(vecSrc, orientation, vecThrow, rotSpeed, pPlayer, sv_neo_grenade_fuse_timer.GetFloat(), false);
-
-	if (pGrenade)
-	{
-		pGrenade->SetDamage(sv_neo_grenade_blast_damage.GetFloat());
-		pGrenade->SetDamageRadius(sv_neo_grenade_blast_radius.GetFloat());
-	}
-
-#endif
-
-	WeaponSound(SPECIAL1);
-
-	// player "shoot" animation
-	pPlayer->DoAnimationEvent(PLAYERANIMEVENT_ATTACK_PRIMARY);
-
-	m_bRedraw = true;
-}
-
 bool CWeaponGrenade::CanDrop()
 {
 	auto owner = GetOwner(); 
@@ -478,18 +315,6 @@ void CWeaponGrenade::Operator_HandleAnimEvent(animevent_t *pEvent, CBaseCombatCh
 
 	case EVENT_WEAPON_THROW:
 		ThrowGrenade(pOwner);
-		DecrementAmmo(pOwner);
-		fThrewGrenade = true;
-		break;
-
-	case EVENT_WEAPON_THROW2:
-		RollGrenade(pOwner);
-		DecrementAmmo(pOwner);
-		fThrewGrenade = true;
-		break;
-
-	case EVENT_WEAPON_THROW3:
-		LobGrenade(pOwner);
 		DecrementAmmo(pOwner);
 		fThrewGrenade = true;
 		break;

--- a/mp/src/game/shared/neo/weapons/weapon_grenade.h
+++ b/mp/src/game/shared/neo/weapons/weapon_grenade.h
@@ -46,7 +46,6 @@ public:
 
 	void	Precache(void);
 	void	PrimaryAttack(void);
-	void	SecondaryAttack(void);
 	void	DecrementAmmo(CBaseCombatCharacter *pOwner);
 	void	ItemPostFrame(void);
 
@@ -57,17 +56,16 @@ public:
 
 	void	Drop(const Vector& vecVelocity) OVERRIDE;
 	bool	CanDrop(void) OVERRIDE;
+	virtual bool CanPerformSecondaryAttack() const override final { return false; }
 
 #ifndef CLIENT_DLL
 	void Operator_HandleAnimEvent(animevent_t *pEvent, CBaseCombatCharacter *pOperator);
 #endif
 
 	void	ThrowGrenade(CNEO_Player *pPlayer, bool isAlive = true, CBaseEntity *pAttacker = NULL);
-	void	LobGrenade(CNEO_Player *pPlayer);
 	bool	IsPrimed() const { return (m_AttackPaused != 0); }
 
 private:
-	void	RollGrenade(CNEO_Player *pPlayer);
 	// Check a throw from vecSrc.  If not valid, move the position back along the line to vecEye
 	void	CheckThrowPosition(CBasePlayer *pPlayer, const Vector &vecEye, Vector &vecSrc);
 

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -467,42 +467,45 @@ void CNEOBaseCombatWeapon::ItemPreFrame(void)
 }
 
 // Handles lowering the weapon view model when character is sprinting
-void CNEOBaseCombatWeapon::ProcessAnimationEvents(void)
+void CNEOBaseCombatWeapon::ProcessAnimationEvents()
 {
 	CNEO_Player* pOwner = static_cast<CNEO_Player*>(ToBasePlayer(GetOwner()));
 	if (!pOwner)
+	{
 		return;
+	}
 
-	if (!m_bLowered && (pOwner->IsSprinting() || pOwner->GetMoveType() == MOVETYPE_LADDER) && !m_bInReload && !m_bRoundBeingChambered)
+	const auto next = [this](const int activity) {
+		SendWeaponAnim(activity);
+		if (GetNeoWepBits() & NEO_WEP_THROWABLE)
+		{
+			return;
+		}
+		constexpr auto nextAttackDelay = 0.2;
+		m_flNextPrimaryAttack = max(gpGlobals->curtime + nextAttackDelay, m_flNextPrimaryAttack);
+		m_flNextSecondaryAttack = m_flNextPrimaryAttack;
+	};
+
+	if (!m_bLowered && !m_bInReload && !m_bRoundBeingChambered &&
+		(pOwner->IsSprinting() || pOwner->GetMoveType() == MOVETYPE_LADDER))
 	{
 		m_bLowered = true;
-		SendWeaponAnim(ACT_VM_IDLE_LOWERED);
-		m_flNextPrimaryAttack = max(gpGlobals->curtime + 0.2, m_flNextPrimaryAttack);
-		m_flNextSecondaryAttack = m_flNextPrimaryAttack;
+		next(ACT_VM_IDLE_LOWERED);
 	}
 	else if (m_bLowered && !(pOwner->IsSprinting() || pOwner->GetMoveType() == MOVETYPE_LADDER))
 	{
 		m_bLowered = false;
-		SendWeaponAnim(ACT_VM_IDLE);
-		m_flNextPrimaryAttack = max(gpGlobals->curtime + 0.2, m_flNextPrimaryAttack);
-		m_flNextSecondaryAttack = m_flNextPrimaryAttack;
+		next(ACT_VM_IDLE);
 	}
 	else if (m_bLowered && m_bRoundBeingChambered)
 	{ // For bolt action weapons
 		m_bLowered = false;
-		SendWeaponAnim(ACT_VM_PULLBACK);
-		m_flNextPrimaryAttack = max(gpGlobals->curtime + 0.2, m_flNextPrimaryAttack);
-		m_flNextSecondaryAttack = m_flNextPrimaryAttack;
+		next(ACT_VM_PULLBACK);
 	}
 
-	if (m_bLowered)
+	if (m_bLowered && gpGlobals->curtime > m_flNextPrimaryAttack)
 	{
-		if (gpGlobals->curtime > m_flNextPrimaryAttack)
-		{
-			SendWeaponAnim(ACT_VM_IDLE_LOWERED);
-			m_flNextPrimaryAttack = max(gpGlobals->curtime + 0.2, m_flNextPrimaryAttack);
-			m_flNextSecondaryAttack = m_flNextPrimaryAttack;
-		}
+		next(ACT_VM_IDLE_LOWERED);
 	}
 }
 

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -219,7 +219,7 @@ public:
 
 	float GetLastAttackTime(void) const { return m_flLastAttackTime; }
 
-	virtual void ProcessAnimationEvents(void);
+	void ProcessAnimationEvents();
 	bool m_bWeaponIsLowered;
 
 	int GetNumShotsFired(void) const { return m_nNumShotsFired; }

--- a/mp/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
@@ -97,42 +97,6 @@ bool CWeaponSmokeGrenade::Reload(void)
 	return true;
 }
 
-void CWeaponSmokeGrenade::SecondaryAttack(void)
-{
-	if (ShootingIsPrevented())
-	{
-		return;
-	}
-
-	if (m_bRedraw || !HasPrimaryAmmo())
-	{
-		return;
-	}
-
-	auto pPlayer = ToBasePlayer(GetOwner());
-	if (!pPlayer)
-	{
-		return;
-	}
-
-	if (m_flNextSecondaryAttack > gpGlobals->curtime)
-	{
-		return;
-	}
-
-	if (m_AttackPaused != GRENADE_PAUSED_SECONDARY)
-	{
-		// Note that this is a secondary attack and prepare the grenade attack to pause.
-		m_AttackPaused = GRENADE_PAUSED_SECONDARY;
-		SendWeaponAnim(ACT_VM_PULLPIN);
-
-		// Don't let weapon idle interfere in the middle of a throw!
-		m_flTimeWeaponIdle = FLT_MAX;
-		m_flNextSecondaryAttack = gpGlobals->curtime + RETHROW_DELAY;
-		m_bDrawbackFinished = false;
-	}
-}
-
 void CWeaponSmokeGrenade::PrimaryAttack(void)
 {
 	if (ShootingIsPrevented())
@@ -212,29 +176,6 @@ void CWeaponSmokeGrenade::ItemPostFrame(void)
 					ThrowGrenade(pOwner);
 
 					SendWeaponAnim(ACT_VM_THROW);
-					m_flNextPrimaryAttack = m_flNextSecondaryAttack = m_flTimeWeaponIdle = gpGlobals->curtime + SequenceDuration();
-					m_bDrawbackFinished = false;
-					m_AttackPaused = GRENADE_PAUSED_NO;
-				}
-				break;
-
-			case GRENADE_PAUSED_SECONDARY:
-				if (!(pOwner->m_nButtons & IN_AIM))
-				{
-					//See if we're ducking
-					if (pOwner->m_nButtons & IN_DUCK)
-					{
-						RollGrenade(pOwner);
-						//Send the weapon animation
-						SendWeaponAnim(ACT_VM_THROW);
-					}
-					else
-					{
-						LobGrenade(pOwner);
-						//Send the weapon animation
-						SendWeaponAnim(ACT_VM_THROW);
-					}
-
 					m_flNextPrimaryAttack = m_flNextSecondaryAttack = m_flTimeWeaponIdle = gpGlobals->curtime + SequenceDuration();
 					m_bDrawbackFinished = false;
 					m_AttackPaused = GRENADE_PAUSED_NO;
@@ -329,107 +270,6 @@ void CWeaponSmokeGrenade::ThrowGrenade(CNEO_Player* pPlayer, bool isAlive, CBase
 	m_bRedraw = true;
 }
 
-void CWeaponSmokeGrenade::LobGrenade(CNEO_Player* pPlayer)
-{
-	// Binds hack: we want grenade secondary attack to trigger on aim, not the attack2 bind.
-	if (pPlayer->m_afButtonPressed & IN_AIM)
-	{
-		return;
-	}
-	else if (!sv_neo_infinite_smoke_grenades.GetBool())
-	{
-		Assert(HasPrimaryAmmo());
-		DecrementAmmo(pPlayer);
-	}
-
-#ifndef CLIENT_DLL
-	Vector	vecEye = pPlayer->EyePosition();
-	Vector	vForward, vRight;
-
-	pPlayer->EyeVectors(&vForward, &vRight, NULL);
-	Vector vecSrc = vecEye + vForward * 2.0f + Vector(0, 0, -8);
-	CheckThrowPosition(pPlayer, vecEye, vecSrc);
-
-	Vector vecThrow;
-	pPlayer->GetVelocity(&vecThrow, NULL);
-	vecThrow += vForward * sv_neo_grenade_lob_intensity.GetFloat() + Vector(0, 0, 50);
-	CBaseGrenade* pGrenade = NEOSmokegrenade_Create(vecSrc, vec3_angle, vecThrow, AngularImpulse(200, random->RandomInt(-600, 600), 0), pPlayer);
-
-	if (pGrenade)
-	{
-		pGrenade->SetDamage(0);
-		pGrenade->SetDamageRadius(0);
-	}
-#endif
-
-	WeaponSound(WPN_DOUBLE);
-
-	// player "shoot" animation
-	pPlayer->DoAnimationEvent(PLAYERANIMEVENT_ATTACK_PRIMARY);
-	
-	m_bRedraw = true;
-}
-
-void CWeaponSmokeGrenade::RollGrenade(CNEO_Player* pPlayer)
-{
-	// Binds hack: we want grenade secondary attack to trigger on aim, not the attack2 bind.
-	if (pPlayer->m_afButtonPressed & IN_AIM)
-	{
-		return;
-	}
-	else if (!sv_neo_infinite_smoke_grenades.GetBool())
-	{
-		Assert(HasPrimaryAmmo());
-		DecrementAmmo(pPlayer);
-	}
-
-#ifndef CLIENT_DLL
-	// BUGBUG: Hardcoded grenade width of 4 - better not change the model :)
-	Vector vecSrc;
-	pPlayer->CollisionProp()->NormalizedToWorldSpace(Vector(0.5f, 0.5f, 0.0f), &vecSrc);
-	vecSrc.z += GRENADE_RADIUS;
-
-	Vector vecFacing = pPlayer->BodyDirection2D();
-	// no up/down direction
-	vecFacing.z = 0;
-	VectorNormalize(vecFacing);
-	trace_t tr;
-	UTIL_TraceLine(vecSrc, vecSrc - Vector(0, 0, 16), MASK_PLAYERSOLID, pPlayer, COLLISION_GROUP_NONE, &tr);
-	if (tr.fraction != 1.0)
-	{
-		// compute forward vec parallel to floor plane and roll grenade along that
-		Vector tangent;
-		CrossProduct(vecFacing, tr.plane.normal, tangent);
-		CrossProduct(tr.plane.normal, tangent, vecFacing);
-	}
-	vecSrc += (vecFacing * 2.0);
-	CheckThrowPosition(pPlayer, pPlayer->WorldSpaceCenter(), vecSrc);
-
-	Vector vecThrow;
-	pPlayer->GetVelocity(&vecThrow, NULL);
-	vecThrow += vecFacing * sv_neo_grenade_roll_intensity.GetFloat();
-	// put it on its side
-	QAngle orientation(0, pPlayer->GetLocalAngles().y, -90);
-	// roll it
-	AngularImpulse rotSpeed(0, 0, 720);
-	CBaseGrenade* pGrenade = NEOSmokegrenade_Create(vecSrc, orientation, vecThrow, rotSpeed, pPlayer);
-
-	if (pGrenade)
-	{
-		pGrenade->SetDamage(0);
-		pGrenade->SetDamageRadius(0);
-	}
-
-#endif
-
-	WeaponSound(SPECIAL1);
-
-	// player "shoot" animation
-	pPlayer->DoAnimationEvent(PLAYERANIMEVENT_ATTACK_PRIMARY);
-
-	m_bRedraw = true;
-}
-
 bool CWeaponSmokeGrenade::CanDrop()
 {
 	auto owner = GetOwner(); 
@@ -457,18 +297,6 @@ void CWeaponSmokeGrenade::Operator_HandleAnimEvent(animevent_t* pEvent, CBaseCom
 
 	case EVENT_WEAPON_THROW:
 		ThrowGrenade(pOwner);
-		DecrementAmmo(pOwner);
-		fThrewGrenade = true;
-		break;
-
-	case EVENT_WEAPON_THROW2:
-		RollGrenade(pOwner);
-		DecrementAmmo(pOwner);
-		fThrewGrenade = true;
-		break;
-
-	case EVENT_WEAPON_THROW3:
-		LobGrenade(pOwner);
 		DecrementAmmo(pOwner);
 		fThrewGrenade = true;
 		break;

--- a/mp/src/game/shared/neo/weapons/weapon_smokegrenade.h
+++ b/mp/src/game/shared/neo/weapons/weapon_smokegrenade.h
@@ -45,7 +45,6 @@ public:
 
 	void	Precache(void);
 	void	PrimaryAttack(void);
-	void	SecondaryAttack(void);
 	void	DecrementAmmo(CBaseCombatCharacter* pOwner);
 	void	ItemPostFrame(void);
 
@@ -55,17 +54,16 @@ public:
 	bool	Reload(void);
 	void	Drop(const Vector& vecVelocity) OVERRIDE;
 	bool	CanDrop() OVERRIDE;
+	virtual bool CanPerformSecondaryAttack() const override final { return false; }
 
 #ifndef CLIENT_DLL
 	void Operator_HandleAnimEvent(animevent_t* pEvent, CBaseCombatCharacter* pOperator);
 #endif
 
 	void	ThrowGrenade(CNEO_Player* pPlayer, bool isAlive = true, CBaseEntity *pAttacker = NULL);
-	void	LobGrenade(CNEO_Player* pPlayer);
 	bool	IsPrimed() const { return (m_AttackPaused != 0); }
 
 private:
-	void	RollGrenade(CNEO_Player* pPlayer);
 	// Check a throw from vecSrc.  If not valid, move the position back along the line to vecEye
 	void	CheckThrowPosition(CBasePlayer* pPlayer, const Vector& vecEye, Vector& vecSrc);
 


### PR DESCRIPTION
## Description
Fix problems with throwable items like grenades.

This PR disables priming throwables with the `+attack2`/"alt fire" button, as that seemed to be happening by mistake.

This also removes the experimental underhanding/lobbing of grenades feature. This was never really properly implemented, and was just remnants from tests years ago. It's not parity, and if we wanted this kind of system in the future, it should probably go through a proper design doc process to be added.

Finally, this fixes the inability to throw grenades/throwables whilst sprinting - parity behaviour is to allow throwing of nades regardless of sprint state.

## Toolchain
- Linux GCC Distro Native [Mint 21.3 + GCC 11.4.0]

## Linked Issues
- Fix #708 
- Fix #713 
