### PR TITLE
Enforce duck speed if character is ducking or forced to duck

### DIFF
--- a/mp/src/game/client/neo/c_neo_player.cpp
+++ b/mp/src/game/client/neo/c_neo_player.cpp
@@ -806,7 +806,7 @@ void C_NEO_Player::PreThink( void )
 
 	float speed = GetNormSpeed();
 	static constexpr float DUCK_WALK_SPEED_MODIFIER = 0.75;
-	if (m_nButtons & IN_DUCK)
+	if (m_nButtons & IN_DUCK || IsDucked() || IsDucking())
 	{
 		speed *= DUCK_WALK_SPEED_MODIFIER;
 	}

--- a/mp/src/game/server/neo/neo_player.cpp
+++ b/mp/src/game/server/neo/neo_player.cpp
@@ -656,7 +656,7 @@ void CNEO_Player::PreThink(void)
 
 	float speed = GetNormSpeed();
 	static constexpr float DUCK_WALK_SPEED_MODIFIER = 0.75;
-	if (m_nButtons & IN_DUCK)
+	if (m_nButtons & IN_DUCK || IsDucked() || IsDucking())
 	{
 		speed *= DUCK_WALK_SPEED_MODIFIER;
 	}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

If the player is not holding the duck key but their character is still ducking, apply the duck speed modifier

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
