### PR TITLE
Add automatic SourceMod gamedata generation

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -22,7 +22,7 @@ jobs:
 
       matrix:
         platform:
-        - { display_name: 'Linux Native Libraries', os: ubuntu-latest, preset_os: linux }
+        - { display_name: 'Linux Native Libraries', os: ubuntu-24.04, preset_os: linux }
         - { display_name: 'Windows Native Libraries', os: windows-latest, preset_os: windows }
 
         preset_build_type:
@@ -45,10 +45,10 @@ jobs:
         echo "preset_name=$preset_name" >> "$GITHUB_ENV"
 
     - name: Install packages
-      if: ${{ matrix.platform.os == 'ubuntu-latest' }}
+      if: ${{ matrix.platform.os == 'ubuntu-24.04' }}
       run: |
         sudo apt update
-        sudo apt install gcc-multilib g++-multilib ninja-build -y
+        sudo apt install libstdc++6 gcc-multilib g++-multilib ninja-build -y
 
     - name: Install packages
       if: ${{ matrix.platform.os == 'windows-latest' }}
@@ -97,6 +97,7 @@ jobs:
         cmake
         --preset ${{ env.preset_name }}
         -DNEO_DEDICATED=ON
+        -DNEO_GENERATE_GAMEDATA=ON
 
     - name: CMake dedicated library build
       working-directory: ${{ env.source_dir }}
@@ -114,6 +115,7 @@ jobs:
         echo "libraries_debuginfo=$(find . -regex '\.\/neo-\w*-\w*-libraries-debuginfo-\w*-\w*' -printf '%f')" >> "$GITHUB_ENV"
         echo "dedicated=$(find . -regex '\.\/neo-\w*-\w*-dedicated-\w*-\w*' -printf '%f')" >> "$GITHUB_ENV"
         echo "dedicated_debuginfo=$(find . -regex '\.\/neo-\w*-\w*-dedicated-debuginfo-\w*-\w*' -printf '%f')" >> "$GITHUB_ENV"
+        echo "gamedata=$(find . -regex '\.\/neo-\w*-\w*-gamedata' -printf '%f')" >> "$GITHUB_ENV"
 
     - name: Upload libraries
       uses: actions/upload-artifact@v4
@@ -138,6 +140,13 @@ jobs:
       with:
         name: ${{ env.dedicated_debuginfo }}
         path: ${{ env.install_dir }}/${{ env.dedicated_debuginfo }}
+
+    - name: Upload SourceMod gamedata
+      if: ${{ matrix.platform.preset_os == 'linux' && matrix.preset_build_type.name == 'release' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.gamedata }}
+        path: ${{ env.install_dir }}/${{ env.gamedata }}
 
   pack-resources:
     name: Windows Native Resources
@@ -197,18 +206,18 @@ jobs:
     name: Upload Latest Build
 
     needs: [build, pack-resources]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/master'
     permissions:
       contents: write
-    
+
     steps:
     - name: Download all artifacts
       uses: actions/download-artifact@v4
 
     - name: Packing artifacts
       run: 'parallel 7z a -tzip -mx=9 "{}.zip" "./{}/*" ::: neo-*'
-        
+
     - name: Create & upload latest build
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -223,11 +232,11 @@ jobs:
     name: Upload Release
 
     needs: [build, pack-resources]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'release' && github.event.action == 'published'
     permissions:
       contents: write
-    
+
     steps:
     - name: Download all artifacts
       uses: actions/download-artifact@v4
@@ -237,7 +246,7 @@ jobs:
 
     - name: Packing artifacts
       run: 'parallel 7z a -tzip -mx=9 "{= s/neo-(.*)/neo-$GITHUB_REF_NAME-\1.zip/ =}" "./{}/*" ::: neo-*'
-        
+
     - name: Upload assets to a release
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mp/src/CMakeLists.txt
+++ b/mp/src/CMakeLists.txt
@@ -11,6 +11,8 @@ message(STATUS "TIMESTAMP: ${BUILD_DATETIME}")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+set(OUTPUT_SUBDIRECTORY out)
+
 include(cmake/utils.cmake)
 include(cmake/build_info.cmake)
 
@@ -40,6 +42,7 @@ option(NEO_INSTALL_LIBRARIES "Install game libraries" OFF)
 option(NEO_INSTALL_RESOURCES "Install game resources" OFF)
 option(NEO_USE_SEPARATE_BUILD_INFO "Use separate build info on Linux" OFF)
 option(NEO_ENABLE_CPACK "Enable CPack" OFF)
+option(NEO_GENERATE_GAMEDATA "Generate SourceMod gamedata" ${NEO_DEDICATED})
 
 message(STATUS "CI build mode: ${NEO_CI_BUILD}")
 message(STATUS "chroot build mode: ${NEO_CHROOT_BUILD}")
@@ -85,14 +88,12 @@ set(CMAKE_POSITION_INDEPENDENT_CODE FALSE)
 
 set(SOURCESDK TRUE)
 
-# TODO use base.xcconfig for OS_MACOS
-
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_definitions(
         DEBUG
         _DEBUG
     )
-elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     add_compile_definitions(
         NDEBUG
     )
@@ -213,7 +214,7 @@ if(OS_WINDOWS)
             /NODEFAULTLIB:libcpmt
             /NODEFAULTLIB:libcpmt1
         )
-    elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    elseif(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
         # TODO "Use Link Time Code Generation" [$LTCG] ?
         # Also /GL https://learn.microsoft.com/en-us/cpp/build/reference/gl-whole-program-optimization
 
@@ -392,6 +393,20 @@ endif()
 
 add_subdirectory(lib)
 
+if(NEO_GENERATE_GAMEDATA)
+    include(FetchContent) # once in the project to include the module
+
+    FetchContent_Declare(
+        gamedata-gen
+        URL https://github.com/NeotokyoRebuild/gamedata-gen/releases/download/v1/gamedata-gen.zip
+        URL_HASH MD5=d661df1e3e36d702b1cd59ceb0888586
+    )
+
+    FetchContent_MakeAvailable(gamedata-gen)
+
+    set(GAMEDATA_GEN_PATH "${gamedata-gen_SOURCE_DIR}/gamedata-gen")
+endif()
+
 if(NOT NEO_DEDICATED)
     add_subdirectory(game/client)
     add_subdirectory(materialsystem/stdshaders)
@@ -405,11 +420,13 @@ else()
     unset(COPY_ALL_LIBS_FLAG)
 endif()
 
-add_custom_target(
-    copy_all_libs ${COPY_ALL_LIBS_FLAG}
-    DEPENDS client_copy_lib server_copy_lib game_shader_dx9_copy_lib
-    VERBATIM
-)
+if(NOT NEO_DEDICATED)
+    add_custom_target(
+        copy_all_libs ${COPY_ALL_LIBS_FLAG}
+        DEPENDS client_copy_lib server_copy_lib game_shader_dx9_copy_lib
+        VERBATIM
+    )
+endif()
 
 if(NEO_CI_BUILD AND "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
     set(BUILD_TYPE_NAME "Release")
@@ -424,41 +441,53 @@ if(NEO_INSTALL_LIBRARIES)
     if(NEO_DEDICATED)
         set(LIBRARY_INSTALL_PATH "${INSTALL_PATH_PREFIX}-dedicated-${INSTALL_PATH_SUFFIX}")
 
-        install(
-            TARGETS server
-            LIBRARY DESTINATION "${LIBRARY_INSTALL_PATH}"
-            RUNTIME DESTINATION "${LIBRARY_INSTALL_PATH}"
-        )
-
         if(NEO_USE_SEPARATE_BUILD_INFO)
             set(SPLIT_DEBUG_INFO_INSTALL_PATH "${INSTALL_PATH_PREFIX}-dedicated-debuginfo-${INSTALL_PATH_SUFFIX}")
 
             if(OS_WINDOWS)
                 install(
+                    TARGETS server
+                    LIBRARY DESTINATION "${LIBRARY_INSTALL_PATH}"
+                    RUNTIME DESTINATION "${LIBRARY_INSTALL_PATH}"
+                )
+
+                install(
                     FILES "$<TARGET_PDB_FILE:server>"
                     DESTINATION "${SPLIT_DEBUG_INFO_INSTALL_PATH}"
                 )
             else()
+                get_target_property(SERVER_STRIPPED_FILE server STRIPPED_FILE)
+                install(
+                    FILES ${SERVER_STRIPPED_FILE}
+                    DESTINATION "${LIBRARY_INSTALL_PATH}"
+                )
+
                 get_target_property(SERVER_SPLIT_DEBUG_INFO_FILE server SPLIT_DEBUG_INFO_FILE)
                 install(
                     FILES ${SERVER_SPLIT_DEBUG_INFO_FILE}
                     DESTINATION "${SPLIT_DEBUG_INFO_INSTALL_PATH}"
                 )
             endif()
+        else()
+            install(
+                TARGETS server
+                LIBRARY DESTINATION "${LIBRARY_INSTALL_PATH}"
+                RUNTIME DESTINATION "${LIBRARY_INSTALL_PATH}"
+            )
         endif()
     else()
         set(LIBRARY_INSTALL_PATH "${INSTALL_PATH_PREFIX}-libraries-${INSTALL_PATH_SUFFIX}")
-
-        install(
-            TARGETS client game_shader_dx9 server
-            LIBRARY DESTINATION "${LIBRARY_INSTALL_PATH}"
-            RUNTIME DESTINATION "${LIBRARY_INSTALL_PATH}"
-        )
 
         if(NEO_USE_SEPARATE_BUILD_INFO)
             set(SPLIT_DEBUG_INFO_INSTALL_PATH "${INSTALL_PATH_PREFIX}-libraries-debuginfo-${INSTALL_PATH_SUFFIX}")
 
             if(OS_WINDOWS)
+                install(
+                    TARGETS client game_shader_dx9 server
+                    LIBRARY DESTINATION "${LIBRARY_INSTALL_PATH}"
+                    RUNTIME DESTINATION "${LIBRARY_INSTALL_PATH}"
+                )
+
                 install(
                     FILES
                         $<TARGET_PDB_FILE:client>
@@ -467,6 +496,17 @@ if(NEO_INSTALL_LIBRARIES)
                     DESTINATION "${SPLIT_DEBUG_INFO_INSTALL_PATH}"
                 )
             else()
+                get_target_property(CLIENT_STRIPPED_FILE client STRIPPED_FILE)
+                get_target_property(SHADER_STRIPPED_FILE game_shader_dx9 STRIPPED_FILE)
+                get_target_property(SERVER_STRIPPED_FILE server STRIPPED_FILE)
+                install(
+                    FILES
+                        ${CLIENT_STRIPPED_FILE}
+                        ${SHADER_STRIPPED_FILE}
+                        ${SERVER_STRIPPED_FILE}
+                    DESTINATION "${LIBRARY_INSTALL_PATH}"
+                )
+
                 get_target_property(CLIENT_SPLIT_DEBUG_INFO_FILE client SPLIT_DEBUG_INFO_FILE)
                 get_target_property(SHADER_SPLIT_DEBUG_INFO_FILE game_shader_dx9 SPLIT_DEBUG_INFO_FILE)
                 get_target_property(SERVER_SPLIT_DEBUG_INFO_FILE server SPLIT_DEBUG_INFO_FILE)
@@ -478,7 +518,27 @@ if(NEO_INSTALL_LIBRARIES)
                     DESTINATION "${SPLIT_DEBUG_INFO_INSTALL_PATH}"
                 )
             endif()
+        else()
+            install(
+                TARGETS client game_shader_dx9 server
+                LIBRARY DESTINATION "${LIBRARY_INSTALL_PATH}"
+                RUNTIME DESTINATION "${LIBRARY_INSTALL_PATH}"
+            )
         endif()
+    endif()
+
+    if(OS_LINUX AND NEO_GENERATE_GAMEDATA)
+        get_target_property(SERVER_GAMEDATA_SDKHOOKS_OUTPUT_FILE server GAMEDATA_SDKHOOKS_OUTPUT_FILE)
+        install(
+            FILES ${SERVER_GAMEDATA_SDKHOOKS_OUTPUT_FILE}
+            DESTINATION "${INSTALL_PATH_PREFIX}-gamedata/neo/addons/sourcemod/gamedata/sdkhooks.games"
+        )
+
+        get_target_property(SERVER_GAMEDATA_SDKTOOLS_OUTPUT_FILE server GAMEDATA_SDKTOOLS_OUTPUT_FILE)
+        install(
+            FILES ${SERVER_GAMEDATA_SDKTOOLS_OUTPUT_FILE}
+            DESTINATION "${INSTALL_PATH_PREFIX}-gamedata/neo/addons/sourcemod/gamedata/sdktools.games"
+        )
     endif()
 endif()
 

--- a/mp/src/cmake/utils.cmake
+++ b/mp/src/cmake/utils.cmake
@@ -61,6 +61,11 @@ function(add_library_copy_target)
         message(FATAL_ERROR "You must provide a target name")
     endif()
 
+    get_target_property(TARGET_STRIPPED_FILE ${PARSED_ARGS_TARGET} STRIPPED_FILE)
+    if(NOT TARGET_STRIPPED_FILE)
+        set(TARGET_STRIPPED_FILE $<TARGET_FILE:${PARSED_ARGS_TARGET}>)
+    endif()
+
     add_custom_target(
         ${PARSED_ARGS_TARGET}_copy_lib
         DEPENDS ${PARSED_ARGS_TARGET} ${PARSED_ARGS_TARGET}_copy_lib_command
@@ -68,14 +73,14 @@ function(add_library_copy_target)
 
     add_custom_command(
         OUTPUT ${PARSED_ARGS_TARGET}_copy_lib_command
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${PARSED_ARGS_TARGET}> "${NEO_OUTPUT_LIBRARY_PATH}/"
+        COMMAND ${CMAKE_COMMAND} -E copy ${TARGET_STRIPPED_FILE} "${NEO_OUTPUT_LIBRARY_PATH}/"
         WORKING_DIRECTORY "${NEO_OUTPUT_LIBRARY_PATH}"
         VERBATIM
     )
 endfunction()
 
 # Used by split_debug_information
-if(NOT MSVC)
+if(NOT COMPILER_MSVC)
     include(CMakeFindBinUtils)
 endif()
 
@@ -88,7 +93,7 @@ function(split_debug_information)
         ${ARGN}
     )
 
-    if(MSVC)
+    if(COMPILER_MSVC)
         # MSVC splits debug information by itself
         return()
     elseif(NOT CMAKE_OBJCOPY)
@@ -120,38 +125,99 @@ function(split_debug_information)
         unset(xc_out)
     endif()
 
-    # NOTE: Prefix expression was simplified - it probably doesn't work for static libraries
-    get_property(TARGET_PREFIX TARGET ${PARSED_ARGS_TARGET} PROPERTY PREFIX)
-    get_property(TARGET_POSTFIX TARGET ${PARSED_ARGS_TARGET} PROPERTY POSTFIX)
-    get_property(TARGET_OUTPUT_NAME TARGET ${PARSED_ARGS_TARGET} PROPERTY OUTPUT_NAME)
+    get_target_property(TARGET_OUTPUT_NAME ${PARSED_ARGS_TARGET} OUTPUT_NAME)
 
-    if("${TARGET_OUTPUT_NAME}" STREQUAL "")
+    if(NOT TARGET_OUTPUT_NAME)
         set(TARGET_OUTPUT_NAME "${PARSED_ARGS_TARGET}")
     endif()
 
-    set(OUTPUT_NAME_FULL "${TARGET_PREFIX}${TARGET_OUTPUT_NAME}${TARGET_POSTFIX}.debug")
+    set(SPLITDEBUG_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_OUTPUT_NAME}.so")
+    set(SPLITDEBUG_TARGET "${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_SUBDIRECTORY}/${TARGET_OUTPUT_NAME}.so")
+    set(SPLITDEBUG_TARGET_DEBUG "${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_SUBDIRECTORY}/${TARGET_OUTPUT_NAME}.so.debug")
 
-    set(SPLITDEBUG_SOURCE "$<TARGET_FILE:${PARSED_ARGS_TARGET}>")
-    set(SPLITDEBUG_TARGET "$<TARGET_FILE_DIR:${PARSED_ARGS_TARGET}>/${OUTPUT_NAME_FULL}")
+    add_custom_target(
+        ${PARSED_ARGS_TARGET}_split_debug_information
+        ALL
+        DEPENDS ${PARSED_ARGS_TARGET} ${SPLITDEBUG_TARGET}
+    )
 
     # NOTE: objcopy --strip-debug does NOT fully strip the binary; two sections are left:
     # - .symtab: Symbol table.
     # - .strtab: String table.
     # These sections are split into the .debug file, so there's no reason to keep them in the executable
-    add_custom_command(TARGET ${PARSED_ARGS_TARGET} POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} --only-keep-debug ${OBJCOPY_COMPRESS_DEBUG_SECTIONS_PARAM} ${SPLITDEBUG_SOURCE} ${SPLITDEBUG_TARGET}
-        COMMAND ${CMAKE_STRIP} ${SPLITDEBUG_SOURCE}
-        COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink="${SPLITDEBUG_TARGET}" ${SPLITDEBUG_SOURCE}
+    add_custom_command(
+        OUTPUT ${SPLITDEBUG_TARGET}
+        COMMAND ${CMAKE_OBJCOPY} --only-keep-debug ${OBJCOPY_COMPRESS_DEBUG_SECTIONS_PARAM} ${SPLITDEBUG_SOURCE} ${SPLITDEBUG_TARGET_DEBUG}
+        COMMAND ${CMAKE_STRIP} ${SPLITDEBUG_SOURCE} -o ${SPLITDEBUG_TARGET}
+        COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink="${SPLITDEBUG_TARGET_DEBUG}" ${SPLITDEBUG_TARGET}
     )
 
     # Set the target property to allow installation
     set_target_properties(${PARSED_ARGS_TARGET} PROPERTIES
-        SPLIT_DEBUG_INFO_FILE ${SPLITDEBUG_TARGET}
+        STRIPPED_FILE ${SPLITDEBUG_TARGET}
+        SPLIT_DEBUG_INFO_FILE ${SPLITDEBUG_TARGET_DEBUG}
     )
 
     # Make sure the file is deleted when cleaning
     set_target_properties(${PARSED_ARGS_TARGET}
         PROPERTIES
-        ADDITIONAL_CLEAN_FILES ${SPLITDEBUG_TARGET}
+        ADDITIONAL_CLEAN_FILES "${SPLITDEBUG_TARGET};${SPLITDEBUG_TARGET_DEBUG}"
+    )
+endfunction()
+
+function(add_gamedata_gen_target)
+    cmake_parse_arguments(
+        PARSED_ARGS
+        ""
+        "TARGET"
+        ""
+        ${ARGN}
+    )
+
+    if(NOT PARSED_ARGS_TARGET)
+        message(FATAL_ERROR "You must provide a target name")
+    endif()
+
+    set(GAMEDATA_LIBRARY "$<TARGET_FILE:${PARSED_ARGS_TARGET}>")
+
+    set(GAMEDATA_INPUT_FILES
+        "${CMAKE_SOURCE_DIR}/gamedata/sdkhooks.games/game.neo.txt.in"
+        "${CMAKE_SOURCE_DIR}/gamedata/sdktools.games/game.neo.txt.in"
+    )
+
+    set(GAMEDATA_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_SUBDIRECTORY})
+    set(GAMEDATA_SDKHOOKS_OUTPUT_FILE "${GAMEDATA_OUTPUT_DIR}/sdkhooks.games/game.neo.txt")
+    set(GAMEDATA_SDKTOOLS_OUTPUT_FILE "${GAMEDATA_OUTPUT_DIR}/sdktools.games/game.neo.txt")
+
+    set(GAMEDATA_OUTPUT_FILES
+        "${GAMEDATA_SDKHOOKS_OUTPUT_FILE}"
+        "${GAMEDATA_SDKTOOLS_OUTPUT_FILE}"
+    )
+
+    set(GAMEDATA_OUTPUT_DIRS
+        "${GAMEDATA_OUTPUT_DIR}/sdkhooks.games"
+        "${GAMEDATA_OUTPUT_DIR}/sdktools.games"
+    )
+
+    add_custom_target(
+        ${PARSED_ARGS_TARGET}_generate_gamedata
+        ALL
+        DEPENDS ${PARSED_ARGS_TARGET} ${GAMEDATA_OUTPUT_FILES}
+    )
+
+    add_custom_command(
+        OUTPUT ${GAMEDATA_OUTPUT_FILES}
+        COMMAND ${GAMEDATA_GEN_PATH}
+            --library ${GAMEDATA_LIBRARY}
+            --input_files ${GAMEDATA_INPUT_FILES}
+            --output_dirs ${GAMEDATA_OUTPUT_DIRS}
+        DEPENDS ${GAMEDATA_INPUT_FILES}
+        VERBATIM
+    )
+
+    set_target_properties(${PARSED_ARGS_TARGET} PROPERTIES
+        GAMEDATA_SDKHOOKS_OUTPUT_FILE "${GAMEDATA_SDKHOOKS_OUTPUT_FILE}"
+        GAMEDATA_SDKTOOLS_OUTPUT_FILE "${GAMEDATA_SDKTOOLS_OUTPUT_FILE}"
+        ADDITIONAL_CLEAN_FILES "${GAMEDATA_OUTPUT_FILES}"
     )
 endfunction()

--- a/mp/src/game/client/CMakeLists.txt
+++ b/mp/src/game/client/CMakeLists.txt
@@ -8,6 +8,10 @@ endif()
 
 add_library_copy_target(TARGET client)
 
+if(NEO_USE_SEPARATE_BUILD_INFO AND NOT COMPILER_MSVC)
+    add_dependencies(client_copy_lib client_split_debug_information)
+endif()
+
 target_include_directories(client
     PRIVATE
     ${CMAKE_SOURCE_DIR}/common

--- a/mp/src/game/server/CMakeLists.txt
+++ b/mp/src/game/server/CMakeLists.txt
@@ -2,14 +2,30 @@ add_library(server SHARED)
 
 set_target_properties(server PROPERTIES PREFIX "")
 
+if(NEO_DEDICATED AND OS_LINUX)
+    set_target_properties(server PROPERTIES OUTPUT_NAME server_srv)
+endif()
+
+if(OS_LINUX AND NEO_GENERATE_GAMEDATA)
+    add_gamedata_gen_target(TARGET server)
+endif()
+
 if(NEO_USE_SEPARATE_BUILD_INFO)
     split_debug_information(TARGET server)
 endif()
 
 add_library_copy_target(TARGET server CREATE_SRV)
 
-if(NEO_DEDICATED AND OS_LINUX)
-    set_target_properties(server PROPERTIES OUTPUT_NAME server_srv)
+if(NEO_USE_SEPARATE_BUILD_INFO AND NOT COMPILER_MSVC)
+    if(OS_LINUX AND NEO_GENERATE_GAMEDATA)
+        add_dependencies(server_split_debug_information server_generate_gamedata)
+    endif()
+
+    add_dependencies(server_copy_lib server_split_debug_information)
+else()
+    if(OS_LINUX AND NEO_GENERATE_GAMEDATA)
+        add_dependencies(server_copy_lib server_generate_gamedata)
+    endif()
 endif()
 
 target_include_directories(server

--- a/mp/src/game/server/baseanimating.h
+++ b/mp/src/game/server/baseanimating.h
@@ -12,6 +12,7 @@
 
 #include "baseentity.h"
 #include "entityoutput.h"
+#include "interface.h"
 #include "studio.h"
 #include "datacache/idatacache.h"
 #include "tier0/threadtools.h"
@@ -180,7 +181,7 @@ public:
 	
 	void GetEyeballs( Vector &origin, QAngle &angles ); // ?? remove ??
 
-	int LookupAttachment( const char *szName );
+	DLL_CLASS_EXPORT int LookupAttachment( const char *szName );
 
 	// These return the attachment in world space
 	bool GetAttachment( const char *szName, Vector &absOrigin, QAngle &absAngles );

--- a/mp/src/game/server/baseentity.h
+++ b/mp/src/game/server/baseentity.h
@@ -308,14 +308,14 @@ a list of all CBaseEntitys is kept in gEntList
 // creates an entity by string name, but does not spawn it
 // If iForceEdictIndex is not -1, then it will use the edict by that index. If the index is 
 // invalid or there is already an edict using that index, it will error out.
-CBaseEntity *CreateEntityByName( const char *className, int iForceEdictIndex = -1 );
+DLL_CLASS_EXPORT CBaseEntity *CreateEntityByName( const char *className, int iForceEdictIndex = -1 );
 CBaseNetworkable *CreateNetworkableByName( const char *className );
 
 // creates an entity and calls all the necessary spawn functions
 extern void SpawnEntityByName( const char *className, CEntityMapData *mapData = NULL );
 
 // calls the spawn functions for an entity
-extern int DispatchSpawn( CBaseEntity *pEntity );
+DLL_CLASS_EXPORT extern int DispatchSpawn( CBaseEntity *pEntity );
 
 inline CBaseEntity *GetContainingEntity( edict_t *pent );
 

--- a/mp/src/game/server/entitylist.h
+++ b/mp/src/game/server/entitylist.h
@@ -133,7 +133,7 @@ public:
 
 	// search functions
 	bool		 IsEntityPtr( void *pTest );
-	CBaseEntity *FindEntityByClassname( CBaseEntity *pStartEntity, const char *szName );
+	DLL_CLASS_EXPORT CBaseEntity *FindEntityByClassname( CBaseEntity *pStartEntity, const char *szName );
 	CBaseEntity *FindEntityByName( CBaseEntity *pStartEntity, const char *szName, CBaseEntity *pSearchingEntity = NULL, CBaseEntity *pActivator = NULL, CBaseEntity *pCaller = NULL, IEntityFindFilter *pFilter = NULL );
 	CBaseEntity *FindEntityByName( CBaseEntity *pStartEntity, string_t iszName, CBaseEntity *pSearchingEntity = NULL, CBaseEntity *pActivator = NULL, CBaseEntity *pCaller = NULL, IEntityFindFilter *pFilter = NULL )
 	{

--- a/mp/src/game/server/entityoutput.h
+++ b/mp/src/game/server/entityoutput.h
@@ -13,9 +13,8 @@
 #pragma once
 #endif
 
-
 #include "baseentity.h"
-
+#include "interface.h"
 
 #define EVENT_FIRE_ALWAYS	-1
 
@@ -73,7 +72,7 @@ public:
 
 	fieldtype_t ValueFieldType() { return m_Value.FieldType(); }
 
-	void FireOutput( variant_t Value, CBaseEntity *pActivator, CBaseEntity *pCaller, float fDelay = 0 );
+	DLL_CLASS_EXPORT void FireOutput( variant_t Value, CBaseEntity *pActivator, CBaseEntity *pCaller, float fDelay = 0 );
 
 	/// Delete every single action in the action list. 
 	void DeleteAllElements( void ) ;

--- a/mp/src/game/server/gameinterface.h
+++ b/mp/src/game/server/gameinterface.h
@@ -12,6 +12,7 @@
 #pragma once
 #endif
 
+#include "interface.h"
 #include "mapentities.h"
 
 class IReplayFactory;
@@ -73,7 +74,7 @@ public:
 	virtual void			GameShutdown( void ) OVERRIDE;
 	virtual bool			LevelInit( const char *pMapName, char const *pMapEntities, char const *pOldLevel, char const *pLandmarkName, bool loadGame, bool background ) OVERRIDE;
 	virtual void			ServerActivate( edict_t *pEdictList, int edictCount, int clientMax ) OVERRIDE;
-	virtual void			LevelShutdown( void ) OVERRIDE;
+	DLL_CLASS_EXPORT virtual void			LevelShutdown( void ) OVERRIDE;
 	virtual void			GameFrame( bool simulating ) OVERRIDE; // could be called multiple times before sending data to clients
 	virtual void			PreClientUpdate( bool simulating ) OVERRIDE; // called after all GameFrame() calls, before sending data to clients
 

--- a/mp/src/game/server/util.h
+++ b/mp/src/game/server/util.h
@@ -69,7 +69,7 @@ T *_CreateEntityTemplate( T *newEnt, const char *className )
 
 #include "tier0/memdbgoff.h"
 
-CBaseEntity *CreateEntityByName( const char *className, int iForceEdictIndex );
+DLL_CLASS_EXPORT CBaseEntity *CreateEntityByName( const char *className, int iForceEdictIndex );
 
 // creates an entity by name, and ensure it's correctness
 // does not spawn the entity

--- a/mp/src/gamedata/sdkhooks.games/game.neo.txt.in
+++ b/mp/src/gamedata/sdkhooks.games/game.neo.txt.in
@@ -1,0 +1,129 @@
+"Games"
+{
+	"neo"
+	{
+		"Offsets"
+		{
+			"EndTouch"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::EndTouch(CBaseEntity*).windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::EndTouch(CBaseEntity*).linux#"
+			}
+			"FireBullets"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::FireBullets(FireBulletsInfo_t const&).windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::FireBullets(FireBulletsInfo_t const&).linux#"
+			}
+			"OnTakeDamage"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::OnTakeDamage(CTakeDamageInfo const&).windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::OnTakeDamage(CTakeDamageInfo const&).linux#"
+			}
+			"OnTakeDamage_Alive"
+			{
+				"windows"	"#CBaseCombatCharacter::CBaseCombatCharacter::OnTakeDamage_Alive(CTakeDamageInfo const&).windows#"
+				"linux"		"#CBaseCombatCharacter::CBaseCombatCharacter::OnTakeDamage_Alive(CTakeDamageInfo const&).linux#"
+			}
+			"PreThink"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::PreThink().windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::PreThink().linux#"
+			}
+			"PostThink"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::PostThink().windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::PostThink().linux#"
+			}
+			"SetTransmit"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::SetTransmit(CCheckTransmitInfo*, bool).windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::SetTransmit(CCheckTransmitInfo*, bool).linux#"
+			}
+			"Spawn"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::Spawn().windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::Spawn().linux#"
+			}
+			"StartTouch"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::StartTouch(CBaseEntity*).windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::StartTouch(CBaseEntity*).linux#"
+			}
+			"Think"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::Think().windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::Think().linux#"
+			}
+			"Touch"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::Touch(CBaseEntity*).windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::Touch(CBaseEntity*).linux#"
+			}
+			"TraceAttack"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::TraceAttack(CTakeDamageInfo const&, Vector const&, CGameTrace*, CDmgAccumulator*).windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::TraceAttack(CTakeDamageInfo const&, Vector const&, CGameTrace*, CDmgAccumulator*).linux#"
+			}
+			"Weapon_CanSwitchTo"
+			{
+				"windows"	"#CBaseCombatCharacter::CBaseCombatCharacter::Weapon_CanSwitchTo(CBaseCombatWeapon*).windows#"
+				"linux"		"#CBaseCombatCharacter::CBaseCombatCharacter::Weapon_CanSwitchTo(CBaseCombatWeapon*).linux#"
+			}
+			"Weapon_CanUse"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::Weapon_CanUse(CBaseCombatWeapon*).windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::Weapon_CanUse(CBaseCombatWeapon*).linux#"
+			}
+			"Weapon_Drop"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::Weapon_Drop(CBaseCombatWeapon*, Vector const*, Vector const*).windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::Weapon_Drop(CBaseCombatWeapon*, Vector const*, Vector const*).linux#"
+			}
+			"Weapon_Equip"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::Weapon_Equip(CBaseCombatWeapon*).windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::Weapon_Equip(CBaseCombatWeapon*).linux#"
+			}
+			"Weapon_Switch"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::Weapon_Switch(CBaseCombatWeapon*, int).windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::Weapon_Switch(CBaseCombatWeapon*, int).linux#"
+			}
+			"ShouldCollide"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::ShouldCollide(int, int) const.windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::ShouldCollide(int, int) const.linux#"
+			}
+			"VPhysicsUpdate"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::VPhysicsUpdate(IPhysicsObject*).windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::VPhysicsUpdate(IPhysicsObject*).linux#"
+			}
+			"Use"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::Use(CBaseEntity*, CBaseEntity*, USE_TYPE, float).windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::Use(CBaseEntity*, CBaseEntity*, USE_TYPE, float).linux#"
+			}
+			"Reload"
+			{
+				"windows"	"#CBaseCombatWeapon::CBaseCombatWeapon::Reload().windows#"
+				"linux"		"#CBaseCombatWeapon::CBaseCombatWeapon::Reload().linux#"
+			}
+			"GetMaxHealth"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::GetMaxHealth() const.windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::GetMaxHealth() const.linux#"
+			}
+			"Blocked"
+			{
+				"windows"	"#CBaseEntity::CBaseEntity::Blocked(CBaseEntity*).windows#"
+				"linux"		"#CBaseEntity::CBaseEntity::Blocked(CBaseEntity*).linux#"
+			}
+			"CanBeAutobalanced"
+			{
+				"windows"	"#CBaseMultiplayerPlayer::CBaseMultiplayerPlayer::CanBeAutobalanced().windows#"
+				"linux"		"#CBaseMultiplayerPlayer::CBaseMultiplayerPlayer::CanBeAutobalanced().linux#"
+			}
+		}
+	}
+}

--- a/mp/src/gamedata/sdktools.games/game.neo.txt.in
+++ b/mp/src/gamedata/sdktools.games/game.neo.txt.in
@@ -1,0 +1,134 @@
+"Games"
+{
+	"neo"
+	{
+		"Offsets"
+		{
+			"AcceptInput"
+			{
+				"windows"	"#CBasePlayer::CBaseEntity::AcceptInput(char const*, CBaseEntity*, CBaseEntity*, variant_t, int).windows#"
+				"linux"		"#CBasePlayer::CBaseEntity::AcceptInput(char const*, CBaseEntity*, CBaseEntity*, variant_t, int).linux#"
+			}
+			"Activate"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::Activate().windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::Activate().linux#"
+			}
+			"CommitSuicide"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::CommitSuicide(bool, bool).windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::CommitSuicide(bool, bool).linux#"
+			}
+			"CreateEntityByName"
+			{
+				"windows"	"#CServerTools::CServerTools::CreateEntityByName(char const*).windows#"
+				"linux"		"#CServerTools::CServerTools::CreateEntityByName(char const*).linux#"
+			}
+			"DispatchSpawn"
+			{
+				"windows"	"#CServerTools::CServerTools::DispatchSpawn(CBaseEntity*).windows#"
+				"linux"		"#CServerTools::CServerTools::DispatchSpawn(CBaseEntity*).linux#"
+			}
+			"Extinguish"
+			{
+				"windows"	"#CBasePlayer::CBaseAnimating::Extinguish().windows#"
+				"linux"		"#CBasePlayer::CBaseAnimating::Extinguish().linux#"
+			}
+			"EyeAngles"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::EyeAngles().windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::EyeAngles().linux#"
+			}
+			"FindEntityByClassname"
+			{
+				"windows"	"#CServerTools::CServerTools::FindEntityByClassname(CBaseEntity*, char const*).windows#"
+				"linux"		"#CServerTools::CServerTools::FindEntityByClassname(CBaseEntity*, char const*).linux#"
+			}
+			"GetAttachment"
+			{
+				"windows"	"#CBasePlayer::CBaseAnimating::GetAttachment(int, matrix3x4_t&).windows#"
+				"linux"		"#CBasePlayer::CBaseAnimating::GetAttachment(int, matrix3x4_t&).linux#"
+			}
+			"GetVelocity"
+			{
+				"windows"	"#CBasePlayer::CBaseAnimating::GetVelocity(Vector*, Vector*).windows#"
+				"linux"		"#CBasePlayer::CBaseAnimating::GetVelocity(Vector*, Vector*).linux#"
+			}
+			"GiveAmmo"
+			{
+				"windows"	"#CBasePlayer::CBaseCombatCharacter::GiveAmmo(int, int, bool).windows#"
+				"linux"		"#CBasePlayer::CBaseCombatCharacter::GiveAmmo(int, int, bool).linux#"
+			}
+			"GiveNamedItem"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::GiveNamedItem(char const*, int).windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::GiveNamedItem(char const*, int).linux#"
+			}
+			"Ignite"
+			{
+				"windows"	"#CBasePlayer::CBaseAnimating::Ignite(float, bool, float, bool).windows#"
+				"linux"		"#CBasePlayer::CBaseAnimating::Ignite(float, bool, float, bool).linux#"
+			}
+			"RemovePlayerItem"
+			{
+				"windows"	"#CBasePlayer::CBasePlayer::RemovePlayerItem(CBaseCombatWeapon*).windows#"
+				"linux"		"#CBasePlayer::CBasePlayer::RemovePlayerItem(CBaseCombatWeapon*).linux#"
+			}
+			"SetOwnerEntity"
+			{
+				"windows"	"#CBasePlayer::CBaseEntity::SetOwnerEntity(CBaseEntity*).windows#"
+				"linux"		"#CBasePlayer::CBaseEntity::SetOwnerEntity(CBaseEntity*).linux#"
+			}
+			"Teleport"
+			{
+				"windows"	"#CBasePlayer::CBaseFlex::Teleport(Vector const*, QAngle const*, Vector const*).windows#"
+				"linux"		"#CBasePlayer::CBaseFlex::Teleport(Vector const*, QAngle const*, Vector const*).linux#"
+			}
+			"Weapon_GetSlot"
+			{
+				"windows"	"#CBasePlayer::CBaseCombatCharacter::Weapon_GetSlot(int) const.windows#"
+				"linux"		"#CBasePlayer::CBaseCombatCharacter::Weapon_GetSlot(int) const.linux#"
+			}
+		}
+		"Signatures"
+		{
+			"FireOutput"
+			{
+				"linux"		"@_ZN17CBaseEntityOutput10FireOutputE9variant_tP11CBaseEntityS2_f"
+				"windows"	"@?FireOutput@CBaseEntityOutput@@QAEXVvariant_t@@PAVCBaseEntity@@1M@Z"
+			}
+			"LookupAttachment"
+			{
+				"linux"		"@_ZN14CBaseAnimating16LookupAttachmentEPKc"
+				"windows"	"@?LookupAttachment@CBaseAnimating@@QAEHPBD@Z"
+			}
+			
+			"LevelShutdown"
+			{
+				"linux"		"@_ZN14CServerGameDLL13LevelShutdownEv"
+				"windows"	"@?LevelShutdown@CServerGameDLL@@UAEXXZ"
+			}
+			"DispatchSpawn"
+			{
+				"linux"		"@_Z13DispatchSpawnP11CBaseEntity"
+				"windows"	"@?DispatchSpawn@@YAHPAVCBaseEntity@@@Z"
+			}
+			"CreateEntityByName"
+			{
+				"linux"		"@_Z18CreateEntityByNamePKci"
+				"windows"	"@?CreateEntityByName@@YAPAVCBaseEntity@@PBDH@Z"
+
+			}
+			"FindEntityByClassname"
+			{
+				"linux"		"@_ZN17CGlobalEntityList21FindEntityByClassnameEP11CBaseEntityPKc"
+				"windows"	"@?FindEntityByClassname@CGlobalEntityList@@QAEPAVCBaseEntity@@PAV2@PBD@Z"
+			}
+		}
+		"Keys"
+		{
+			"GameRulesProxy"		"CNEOGameRulesProxy"
+			"GameRulesDataTable"	"neo_gamerules_data"
+		}
+	}
+}

--- a/mp/src/materialsystem/stdshaders/CMakeLists.txt
+++ b/mp/src/materialsystem/stdshaders/CMakeLists.txt
@@ -8,6 +8,10 @@ endif()
 
 add_library_copy_target(TARGET game_shader_dx9)
 
+if(NEO_USE_SEPARATE_BUILD_INFO AND NOT COMPILER_MSVC)
+    add_dependencies(game_shader_dx9_copy_lib game_shader_dx9_split_debug_information)
+endif()
+
 target_include_directories(game_shader_dx9
     PRIVATE
         ${CMAKE_SOURCE_DIR}/common


### PR DESCRIPTION

## Description
Add automatic SourceMod gamedata file generation using [gamedata-gen](https://github.com/NeotokyoRebuild/gamedata-gen).

Not all SourceMod functionality is tested - needs help.

## Toolchain
- Windows 10 MSVC VS2022 - only compiled without testing
- Linux GCC Arch Linux Native (g++ (GCC) 14.2.1 20240910)
- Linux ubuntu-24.04 in GitHub Actions

## Linked Issues
Resolves #828 
Partially resolves #836 - we need to create PR to [SourceMod](https://github.com/alliedmodders/sourcemod/) repository and as a future feature add automatic gamedata diff and PR creation if files are changed.
