### PR TITLE
Spectator xray toggled off on spawn, fixes to how outline is drawn

### DIFF
--- a/mp/src/game/client/c_baseanimating.cpp
+++ b/mp/src/game/client/c_baseanimating.cpp
@@ -3174,6 +3174,12 @@ int C_BaseAnimating::DrawModel( int flags )
 		{
 			extraFlags |= STUDIO_GENERATE_STATS;
 		}
+#ifdef NEO
+		if (flags & STUDIO_IGNORE_NEO_EFFECTS)
+		{
+			extraFlags |= STUDIO_IGNORE_NEO_EFFECTS;
+		}
+#endif
 
 		// Necessary for lighting blending
 		CreateModelInstance();

--- a/mp/src/game/client/c_basecombatcharacter.cpp
+++ b/mp/src/game/client/c_basecombatcharacter.cpp
@@ -166,10 +166,11 @@ void C_BaseCombatCharacter::UpdateGlowEffect( void )
 #ifdef NEO
 		NEORules()->GetTeamGlowColor(GetTeamNumber(), r, g, b);
 		SetGlowEffectColor(r, g, b);
+		m_pGlowEffect = new CGlowObject( this, Vector( r, g, b ), 1.0, true, true );
 #else
 		GetGlowEffectColor( &r, &g, &b );
+		m_pGlowEffect = new CGlowObject( this, Vector( r, g, b ), 1.0, true );
 #endif
-		m_pGlowEffect = new CGlowObject( this, Vector( r, g, b ), 1.0, true, true );
 	}
 }
 

--- a/mp/src/game/client/c_basecombatcharacter.cpp
+++ b/mp/src/game/client/c_basecombatcharacter.cpp
@@ -169,7 +169,7 @@ void C_BaseCombatCharacter::UpdateGlowEffect( void )
 #else
 		GetGlowEffectColor( &r, &g, &b );
 #endif
-		m_pGlowEffect = new CGlowObject( this, Vector( r, g, b ), 1.0, true );
+		m_pGlowEffect = new CGlowObject( this, Vector( r, g, b ), 1.0, true, true );
 	}
 }
 

--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -1202,16 +1202,6 @@ void ClientModeShared::FireGameEvent( IGameEvent *event )
 		{
 			// that's me
 			pPlayer->TeamChange( team );
-#ifdef NEO
-			// Switch off Xray when switching teams
-			for (int i = 1; i <= MAX_PLAYERS; i++)
-			{
-				if (auto player = UTIL_PlayerByIndex(i))
-				{
-					player->SetClientSideGlowEnabled(false);
-				}
-			}
-#endif
 		}
 	}
 #ifdef NEO

--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -831,7 +831,7 @@ int ClientModeShared::HandleSpectatorKeyInput( int down, ButtonCode_t keynum, co
 		bool enabled = glow_outline_effect_enable->GetBool();
 		for (int i = 0; i < MAX_PLAYERS; i++)
 		{
-			if (auto player = dynamic_cast<C_BaseCombatCharacter *>(ClientEntityList().GetBaseEntity(i)))
+			if (auto player = UTIL_PlayerByIndex(i))
 			{
 				player->SetClientSideGlowEnabled(enabled);
 			}
@@ -1211,7 +1211,7 @@ void ClientModeShared::FireGameEvent( IGameEvent *event )
 			// Switch off Xray when switching teams
 			for (int i = 0; i < MAX_PLAYERS; i++)
 			{
-				if (auto player = dynamic_cast<C_BaseCombatCharacter*>(ClientEntityList().GetBaseEntity(i)))
+				if (auto player = UTIL_PlayerByIndex(i))
 				{
 					player->SetClientSideGlowEnabled(false);
 				}

--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -761,6 +761,9 @@ int	ClientModeShared::KeyInput( int down, ButtonCode_t keynum, const char *pszCu
 	return 1;
 }
 
+#ifdef NEO
+extern ConVar glow_outline_effect_enable;
+#endif // NEO
 //-----------------------------------------------------------------------------
 // Purpose: See if spectator input occurred. Return 0 if the key is swallowed.
 //-----------------------------------------------------------------------------
@@ -814,21 +817,14 @@ int ClientModeShared::HandleSpectatorKeyInput( int down, ButtonCode_t keynum, co
 #ifdef GLOWS_ENABLE
 	else if (down && pszCurrentBinding && Q_strcmp(pszCurrentBinding, "+attack2") == 0)
 	{
-		ConVar* glow_outline_effect_enable = cvar->FindVar("glow_outline_effect_enable");
-		if (!glow_outline_effect_enable)
-			return 0;
+		const bool outlinesEnabled = !glow_outline_effect_enable.GetBool();
+		glow_outline_effect_enable.SetValue(outlinesEnabled);
 
-		if (glow_outline_effect_enable->GetBool())
-			engine->ExecuteClientCmd("glow_outline_effect_enable 0");
-		else
-			engine->ExecuteClientCmd("glow_outline_effect_enable 1");
-
-		bool enabled = glow_outline_effect_enable->GetBool();
-		for (int i = 1; i <= MAX_PLAYERS; i++)
+		for (int i = 1; i <= gpGlobals->maxClients; i++)
 		{
 			if (auto player = UTIL_PlayerByIndex(i))
 			{
-				player->SetClientSideGlowEnabled(enabled);
+				player->SetClientSideGlowEnabled(outlinesEnabled);
 			}
 		}
 		return 0;

--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -814,11 +814,6 @@ int ClientModeShared::HandleSpectatorKeyInput( int down, ButtonCode_t keynum, co
 #ifdef GLOWS_ENABLE
 	else if (down && pszCurrentBinding && Q_strcmp(pszCurrentBinding, "+attack2") == 0)
 	{
-		if (GetLocalPlayerTeam() != TEAM_SPECTATOR)
-		{ // Can't use xray when dead spectating friends
-			return 0;
-		}
-
 		ConVar* glow_outline_effect_enable = cvar->FindVar("glow_outline_effect_enable");
 		if (!glow_outline_effect_enable)
 			return 0;
@@ -829,7 +824,7 @@ int ClientModeShared::HandleSpectatorKeyInput( int down, ButtonCode_t keynum, co
 			engine->ExecuteClientCmd("glow_outline_effect_enable 1");
 
 		bool enabled = glow_outline_effect_enable->GetBool();
-		for (int i = 0; i < MAX_PLAYERS; i++)
+		for (int i = 1; i <= MAX_PLAYERS; i++)
 		{
 			if (auto player = UTIL_PlayerByIndex(i))
 			{
@@ -1209,7 +1204,7 @@ void ClientModeShared::FireGameEvent( IGameEvent *event )
 			pPlayer->TeamChange( team );
 #ifdef NEO
 			// Switch off Xray when switching teams
-			for (int i = 0; i < MAX_PLAYERS; i++)
+			for (int i = 1; i <= MAX_PLAYERS; i++)
 			{
 				if (auto player = UTIL_PlayerByIndex(i))
 				{

--- a/mp/src/game/client/glow_outline_effect.cpp
+++ b/mp/src/game/client/glow_outline_effect.cpp
@@ -102,7 +102,7 @@ void CGlowObjectManager::RenderGlowModels( const CViewSetup *pSetup, int nSplitS
 	SetRenderTargetAndViewPort( pRtFullFrame, pSetup->width, pSetup->height );
 
 	pRenderContext->ClearColor3ub( 0, 0, 0 );
-	pRenderContext->ClearBuffers( true, false, false );
+	pRenderContext->ClearBuffers( true, true, false );
 
 	// Set override material for glow color
 	IMaterial *pMatGlowColor = NULL;

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -594,6 +594,12 @@ extern ConVar mat_neo_toc_test;
 int C_NEO_Player::DrawModel(int flags)
 {
 	int ret = 0;
+
+	if (flags & STUDIO_IGNORE_NEO_EFFECTS || !(flags & STUDIO_RENDER))
+	{
+		return BaseClass::DrawModel(flags);
+	}
+
 	auto pLocalPlayer = C_NEO_Player::GetLocalNEOPlayer();
 	if (!pLocalPlayer)
 	{
@@ -615,6 +621,7 @@ int C_NEO_Player::DrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("models/player/toc", TEXTURE_GROUP_CLIENT_EFFECTS);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::DrawModel(flags);
+		modelrender->ForcedMaterialOverride(null);
 	}
 
 	auto vel = GetAbsVelocity().Length();
@@ -623,6 +630,7 @@ int C_NEO_Player::DrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("dev/motion_third", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::DrawModel(flags);
+		modelrender->ForcedMaterialOverride(null);
 	}
 
 	else if (inThermalVision && !IsCloaked())
@@ -630,9 +638,9 @@ int C_NEO_Player::DrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("dev/thermal_third", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::DrawModel(flags);
+		modelrender->ForcedMaterialOverride(null);
 	}
 
-	modelrender->ForcedMaterialOverride(null);
 	return ret;
 }
 
@@ -1103,28 +1111,6 @@ void C_NEO_Player::TeamChange(int iNewTeam)
 	if (IsLocalPlayer())
 	{
 		engine->ClientCmd(classmenu.GetName());
-		if (iNewTeam == TEAM_SPECTATOR)
-		{
-			for (int i = 0; i < MAX_PLAYERS; i++)
-			{
-				auto player = UTIL_PlayerByIndex(i);
-				if (player)
-				{
-					player->SetClientSideGlowEnabled(true);
-				}
-			}
-		}
-		else
-		{
-			for (int i = 0; i < MAX_PLAYERS; i++)
-			{
-				auto player = UTIL_PlayerByIndex(i);
-				if (player)
-				{
-					player->SetClientSideGlowEnabled(false);
-				}
-			}
-		}
 	}
 	BaseClass::TeamChange(iNewTeam);
 }

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -861,7 +861,7 @@ void C_NEO_Player::PreThink( void )
 			// NEO TODO (Adam) since the stuff in C_NEO_PLAYER::Spawn() only runs the first time a person spawns in the map, would it be worth moving some of the stuff from there here instead?
 #ifdef GLOWS_ENABLE
 			// Disable client side glow effects of all players
-			for (int i = 1; i <= MAX_PLAYERS; i++)
+			for (int i = 1; i <= gpGlobals->maxClients; i++)
 			{
 				if (auto player = UTIL_PlayerByIndex(i))
 				{

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -206,6 +206,7 @@ public:
 	unsigned char m_NeoFlags;
 
 private:
+	bool m_bFirstAliveTick;
 	bool m_bFirstDeathTick;
 	bool m_bPreviouslyReloading;
 	bool m_bIsAllowedToToggleVision;

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -2739,6 +2739,9 @@ int CNEO_Player::ShouldTransmit(const CCheckTransmitInfo* pInfo)
 		{
 			// If other is spectator or same team
 			if (otherNeoPlayer->GetTeamNumber() == TEAM_SPECTATOR ||
+#ifdef GLOWS_ENABLE
+				otherNeoPlayer->IsDead() ||
+#endif
 					GetTeamNumber() == otherNeoPlayer->GetTeamNumber())
 			{
 				return FL_EDICT_ALWAYS;

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -17,6 +17,7 @@ extern ConVar weaponstay;
 #include "prediction.h"
 #include "hud_crosshair.h"
 #include "ui/neo_hud_crosshair.h"
+#include "model_types.h"
 #endif
 
 #include "basecombatweapon_shared.h"
@@ -1057,6 +1058,11 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 	if (GetOwner() == localPlayer && ShouldDrawLocalPlayerViewModel())
 		return 0;
 
+	if (flags & STUDIO_IGNORE_NEO_EFFECTS || !(flags & STUDIO_RENDER))
+	{
+		return BaseClass::DrawModel(flags);
+	}
+
 	int ret = 0;
 	auto pLocalPlayer = C_NEO_Player::GetLocalNEOPlayer();
 	if (!pLocalPlayer)
@@ -1085,6 +1091,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("models/player/toc", TEXTURE_GROUP_CLIENT_EFFECTS);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::DrawModel(flags);
+		modelrender->ForcedMaterialOverride(null);
 	}
 
 	auto vel = pOwner->GetAbsVelocity().Length();
@@ -1093,6 +1100,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("dev/motion_third", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::DrawModel(flags);
+		modelrender->ForcedMaterialOverride(null);
 	}
 
 	else if (inThermalVision && !pOwner->IsCloaked())
@@ -1100,15 +1108,21 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("dev/thermal_third", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::DrawModel(flags);
+		modelrender->ForcedMaterialOverride(null);
 	}
 
-	modelrender->ForcedMaterialOverride(null);
 	return ret;
 }
 
 int CNEOBaseCombatWeapon::InternalDrawModel(int flags)
 {
 	int ret = 0;
+
+	if (flags & STUDIO_IGNORE_NEO_EFFECTS || !(flags & STUDIO_RENDER))
+	{
+		return BaseClass::InternalDrawModel(flags);
+	}
+
 	auto pLocalPlayer = C_NEO_Player::GetLocalNEOPlayer();
 	if (!pLocalPlayer)
 	{
@@ -1136,6 +1150,7 @@ int CNEOBaseCombatWeapon::InternalDrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("models/player/toc", TEXTURE_GROUP_CLIENT_EFFECTS);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::InternalDrawModel(flags);
+		modelrender->ForcedMaterialOverride(null);
 	}
 
 	auto vel = pOwner->GetAbsVelocity().Length();
@@ -1144,6 +1159,7 @@ int CNEOBaseCombatWeapon::InternalDrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("dev/motion_third", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::InternalDrawModel(flags);
+		modelrender->ForcedMaterialOverride(null);
 	}
 
 	else if (inThermalVision && !pOwner->IsCloaked())
@@ -1151,9 +1167,9 @@ int CNEOBaseCombatWeapon::InternalDrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("dev/thermal_third", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::InternalDrawModel(flags);
+		modelrender->ForcedMaterialOverride(null);
 	}
 
-	modelrender->ForcedMaterialOverride(null);
 	return ret;
 }
 

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -1063,7 +1063,6 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 		return BaseClass::DrawModel(flags);
 	}
 
-	int ret = 0;
 	auto pLocalPlayer = C_NEO_Player::GetLocalNEOPlayer();
 	if (!pLocalPlayer)
 	{
@@ -1080,6 +1079,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 	bool inMotionVision = pLocalPlayer->IsInVision() && pLocalPlayer->GetClass() == NEO_CLASS_ASSAULT;
 	bool inThermalVision = pLocalPlayer->IsInVision() && pLocalPlayer->GetClass() == NEO_CLASS_SUPPORT;
 
+	int ret = 0;
 	if (!pOwner->IsCloaked() || inThermalVision)
 	{
 		ret |= BaseClass::DrawModel(flags);
@@ -1091,7 +1091,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("models/player/toc", TEXTURE_GROUP_CLIENT_EFFECTS);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::DrawModel(flags);
-		modelrender->ForcedMaterialOverride(null);
+		modelrender->ForcedMaterialOverride(nullptr);
 	}
 
 	auto vel = pOwner->GetAbsVelocity().Length();
@@ -1100,7 +1100,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("dev/motion_third", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::DrawModel(flags);
-		modelrender->ForcedMaterialOverride(null);
+		modelrender->ForcedMaterialOverride(nullptr);
 	}
 
 	else if (inThermalVision && !pOwner->IsCloaked())
@@ -1108,7 +1108,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("dev/thermal_third", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::DrawModel(flags);
-		modelrender->ForcedMaterialOverride(null);
+		modelrender->ForcedMaterialOverride(nullptr);
 	}
 
 	return ret;
@@ -1116,8 +1116,6 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 
 int CNEOBaseCombatWeapon::InternalDrawModel(int flags)
 {
-	int ret = 0;
-
 	if (flags & STUDIO_IGNORE_NEO_EFFECTS || !(flags & STUDIO_RENDER))
 	{
 		return BaseClass::InternalDrawModel(flags);
@@ -1139,6 +1137,7 @@ int CNEOBaseCombatWeapon::InternalDrawModel(int flags)
 	bool inMotionVision = pLocalPlayer->IsInVision() && pLocalPlayer->GetClass() == NEO_CLASS_ASSAULT;
 	bool inThermalVision = pLocalPlayer->IsInVision() && pLocalPlayer->GetClass() == NEO_CLASS_SUPPORT;
 
+	int ret = 0;
 	if (!pOwner->IsCloaked() || inThermalVision)
 	{
 		ret |= BaseClass::InternalDrawModel(flags);
@@ -1150,7 +1149,7 @@ int CNEOBaseCombatWeapon::InternalDrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("models/player/toc", TEXTURE_GROUP_CLIENT_EFFECTS);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::InternalDrawModel(flags);
-		modelrender->ForcedMaterialOverride(null);
+		modelrender->ForcedMaterialOverride(nullptr);
 	}
 
 	auto vel = pOwner->GetAbsVelocity().Length();
@@ -1159,7 +1158,7 @@ int CNEOBaseCombatWeapon::InternalDrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("dev/motion_third", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::InternalDrawModel(flags);
-		modelrender->ForcedMaterialOverride(null);
+		modelrender->ForcedMaterialOverride(nullptr);
 	}
 
 	else if (inThermalVision && !pOwner->IsCloaked())
@@ -1167,7 +1166,7 @@ int CNEOBaseCombatWeapon::InternalDrawModel(int flags)
 		IMaterial* pass = materials->FindMaterial("dev/thermal_third", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
 		ret |= BaseClass::InternalDrawModel(flags);
-		modelrender->ForcedMaterialOverride(null);
+		modelrender->ForcedMaterialOverride(nullptr);
 	}
 
 	return ret;

--- a/mp/src/public/model_types.h
+++ b/mp/src/public/model_types.h
@@ -22,6 +22,9 @@
 #define STUDIO_ITEM_BLINK				0x00000040
 #define STUDIO_NOSHADOWS				0x00000080
 #define STUDIO_WIREFRAME_VCOLLIDE		0x00000100
+#ifdef NEO
+#define STUDIO_IGNORE_NEO_EFFECTS		0x00000200
+#endif
 
 // Not a studio flag, but used to flag when we want studio stats
 #define STUDIO_GENERATE_STATS			0x01000000


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Re-overrides the material used to draw player glow for every new player drawn, disabled enabling of xray when dead spectating teammates, moves the toggle off of xray vision when changing teams to clientmodeshared

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #702