### PR TITLE
Do not delete g_pNeoLoading ourselves, probably already done by engine

### DIFF
--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -324,13 +324,6 @@ ClientModeShared::ClientModeShared()
 ClientModeShared::~ClientModeShared()
 {
 	delete m_pViewport; 
-#ifdef NEO
-	if (g_pNeoLoading)
-	{
-		g_pNeoLoading->MarkForDeletion();
-		g_pNeoLoading = nullptr;
-	}
-#endif
 }
 
 void ClientModeShared::ReloadScheme( bool flushLowLevel )


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Still getting crash here (user after free on dangling pointer?). Just don't handle it. It's also called on exit so it's unnecessary to even cleanup here anyway.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14


