### PR TITLE
Fair spawn mechanics

### DIFF
--- a/mp/src/game/server/neo/neo_client.cpp
+++ b/mp/src/game/server/neo/neo_client.cpp
@@ -50,6 +50,8 @@ void FinishClientPutInServer( CNEO_Player *pPlayer )
 				const CNEORules::RestoreInfo &restoreInfo = restoredInfos.Element(hdl);
 				pPlayer->m_iXP.Set(restoreInfo.xp);
 				pPlayer->IncrementDeathCount(restoreInfo.deaths);
+				pPlayer->SetDeathTime(restoreInfo.deathTime);
+				pPlayer->m_bSpawnedThisRound = restoreInfo.spawnedThisRound;
 				ClientPrint(pPlayer, HUD_PRINTTALK, "Your XP and death count have been restored.\n");
 			}
 		}

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -503,10 +503,17 @@ void CNEO_Player::Spawn(void)
 
 	if (teamNumber == TEAM_JINRAI || teamNumber == TEAM_NSF)
 	{
-		if (NEORules()->IsRoundOn())
+		if (NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze)
 		{
-			m_bSpawnedThisRound = true; // NEO TODO (Adam) should people who were spectating at the start of the match and potentially have unfair information about the enemy team be allowed to join the game?
+			AddFlag(FL_GODMODE);
+			AddNeoFlag(NEO_FL_FREEZETIME);
 		}
+
+		if (NEORules()->IsRoundOn())
+		{ // NEO TODO (Adam) should people who were spectating at the start of the match and potentially have unfair information about the enemy team be allowed to join the game?
+			m_bSpawnedThisRound = true;
+		}
+
 		State_Transition(STATE_ACTIVE);
 	}
 	

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -503,6 +503,10 @@ void CNEO_Player::Spawn(void)
 
 	if (teamNumber == TEAM_JINRAI || teamNumber == TEAM_NSF)
 	{
+		if (NEORules()->IsRoundOn())
+		{
+			m_bSpawnedThisRound = true; // NEO TODO (Adam) should people who were spectating at the start of the match and potentially have unfair information about the enemy team be allowed to join the game?
+		}
 		State_Transition(STATE_ACTIVE);
 	}
 	

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -199,6 +199,8 @@ public:
 	AttackersTotals GetAttackersTotals() const;
 	void StartShowDmgStats(const CTakeDamageInfo *info);
 
+	inline void SetDeathTime(const float deathTime) { m_flDeathTime.Set(deathTime); }
+
 	IMPLEMENT_NETWORK_VAR_FOR_DERIVED(m_EyeAngleOffset);
 
 private:
@@ -258,6 +260,7 @@ public:
 	CNetworkVar(bool, m_bClientWantNeoName);
 
 	bool m_bIsPendingSpawnForThisRound;
+	bool m_bSpawnedThisRound = false;
 	bool m_bKilledInflicted = false; // Server-side var only
 	int m_iTeamDamageInflicted = 0;
 	int m_iTeamKillsInflicted = 0;

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -2024,11 +2024,6 @@ void CNEORules::StartNextRound()
 		}
 		pPlayer->RemoveAllItems(true);
 		pPlayer->Spawn();
-		if (gpGlobals->curtime < m_flNeoRoundStartTime + mp_neo_preround_freeze_time.GetFloat())
-		{
-			pPlayer->AddFlag(FL_GODMODE);
-			pPlayer->AddNeoFlag(NEO_FL_FREEZETIME);
-		}
 
 		pPlayer->m_bInAim = false;
 		pPlayer->m_bInThermOpticCamo = false;

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -3393,7 +3393,7 @@ void CNEORules::ClientDisconnected(edict_t* pClient)
 					.xp = pNeoPlayer->m_iXP.Get(),
 					.deaths = pNeoPlayer->DeathCount(),
 					.spawnedThisRound = pNeoPlayer->m_bSpawnedThisRound,
-					.deathTime = gpGlobals->curtime, // NEOTODO (Adam) prevent players abusing retry command to save themselves in games with respawns. Should award xp to whoever did most damage to disconnecting player, for now simply ensure they can't respawn too quickly
+					.deathTime = pNeoPlayer->IsAlive() ? gpGlobals->curtime : pNeoPlayer->GetDeathTime(), // NEOTODO (Adam) prevent players abusing retry command to save themselves in games with respawns. Should award xp to whoever did most damage to disconnecting player, for now simply ensure they can't respawn too quickly
 				};
 
 				if (restoreInfo.xp == 0 && restoreInfo.deaths == 0 && restoreInfo.deathTime == 0.f && restoreInfo.spawnedThisRound == false)

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -246,6 +246,7 @@ public:
 #endif
 	bool IsRoundPreRoundFreeze() const;
 	bool IsRoundLive() const;
+	bool IsRoundOn() const;
 	bool IsRoundOver() const;
 #ifdef GAME_DLL
 	void GatherGameTypeVotes();
@@ -349,6 +350,8 @@ public:
 	{
 		int xp;
 		int deaths;
+		bool spawnedThisRound;
+		float deathTime;
 	};
 	// AccountID_t <- CSteamID::GetAccountID
 	CUtlHashtable<AccountID_t, RestoreInfo> m_pRestoredInfos;


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Prevents players from spawning if previously spawned during that ongoing round, and enforces the DEATH_ANIMATION_TIME in game modes with respawns enabled.

Ensures people who spawn during freeze time are frozen.

Also stops spectators from being respawned and frozen during round start.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #793