### PR TITLE
Fix vision modes on maps with colour correction and or hdr

### DIFF
--- a/mp/src/game/client/viewpostprocess.cpp
+++ b/mp/src/game/client/viewpostprocess.cpp
@@ -2517,6 +2517,10 @@ void DoEnginePostProcessing( int x, int y, int w, int h, bool bFlashlightIsOn, b
 		}
 		if (target && target->IsInVision()) // don't want HDR to interfere with vision effects
 		{
+			if (hdrType == HDR_TYPE_INTEGER || hdrType == HDR_TYPE_FLOAT)
+			{
+				SetToneMapScale(pRenderContext, 1.f, 0.5f, 2.f);
+			}
 			hdrType = HDR_TYPE_NONE;
 			flBloomScale = 0.f;
 		}
@@ -2602,6 +2606,9 @@ void DoEnginePostProcessing( int x, int y, int w, int h, bool bFlashlightIsOn, b
 										  ( g_pMaterialSystemHardwareConfig->GetDXSupportLevel() >= 90) &&
 										  ( g_pMaterialSystemHardwareConfig->GetHDRType() != HDR_TYPE_FLOAT ) &&
 										  g_pColorCorrectionMgr->HasNonZeroColorCorrectionWeights() &&
+#ifdef NEO
+										  (!target || (target && !target->IsInVision())) &&
+#endif // NEO
 										  mat_colorcorrection.GetInt();
 			bool  bSplitScreenHDR		= mat_show_ab_hdr.GetInt();
 			pRenderContext->EnableColorCorrection( bPerformColCorrect );


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

We disable hdr when using vision modes already, but that doesn't revert the changes to the tonemap made by hdr when it was enabled.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->