### PR TITLE
Rangefinder HUD

### DIFF
--- a/mp/src/game/client/neo/ui/neo_hud_compass.h
+++ b/mp/src/game/client/neo/ui/neo_hud_compass.h
@@ -38,6 +38,7 @@ private:
 	mutable int m_savedXBoxWidth = 0;
 
 	wchar_t m_wszCompassUnicode[UNICODE_NEO_COMPASS_STR_LENGTH];
+	wchar_t m_wszRangeFinder[11];
 
 	CPanelAnimationVarAliasType(bool, m_showCompass, "visible", "1", "bool");
 	CPanelAnimationVarAliasType(int, m_yFromBottomPos, "y_bottom_pos", "3", "proportional_ypos");

--- a/mp/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/mp/src/game/client/neo/ui/neo_root_settings.cpp
@@ -243,6 +243,7 @@ void NeoSettingsRestore(NeoSettings *ns, const NeoSettings::Keys::Flags flagsKey
 		}
 		pGeneral->bStreamerMode = cvr->neo_cl_streamermode.GetBool();
 		pGeneral->bAutoDetectOBS = cvr->neo_cl_streamermode_autodetect_obs.GetBool();
+		pGeneral->bEnableRangeFinder = cvr->neo_cl_hud_rangefinder_enabled.GetBool();
 	}
 	{
 		NeoSettings::Keys *pKeys = &ns->keys;
@@ -444,6 +445,7 @@ void NeoSettingsSave(const NeoSettings *ns)
 		cvr->cl_downloadfilter.SetValue(DLFILTER_STRMAP[pGeneral->iDlFilter]);
 		cvr->neo_cl_streamermode.SetValue(pGeneral->bStreamerMode);
 		cvr->neo_cl_streamermode_autodetect_obs.SetValue(pGeneral->bAutoDetectOBS);
+		cvr->neo_cl_hud_rangefinder_enabled.SetValue(pGeneral->bEnableRangeFinder);
 	}
 	{
 		const NeoSettings::Keys *pKeys = &ns->keys;
@@ -644,6 +646,7 @@ void NeoSettings_General(NeoSettings *ns)
 	NeoUI::RingBoxBool(L"Streamer mode", &pGeneral->bStreamerMode);
 	NeoUI::RingBoxBool(L"Auto streamer mode (requires restart)", &pGeneral->bAutoDetectOBS);
 	NeoUI::Label(L"OBS detection", g_bOBSDetected ? L"OBS detected on startup" : L"Not detected on startup");
+	NeoUI::RingBoxBool(L"Show rangefinder", &pGeneral->bEnableRangeFinder);
 }
 
 void NeoSettings_Keys(NeoSettings *ns)

--- a/mp/src/game/client/neo/ui/neo_root_settings.h
+++ b/mp/src/game/client/neo/ui/neo_root_settings.h
@@ -40,6 +40,7 @@ struct NeoSettings
 		int iDlFilter;
 		bool bStreamerMode;
 		bool bAutoDetectOBS;
+		bool bEnableRangeFinder;
 	};
 
 	struct Keys
@@ -164,6 +165,7 @@ struct NeoSettings
 		CONVARREF_DEF(neo_cl_toggleconsole);
 		CONVARREF_DEF(neo_cl_streamermode);
 		CONVARREF_DEF(neo_cl_streamermode_autodetect_obs);
+		CONVARREF_DEF(neo_cl_hud_rangefinder_enabled);
 
 		// Multiplayer
 		CONVARREF_DEF(cl_playerspraydisable);


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* In meters, the distance between the player and solid wall
* Skybox and >= 1000m will return "---m" to show infinity value
* Only shown in ADS
* ConVars:
    * neo_cl_hud_rangefinder_enabled - 1 as default, Toggle enable/disable
    * neo_cl_hud_rangefinder_pos_frac_[x/y] - 0.55 as default, position in fraction in screen width/height
* Added to settings > General to toggle rangefinder


## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

* fixes #761

