### PR TITLE
Correct improper symlink command order

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ These instructions have been written with a Debian 12 machine in mind, but they 
 
     (NOTE: I'm NOT sure if this is how it is on other systems other than Debian 12, so please, check first if you have `~/.steam/sdk32` before running these! If you have Desktop Steam installed, then you should have this directory, but it doesn't seem to be the case with SteamCMD, which is why we need to do this.)
     ```
-    ln -s ~/.steam/sdk32 ~/.steam/steam/steamcmd/linux32
+    ln -s ~/.steam/steam/steamcmd/linux32 ~/.steam/sdk32
     ```
 9. For firewall, open the following ports:
     * 27015 TCP+UDP (you can keep the TCP port closed if you don't need RCON support)


### PR DESCRIPTION
target/link were confused. the command as it was would create a link from linux32 TO sdk32 (or if it's an existing folder, as it would be here, confusedly create a broken sdk32 link inside of linux32.)

