### PR TITLE
Fix knife incorrect initial secondary attack

### DIFF
--- a/mp/src/game/shared/neo/weapons/weapon_knife.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_knife.cpp
@@ -98,16 +98,11 @@ void CWeaponKnife::PrimaryAttack()
 	// Move other players back to history positions based on local player's lag
 	lagcompensation->StartLagCompensation(pPlayer, pPlayer->GetCurrentCommand());
 #endif
-	Swing(false);
+	Swing();
 #ifndef CLIENT_DLL
 	// Move other players back to history positions based on local player's lag
 	lagcompensation->FinishLagCompensation(pPlayer);
 #endif
-}
-
-void CWeaponKnife::SecondaryAttack()
-{
-	Swing(true);
 }
 
 bool CWeaponKnife::CanBePickedUpByClass(int classId)
@@ -129,7 +124,7 @@ bool CWeaponKnife::IsViewable()
 }
 #endif
 
-void CWeaponKnife::Swing(int bIsSecondary)
+void CWeaponKnife::Swing()
 {
 	auto pOwner = static_cast<CNEO_Player*>(GetOwner());
 	if (!pOwner)

--- a/mp/src/game/shared/neo/weapons/weapon_knife.h
+++ b/mp/src/game/shared/neo/weapons/weapon_knife.h
@@ -33,11 +33,11 @@ public:
 	CWeaponKnife();
 
 	virtual void PrimaryAttack() final;
-	virtual void SecondaryAttack() final;
 	virtual void Drop(const Vector &vecVelocity) final { /* knives shouldn't drop */ }
 
 	virtual bool CanBePickedUpByClass(int classId) final;
 	virtual bool CanDrop() final { return false; }
+	virtual bool CanPerformSecondaryAttack() const override final { return false; }
 
 #ifdef CLIENT_DLL
 	virtual bool ShouldDraw() final;
@@ -55,7 +55,7 @@ public:
 
 protected:
 	void		ImpactEffect(trace_t &traceHit);
-	void		Swing(int bIsSecondary);
+	void		Swing();
 	Activity	ChooseIntersectionPointAndActivity(trace_t& hitTrace, const Vector& mins, const Vector& maxs, CBasePlayer* pOwner);
 	bool		ImpactWater(const Vector &start, const Vector &end);
 	void		Hit(trace_t& traceHit, Activity nHitActivity);


### PR DESCRIPTION
## Description
Fix a problem where the knife swing could be incorrectly triggered once, using the `+attack2` input.

This is a supplementary fix to #708 since I forgot to address the knife stuff in the earlier PR #714 that closed the issue.

We had some buggy scaffolding in place for supporting a speculative future secondary attack feature for the knife, but in the spirit of YAGNI I've decided to delete it for now to simplify the code.

## To reproduce
See #708 (only the knife case is applicable here, grenades should be already fixed).

## Toolchain
- Linux GCC Distro Native [Mint 21.3 + GCC 11.4.0]

## Linked Issues
- fixes #708 
- related #714 