### PR TITLE
Third person to first person view model problem fixes

### DIFF
--- a/mp/src/game/client/c_baseplayer.cpp
+++ b/mp/src/game/client/c_baseplayer.cpp
@@ -2039,11 +2039,22 @@ void C_BasePlayer::ThirdPersonSwitch( bool bThirdperson )
 		}
 
 		//Notify weapon.
+#ifndef NEO
 		CBaseCombatWeapon *pWeapon = GetActiveWeapon();
 		if ( pWeapon )
 		{
 			pWeapon->ThirdPersonSwitch( bThirdperson );
 		}
+#else
+		for (int i = 0; i < WeaponCount(); i++)
+		{
+			CBaseCombatWeapon* pWeapon = GetWeapon(i);
+			if (pWeapon)
+			{
+				pWeapon->ThirdPersonSwitch( bThirdperson );
+			}
+		}
+#endif // NEO
 	}
 }
 

--- a/mp/src/game/shared/basecombatweapon_shared.cpp
+++ b/mp/src/game/shared/basecombatweapon_shared.cpp
@@ -1502,6 +1502,7 @@ bool CBaseCombatWeapon::Holster( CBaseCombatWeapon *pSwitchingTo )
 	// kill any think functions
 	SetThink(NULL);
 
+#ifndef NEO
 	// Send holster animation
 	SendWeaponAnim( ACT_VM_HOLSTER );
 
@@ -1526,10 +1527,9 @@ bool CBaseCombatWeapon::Holster( CBaseCombatWeapon *pSwitchingTo )
 	else
 	{
 		// Hide the weapon when the holster animation's finished
-#ifndef NEO
 		SetContextThink( &CBaseCombatWeapon::HideThink, gpGlobals->curtime + flSequenceDuration, HIDEWEAPON_THINK_CONTEXT );
-#endif // NEO
 	}
+#endif // NEO
 
 	// if we were displaying a hud hint, squelch it.
 	if (m_flHudHintMinDisplayTime && gpGlobals->curtime < m_flHudHintMinDisplayTime)
@@ -2428,7 +2428,7 @@ bool CBaseCombatWeapon::SetIdealActivity( Activity ideal )
 
 	//Find the next sequence in the potential chain of sequences leading to our ideal one
 	int nextSequence = FindTransitionSequence( GetSequence(), m_nIdealSequence, NULL );
-
+	
 	// Don't use transitions when we're deploying
 	if ( ideal != ACT_VM_DRAW && IsWeaponVisible() && nextSequence != m_nIdealSequence )
 	{

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -1058,6 +1058,26 @@ bool CNEOBaseCombatWeapon::ShouldDraw(void)
 	return true;
 }
 
+void CNEOBaseCombatWeapon::ThirdPersonSwitch(bool bThirdPerson)
+{
+	UpdateVisibility();
+	if (!bThirdPerson)
+	{
+		SetModel(GetViewModel());
+	}
+}
+
+
+int CNEOBaseCombatWeapon::RestoreData(const char* context, int slot, int type)
+{
+	int val = BaseClass::RestoreData(context, slot, type);
+	if (ShouldDrawLocalPlayerViewModel() && GetModelIndex() != modelinfo->GetModelIndex(STRING(GetModelName())))
+	{ // NEOHACK (Adam) This restore data method converts the local players' weapon model back to a world model if the player was in third person with this weapon equipped, regardless of whether they are back in first person or not. Need to set it back to a viewmodel (Must an entity have the same model on server and client? If so we need to refactor how we handle view models)
+		SetModel(GetViewModel());
+	}
+	return val;
+}
+
 extern ConVar mat_neo_toc_test;
 int CNEOBaseCombatWeapon::DrawModel(int flags)
 {

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -252,6 +252,8 @@ public:
 	virtual bool Holster(CBaseCombatWeapon* pSwitchingTo);
 	virtual void ItemHolsterFrame() override;
 	virtual bool ShouldDraw(void) override;
+	virtual void ThirdPersonSwitch(bool bThirdPerson) override;
+	virtual int RestoreData(const char* context, int slot, int type) override;
 	virtual int DrawModel(int flags) override;
 	virtual int InternalDrawModel(int flags) override;
 	virtual ShadowType_t ShadowCastType(void) override;


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Fixes some issues with the viewmodel when switching to thirdperson and then back to first person.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Issue 1: when switching to third person and back to first person, the third person muzzle flash for the gun that was active when in first person will be visible in first person until weapons are switched

Issue 2: when switching between weapons after coming back to first person, the weapon view model flashes briefly in the idle position before disappearing after which ACT_VM_DRAW correctly brings it up from below/side of the screen.

Issue 3: The primary attack animation breaks with continuous use.

Third person isn't a parity feature so I didn't bother to open issues for these, except for the third issue which this PR addresses but its more of a workaround I think.

- related #829 