### PR TITLE
Material proxy for getting team number

### DIFF
--- a/mp/src/game/client/CMakeLists.txt
+++ b/mp/src/game/client/CMakeLists.txt
@@ -1506,6 +1506,7 @@ target_sources_grouped(
     FILES
     neo/material_proxies/neo_matproxy_thermoptic.cpp
     neo/material_proxies/neo_matproxy_thermoptic.h
+    neo/material_proxies/neo_matproxy_teamnum.cpp
 )
 
 target_sources_grouped(

--- a/mp/src/game/client/neo/material_proxies/neo_matproxy_teamnum.cpp
+++ b/mp/src/game/client/neo/material_proxies/neo_matproxy_teamnum.cpp
@@ -17,8 +17,6 @@ class CNEOEntityTeamProxy : public CResultProxy
 public:
     bool Init( IMaterial *pMaterial, KeyValues *pKeyValues );
     void OnBind( void *pC_BaseEntity );
-
-private:
 };
 
 bool CNEOEntityTeamProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )

--- a/mp/src/game/client/neo/material_proxies/neo_matproxy_teamnum.cpp
+++ b/mp/src/game/client/neo/material_proxies/neo_matproxy_teamnum.cpp
@@ -1,0 +1,52 @@
+#include "cbase.h"
+#include "functionproxy.h"
+#include "toolframework_client.h"
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+// forward declarations
+void ToolFramework_RecordMaterialParams(IMaterial* pMaterial);
+
+//-----------------------------------------------------------------------------
+// Returns the team number of the entity the material (proxy) is attached to
+//-----------------------------------------------------------------------------
+
+class CNEOEntityTeamProxy : public CResultProxy
+{
+public:
+    bool Init( IMaterial *pMaterial, KeyValues *pKeyValues );
+    void OnBind( void *pC_BaseEntity );
+
+private:
+};
+
+bool CNEOEntityTeamProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
+{
+    if (!CResultProxy::Init( pMaterial, pKeyValues ))
+        return false;
+
+    return true;
+}
+
+void CNEOEntityTeamProxy::OnBind( void *pC_BaseEntity )
+{
+    if (!pC_BaseEntity)
+        return;
+
+    C_BaseEntity *pEntity = BindArgToEntity( pC_BaseEntity );
+    if (!pEntity)
+        return;
+
+    Assert(m_pResult);
+
+    // Shaders like floats, apparently
+    SetFloatResult(static_cast<float>(pEntity->GetTeamNumber()));
+
+    if ( ToolsEnabled() )
+    {
+        ToolFramework_RecordMaterialParams( GetMaterial() );
+    }
+}
+
+EXPOSE_INTERFACE( CNEOEntityTeamProxy, IMaterialProxy, "EntityTeam" IMATERIAL_PROXY_INTERFACE_VERSION );


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Material proxy for getting the team of the entity the material is attached to.
If this proxy were used on a material for any of the jinrai player skins, it would return 2 (given its actually being used on a jinrai player)

It will give an output from resultVar like other proxies.
0 = Unassigned
1 = Spectator
2 = Jinrai
3 = NSF

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

