### PR TITLE
Dont draw guns if owner isn't being drawn

### DIFF
--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -1033,6 +1033,11 @@ bool CNEOBaseCombatWeapon::ShouldDraw(void)
 	if (!pOwner)
 		return true;
 
+	if (!pOwner->ShouldDraw())
+	{
+		return false;
+	}
+
 	C_BasePlayer* pLocalPlayer = C_BasePlayer::GetLocalPlayer();
 
 	// carried by local player?


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Could probably explore the topic of not giving spectators guns as well, and also afterwards or in general make sure spectators cannot pickup guns or other utility from the floor, but either way this should probably also be the case.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #798 
