### PR TITLE
Hide own view model on death

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -976,6 +976,11 @@ void C_NEO_Player::PostThink(void)
 			m_bInVision = false;
 			m_bInLean = NEO_LEAN_NONE;
 
+			if (auto vm = GetViewModel(0, false))
+			{
+				vm->AddEffects(EF_NODRAW);
+			}
+
 			if (IsLocalPlayer() && (GetTeamNumber() == TEAM_JINRAI || GetTeamNumber() == TEAM_NSF))
 			{
 				SetObserverMode(OBS_MODE_DEATHCAM);

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -977,7 +977,7 @@ void C_NEO_Player::PostThink(void)
 			m_bInLean = NEO_LEAN_NONE;
 
 			if (auto vm = GetViewModel(0, false))
-			{
+			{ // NEOJANK (Adam) Own viewmodels remain visible in the spot where a person died. This wasn't an issue before, what changed? Workaround for now
 				vm->AddEffects(EF_NODRAW);
 			}
 

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -976,11 +976,6 @@ void C_NEO_Player::PostThink(void)
 			m_bInVision = false;
 			m_bInLean = NEO_LEAN_NONE;
 
-			if (auto vm = GetViewModel(0, false))
-			{ // NEOJANK (Adam) Own viewmodels remain visible in the spot where a person died. This wasn't an issue before, what changed? Workaround for now
-				vm->AddEffects(EF_NODRAW);
-			}
-
 			if (IsLocalPlayer() && (GetTeamNumber() == TEAM_JINRAI || GetTeamNumber() == TEAM_NSF))
 			{
 				SetObserverMode(OBS_MODE_DEATHCAM);

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -1889,11 +1889,12 @@ void CNEO_Player::Weapon_Drop( CBaseCombatWeapon *pWeapon,
 		}
 	}
 
-	if (!pWeapon)
-		return;
+	if (pWeapon)
+	{
+		pWeapon->m_bInReload = false;
+		pWeapon->StopWeaponSound(RELOAD_NPC);
+	}
 
-	pWeapon->m_bInReload = false;
-	pWeapon->StopWeaponSound(RELOAD_NPC);
 	BaseClass::Weapon_Drop(pWeapon, pvecTarget, pVelocity);
 }
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Will fix the issue where after death your own view model remains visible in the spot where you died. No clue what caused it initially, this is a workaround I guess.

(Edit) Use Rain's solution instead

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #720