### PR TITLE
mpn_unsilenced fov and viewmodel offset when aiming

### DIFF
--- a/mp/game/neo/scripts/weapon_mpn_unsilenced.txt
+++ b/mp/game/neo/scripts/weapon_mpn_unsilenced.txt
@@ -54,10 +54,10 @@ WeaponData
 
 	"ZoomOffset"
 	{
-		"fov"		"70.0"
-		"forward"	"28.0"
-		"right"		"12.0"
-		"up"		"1.0"
+		"fov"		"45"
+		"forward"	"15"
+		"right"		"6.5"
+		"up"		"6"
 	}
 	
 	"AimOffset"


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

give mpn_unsilenced same fov and viewmodel offset as mpn

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->