### PR TITLE
Cancel concurrent jobs of the same group

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.platform.display_name }} ${{ matrix.preset_build_type.display_name }}


### PR DESCRIPTION
## Description
When there are multiple CI jobs active concurrently, cancel all except the most recent one. This saves some runner minutes from doing redundant work when we only care about the most recent run.

This might also fix a hypothetical race condition on the "Latest Master Build" job, where if two such jobs started at a similar time by two different pushes, whichever of them finished last would (I think?) overwrite the release output, regardless of their chronology—whereas we'd always want the latest commit to prevail. I haven't verified if this can actually happen however.

Related docs: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs

## Toolchain
N/A