### PR TITLE
Make SUB_Remove non-virtual

### DIFF
--- a/mp/src/game/server/baseentity.h
+++ b/mp/src/game/server/baseentity.h
@@ -1040,12 +1040,7 @@ public:
 	virtual void			StopLoopingSounds( void ) {}
 
 	// common member functions
-#ifdef NEO
-	// virtual because Neo weapons want to override this
-	virtual void			SUB_Remove(void);
-#else
 	void					SUB_Remove( void );
-#endif
 
 	void					SUB_DoNothing( void );
 	void					SUB_StartFadeOut( float delay = 10.0f, bool bNotSolid = true );

--- a/mp/src/game/server/neo/neo_detpack.cpp
+++ b/mp/src/game/server/neo/neo_detpack.cpp
@@ -260,7 +260,7 @@ void CNEODeployedDetpack::Detonate(void)
 	}
 	BaseClass::Detonate();
 
-	SetThink(&CNEODeployedDetpack::SUB_Remove);
+	SetThink(&CBaseEntity::SUB_Remove);
 	SetNextThink(gpGlobals->curtime);
 }
 

--- a/mp/src/game/server/neo/neo_smokegrenade.cpp
+++ b/mp/src/game/server/neo/neo_smokegrenade.cpp
@@ -281,7 +281,7 @@ void CNEOGrenadeSmoke::Detonate(void)
 	}
 	else if (gpGlobals->curtime - m_flSmokeBloomTime >= sv_neo_smoke_bloom_duration.GetFloat())
 	{
-		SetThink(&CNEOGrenadeSmoke::SUB_Remove);
+		SetThink(&CBaseEntity::SUB_Remove);
 		AddEffects(EF_NODRAW);
 	}
 	

--- a/mp/src/game/shared/neo/weapons/weapon_ghost.h
+++ b/mp/src/game/shared/neo/weapons/weapon_ghost.h
@@ -52,14 +52,6 @@ public:
 	int ShouldTransmit(const CCheckTransmitInfo *pInfo) override;
 #endif
 
-#if _DEBUG
-	virtual void SUB_Remove(void) override
-	{
-		DevWarning("SUB_Remove called on ghost!"); // this is probably a mistake if it ever happens
-		BaseClass::SUB_Remove();
-	}
-#endif
-
 #ifdef CLIENT_DLL
 	void PlayGhostSound(float volume = 1.0f);
 	void StopGhostSound(void);


### PR DESCRIPTION
## Description
The `SUB_Remove` think function pointer was made virtual in aae9c8053a3b52c87289d006c6d44ea6cb3d9a1f as a workaround to fix weapons disappearing mid-round. This was later properly addressed in 429f83fd379345e48190cb3e4425acf9495f7a44, making the virtual declaration redundant. Hence I'm removing the virtual declaration for simplicity, and to avoid the needless vtable indirection overhead.

## Toolchain
- Linux GCC Distro Native [Mint 21.3 + GCC 11.4.0]