### PR TITLE
Use EF_NOSHADOW to control weapon shadow state

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -479,7 +479,7 @@ void C_NEO_Player::CheckThermOpticButtons()
 
 		if (m_HL2Local.m_cloakPower >= CLOAK_AUX_COST)
 		{
-			m_bInThermOpticCamo = !m_bInThermOpticCamo;
+			SetCloakState(!m_bInThermOpticCamo);
 		}
 	}
 
@@ -870,7 +870,7 @@ void C_NEO_Player::PreThink( void )
 
 				if (m_HL2Local.m_cloakPower < CLOAK_AUX_COST)
 				{
-					m_bInThermOpticCamo = false;
+					SetCloakState(false);
 
 					m_HL2Local.m_cloakPower = 0.0f;
 					m_flCamoAuxLastTime = 0;
@@ -1614,6 +1614,20 @@ void C_NEO_Player::PlayCloakSound(void)
 	params.m_nChannel = CHAN_VOICE;
 
 	EmitSound(filter, entindex(), params);
+}
+
+void C_NEO_Player::SetCloakState(bool state)
+{
+	m_bInThermOpticCamo = state;
+
+	const auto setShadowState = m_bInThermOpticCamo ? [](CBaseCombatWeapon* weapon) {weapon->AddEffects(EF_NOSHADOW);} : [](CBaseCombatWeapon* weapon) {weapon->RemoveEffects(EF_NOSHADOW);};
+	for (int i = 0; i < MAX_WEAPONS; i++)
+	{
+		if (CBaseCombatWeapon* weapon = GetWeapon(i))
+		{
+			setShadowState(weapon);
+		}
+	}
 }
 
 void C_NEO_Player::PreDataUpdate(DataUpdateType_t updateType)

--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -1620,12 +1620,14 @@ void C_NEO_Player::SetCloakState(bool state)
 {
 	m_bInThermOpticCamo = state;
 
-	const auto setShadowState = m_bInThermOpticCamo ? [](CBaseCombatWeapon* weapon) {weapon->AddEffects(EF_NOSHADOW);} : [](CBaseCombatWeapon* weapon) {weapon->RemoveEffects(EF_NOSHADOW);};
+	void (CBaseCombatWeapon:: * setShadowState)(int) = m_bInThermOpticCamo ? &CBaseCombatWeapon::AddEffects 
+																		   : &CBaseCombatWeapon::RemoveEffects;
+
 	for (int i = 0; i < MAX_WEAPONS; i++)
 	{
 		if (CBaseCombatWeapon* weapon = GetWeapon(i))
 		{
-			setShadowState(weapon);
+			(weapon->*setShadowState)(EF_NOSHADOW);
 		}
 	}
 }

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -168,10 +168,7 @@ private:
 	void CheckVisionButtons();
 	void CheckLeanButtons();
 	void PlayCloakSound();
-public:
 	void SetCloakState(bool state);
-
-private:
 
 	bool IsAllowedToSuperJump(void);
 

--- a/mp/src/game/client/neo/c_neo_player.h
+++ b/mp/src/game/client/neo/c_neo_player.h
@@ -168,6 +168,10 @@ private:
 	void CheckVisionButtons();
 	void CheckLeanButtons();
 	void PlayCloakSound();
+public:
+	void SetCloakState(bool state);
+
+private:
 
 	bool IsAllowedToSuperJump(void);
 

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -854,12 +854,14 @@ void CNEO_Player::SetCloakState(bool state)
 {
 	m_bInThermOpticCamo = state;
 
-	const auto setShadowState = m_bInThermOpticCamo ? [](CBaseCombatWeapon* weapon) {weapon->AddEffects(EF_NOSHADOW);} : [](CBaseCombatWeapon* weapon) {weapon->RemoveEffects(EF_NOSHADOW);};
+	void (CBaseCombatWeapon:: * setShadowState)(int) = m_bInThermOpticCamo ? &CBaseCombatWeapon::AddEffects 
+																		   : &CBaseCombatWeapon::RemoveEffects;
+
 	for (int i = 0; i < MAX_WEAPONS; i++)
 	{
 		if (CBaseCombatWeapon* weapon = GetWeapon(i))
 		{
-			setShadowState(weapon);
+			(weapon->*setShadowState)(EF_NOSHADOW);
 		}
 	}
 }

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -715,7 +715,7 @@ void CNEO_Player::PreThink(void)
 
 				if (m_HL2Local.m_cloakPower <= 0.1f)
 				{
-					m_bInThermOpticCamo = false;
+					SetCloakState(false);
 					m_flCamoAuxLastTime = 0;
 				}
 				else
@@ -850,6 +850,20 @@ void CNEO_Player::PlayCloakSound()
 	}
 }
 
