### PR TITLE
CI automatic release changes

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -191,8 +193,8 @@ jobs:
       with:
         name: ${{ env.resources }}
         path: ${{ env.install_dir }}/${{ env.resources }}
-  release-latest-build:
-    name: Release Latest Build
+  upload-latest-build:
+    name: Upload Latest Build
 
     needs: [build, pack-resources]
     runs-on: ubuntu-latest
@@ -207,7 +209,7 @@ jobs:
     - name: Packing artifacts
       run: 'parallel 7z a -tzip -mx=9 "{}.zip" "./{}/*" ::: neo-*'
         
-    - name: Create latest release
+    - name: Create & upload latest build
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_INFO: ${{ github.repository }}
@@ -217,12 +219,12 @@ jobs:
         # Create new "latest"
         gh release create latest neo-*.zip --prerelease --title "Latest Master Build" --repo "$REPO_INFO"
 
-  release-tag:
-    name: Release Tag
+  upload-release:
+    name: Upload Release
 
     needs: [build, pack-resources]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' && github.event.action == 'published'
     permissions:
       contents: write
     
@@ -236,7 +238,7 @@ jobs:
     - name: Packing artifacts
       run: 'parallel 7z a -tzip -mx=9 "{= s/neo-(.*)/neo-$GITHUB_REF_NAME-\1.zip/ =}" "./{}/*" ::: neo-*'
         
-    - name: Upload assets to a tag release
+    - name: Upload assets to a release
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_INFO: ${{ github.repository }}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
A "rework" of the automatic releases
- Uses GitHub CLI instead of a random action
- Instead of re-creating a release with assets for every tag, it uploads assets for published releases (keeps description and etc.)
- For releases, it adds the name of the tag associated with the release in the filenames of assets (ex. `neo-20240101-...` becomes `neo-v10.0-prealpha-20240101-...`)
- Renamed "Latest Build" to "Latest Master Build"

You can see it work on my repo: https://github.com/xedmain/ntrebuild/releases
