### PR TITLE
IFF fix when previously using xray

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -809,7 +809,7 @@ void C_NEO_Player::PlayStepSound( Vector &vecOrigin,
 }
 
 extern ConVar sv_infinite_aux_power;
-
+extern ConVar glow_outline_effect_enable;
 void C_NEO_Player::PreThink( void )
 {
 	BaseClass::PreThink();
@@ -912,6 +912,7 @@ void C_NEO_Player::PreThink( void )
 					player->SetClientSideGlowEnabled(false);
 				}
 			}
+			glow_outline_effect_enable.SetValue(false);
 #endif // GLOWS_ENABLE
 		}
 		Lean();


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Returns the IFF indicators above friendly players when player was previously using xray in spectator mode. Also fixes a problem where xray button had to be pressed twice to enable xray in spectator mode if person was using xray previously before respawning.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #783 