+void CNEO_Player::SetCloakState(bool state)
+{
+	m_bInThermOpticCamo = state;
+
+	const auto setShadowState = m_bInThermOpticCamo ? [](CBaseCombatWeapon* weapon) {weapon->AddEffects(EF_NOSHADOW);} : [](CBaseCombatWeapon* weapon) {weapon->RemoveEffects(EF_NOSHADOW);};
+	for (int i = 0; i < MAX_WEAPONS; i++)
+	{
+		if (CBaseCombatWeapon* weapon = GetWeapon(i))
+		{
+			setShadowState(weapon);
+		}
+	}
+}
+
 void CNEO_Player::CloakFlash()
 {
 	CRecipientFilter filter;
@@ -880,7 +894,7 @@ void CNEO_Player::CheckThermOpticButtons()
 
 		if (m_HL2Local.m_cloakPower >= CLOAK_AUX_COST)
 		{
-			m_bInThermOpticCamo = !m_bInThermOpticCamo;
+			SetCloakState(!m_bInThermOpticCamo);
 
 			if (m_bInThermOpticCamo)
 			{

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -211,10 +211,7 @@ private:
 	void CheckLeanButtons();
 	void PlayCloakSound();
 	void CloakFlash();
-public:
 	void SetCloakState(bool state);
-
-private:
 
 	bool IsAllowedToSuperJump(void);
 

--- a/mp/src/game/server/neo/neo_player.h
+++ b/mp/src/game/server/neo/neo_player.h
@@ -211,6 +211,10 @@ private:
 	void CheckLeanButtons();
 	void PlayCloakSound();
 	void CloakFlash();
+public:
+	void SetCloakState(bool state);
+
+private:
 
 	bool IsAllowedToSuperJump(void);
 

--- a/mp/src/game/shared/basecombatweapon_shared.cpp
+++ b/mp/src/game/shared/basecombatweapon_shared.cpp
@@ -710,6 +710,9 @@ void CBaseCombatWeapon::Drop( const Vector &vecVelocity )
 	SetGravity(1.0);
 	m_iState = WEAPON_NOT_CARRIED;
 	RemoveEffects( EF_NODRAW );
+#ifdef NEO
+	RemoveEffects( EF_NOSHADOW );
+#endif // NEO
 	FallInit();
 	SetGroundEntity( NULL );
 	SetThink( &CBaseCombatWeapon::SetPickupTouch );

--- a/mp/src/game/shared/basecombatweapon_shared.cpp
+++ b/mp/src/game/shared/basecombatweapon_shared.cpp
@@ -709,10 +709,11 @@ void CBaseCombatWeapon::Drop( const Vector &vecVelocity )
 	// clear follow stuff, setup for collision
 	SetGravity(1.0);
 	m_iState = WEAPON_NOT_CARRIED;
-	RemoveEffects( EF_NODRAW );
 #ifdef NEO
-	RemoveEffects( EF_NOSHADOW );
-#endif // NEO
+	RemoveEffects(EF_NODRAW | EF_NOSHADOW);
+#else
+	RemoveEffects( EF_NODRAW );
+#endif
 	FallInit();
 	SetGroundEntity( NULL );
 	SetThink( &CBaseCombatWeapon::SetPickupTouch );

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -249,6 +249,11 @@ void CNEOBaseCombatWeapon::Spawn()
 void CNEOBaseCombatWeapon::Equip(CBaseCombatCharacter* pOwner)
 {
 	BaseClass::Equip(pOwner);
+	auto neoOwner = static_cast<CNEO_Player*>(pOwner);
+	if (neoOwner->m_bInThermOpticCamo)
+	{
+		AddEffects(EF_NOSHADOW);
+	}
 #ifndef CLIENT_DLL
 	NEO_WEP_BITS_UNDERLYING_TYPE weapon = GetNeoWepBits();
 	if (weapon & (NEO_WEP_KYLA | NEO_WEP_MILSO | NEO_WEP_TACHI))
@@ -1103,16 +1108,6 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 	}
 
 	return ret;
-}
-
-ShadowType_t CNEOBaseCombatWeapon::ShadowCastType(void)
-{
-	C_NEO_Player* owner = static_cast<C_NEO_Player*>(ToBasePlayer(GetOwner()));
-	if (owner && owner->IsCloaked())
-	{
-		return SHADOWS_NONE;
-	}
-	return BaseClass::ShadowCastType();
 }
 
 RenderGroup_t CNEOBaseCombatWeapon::GetRenderGroup()

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -253,7 +253,6 @@ public:
 	virtual void ItemHolsterFrame() override;
 	virtual bool ShouldDraw(void) override;
 	virtual int DrawModel(int flags) override;
-	virtual ShadowType_t ShadowCastType(void) override;
 	virtual RenderGroup_t GetRenderGroup() override;
 	virtual bool UsesPowerOfTwoFrameBufferTexture() override;
 #endif


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Weapons that weren't active weren't getting data updates and so ShadowCastType() wasn't being run for them. This pr switches how we control whether shadows are drawn for weapons specifically to instead use the effect EF_NOSHADOW. I've tested bots toggling cloak on and off manually, bots running out of cloak, bots dropping weapons while cloaked, bots dying while cloaked and the shadow behavior for all of these seems correct.

One situation I can think of that I haven't tested where this might break would be a cloaked player who enabled cloak while not in pvs running into view of the player.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #831 