### PR TITLE
Add IO to neo_game_config for custom round events

### DIFF
--- a/mp/src/game/server/neo/neo_game_config.cpp
+++ b/mp/src/game/server/neo/neo_game_config.cpp
@@ -10,6 +10,7 @@ BEGIN_DATADESC(CNEOGameConfig)
 
 	DEFINE_INPUTFUNC(FIELD_INTEGER, "FireTeamWin", InputFireTeamWin),
 	DEFINE_INPUTFUNC(FIELD_VOID, "FireDMPlayerWin", InputFireDMPlayerWin),
+	DEFINE_INPUTFUNC(FIELD_VOID, "FireRoundTie", InputFireRoundTie),
 
 	DEFINE_OUTPUT(m_OnRoundEnd, "OnRoundEnd"),
 	DEFINE_OUTPUT(m_OnRoundStart, "OnRoundStart")
@@ -43,6 +44,11 @@ void CNEOGameConfig::InputFireDMPlayerWin(inputdata_t& inputData)
     {
         static_cast<CNEORules*>(g_pGameRules)->SetWinningDMPlayer(static_cast<CNEO_Player*>(pPlayer));
     }
+}
+
+void CNEOGameConfig::InputFireRoundTie(inputdata_t& inputData)
+{
+	static_cast<CNEORules*>(g_pGameRules)->SetWinningTeam(1, 7, false, true, true, false);
 }
 
 // Outputs

--- a/mp/src/game/server/neo/neo_game_config.cpp
+++ b/mp/src/game/server/neo/neo_game_config.cpp
@@ -27,19 +27,6 @@ void CNEOGameConfig::Spawn()
 
 // Inputs
 
-enum
-{
-	NEO_VICTORY_GHOST_CAPTURE = 0,
-	NEO_VICTORY_VIP_ESCORT,
-	NEO_VICTORY_VIP_ELIMINATION,
-	NEO_VICTORY_TEAM_ELIMINATION,
-	NEO_VICTORY_TIMEOUT_WIN_BY_NUMBERS,
-	NEO_VICTORY_POINTS,
-	NEO_VICTORY_FORFEIT,
-	NEO_VICTORY_STALEMATE,
-	NEO_VICTORY_MAPIO
-};
-
 void CNEOGameConfig::InputFireTeamWin(inputdata_t& inputData)
 {
 	int team = inputData.value.Int();

--- a/mp/src/game/server/neo/neo_game_config.cpp
+++ b/mp/src/game/server/neo/neo_game_config.cpp
@@ -16,6 +16,8 @@ BEGIN_DATADESC(CNEOGameConfig)
 	DEFINE_OUTPUT(m_OnRoundStart, "OnRoundStart")
 END_DATADESC()
 
+CNEOGameConfig* CNEOGameConfig::s_pGameRulesToConfig = nullptr;
+
 void CNEOGameConfig::Spawn()
 {
 	BaseClass::Spawn();

--- a/mp/src/game/server/neo/neo_game_config.cpp
+++ b/mp/src/game/server/neo/neo_game_config.cpp
@@ -27,10 +27,23 @@ void CNEOGameConfig::Spawn()
 
 // Inputs
 
+enum
+{
+	NEO_VICTORY_GHOST_CAPTURE = 0,
+	NEO_VICTORY_VIP_ESCORT,
+	NEO_VICTORY_VIP_ELIMINATION,
+	NEO_VICTORY_TEAM_ELIMINATION,
+	NEO_VICTORY_TIMEOUT_WIN_BY_NUMBERS,
+	NEO_VICTORY_POINTS,
+	NEO_VICTORY_FORFEIT,
+	NEO_VICTORY_STALEMATE,
+	NEO_VICTORY_MAPIO
+};
+
 void CNEOGameConfig::InputFireTeamWin(inputdata_t& inputData)
 {
 	int team = inputData.value.Int();
-	static_cast<CNEORules*>(g_pGameRules)->SetWinningTeam(team, 8, false, true, false, false);
+	static_cast<CNEORules*>(g_pGameRules)->SetWinningTeam(team, NEO_VICTORY_MAPIO, false, true, false, false);
 }
 
 void CNEOGameConfig::InputFireDMPlayerWin(inputdata_t& inputData)
@@ -50,7 +63,7 @@ void CNEOGameConfig::InputFireDMPlayerWin(inputdata_t& inputData)
 
 void CNEOGameConfig::InputFireRoundTie(inputdata_t& inputData)
 {
-	static_cast<CNEORules*>(g_pGameRules)->SetWinningTeam(1, 7, false, true, true, false);
+	static_cast<CNEORules*>(g_pGameRules)->SetWinningTeam(1, NEO_VICTORY_STALEMATE, false, true, true, false);
 }
 
 // Outputs

--- a/mp/src/game/server/neo/neo_game_config.cpp
+++ b/mp/src/game/server/neo/neo_game_config.cpp
@@ -7,4 +7,52 @@ LINK_ENTITY_TO_CLASS(neo_game_config, CNEOGameConfig);
 
 BEGIN_DATADESC(CNEOGameConfig)
 	DEFINE_KEYFIELD(m_GameType, FIELD_INTEGER, "GameType"),
+
+	DEFINE_INPUTFUNC(FIELD_INTEGER, "FireTeamWin", InputFireTeamWin),
+	DEFINE_INPUTFUNC(FIELD_VOID, "FireDMPlayerWin", InputFireDMPlayerWin),
+
+	DEFINE_OUTPUT(m_OnRoundEnd, "OnRoundEnd"),
+	DEFINE_OUTPUT(m_OnRoundStart, "OnRoundStart")
 END_DATADESC()
+
+void CNEOGameConfig::Spawn()
+{
+	BaseClass::Spawn();
+
+	s_pGameRulesToConfig = this;
+}
+
+// Inputs
+
+void CNEOGameConfig::InputFireTeamWin(inputdata_t& inputData)
+{
+	int team = inputData.value.Int();
+	static_cast<CNEORules*>(g_pGameRules)->SetWinningTeam(team, 8, false, true, false, false);
+}
+
+void CNEOGameConfig::InputFireDMPlayerWin(inputdata_t& inputData)
+{
+	CBasePlayer* pPlayer = NULL;
+
+	if (inputData.pActivator && inputData.pActivator->IsPlayer())
+	{
+		pPlayer = (CBasePlayer*)inputData.pActivator;
+	}
+
+	if (pPlayer)
+    {
+        static_cast<CNEORules*>(g_pGameRules)->SetWinningDMPlayer(static_cast<CNEO_Player*>(pPlayer));
+    }
+}
+
+// Outputs
+
+void CNEOGameConfig::OutputRoundEnd()
+{
+	m_OnRoundEnd.FireOutput(NULL, this);
+}
+
+void CNEOGameConfig::OutputRoundStart()
+{
+	m_OnRoundStart.FireOutput(NULL, this);
+}

--- a/mp/src/game/server/neo/neo_game_config.h
+++ b/mp/src/game/server/neo/neo_game_config.h
@@ -10,5 +10,21 @@ class CNEOGameConfig : public CLogicalEntity
 	DECLARE_DATADESC();
 
 public:
+	void Spawn() override;
+	static CNEOGameConfig* s_pGameRulesToConfig;
+
 	int m_GameType = NEO_GAME_TYPE_TDM;
+
+	// Inputs
+	void InputFireTeamWin(inputdata_t& inputData);
+	void InputFireDMPlayerWin(inputdata_t& inputData);
+
+	// Outputs
+	void OutputRoundEnd();
+	void OutputRoundStart();
+
+	COutputEvent m_OnRoundEnd;
+	COutputEvent m_OnRoundStart;
 };
+
+CNEOGameConfig* CNEOGameConfig::s_pGameRulesToConfig = nullptr;

--- a/mp/src/game/server/neo/neo_game_config.h
+++ b/mp/src/game/server/neo/neo_game_config.h
@@ -18,6 +18,7 @@ public:
 	// Inputs
 	void InputFireTeamWin(inputdata_t& inputData);
 	void InputFireDMPlayerWin(inputdata_t& inputData);
+	void InputFireRoundTie(inputdata_t& inputData);
 
 	// Outputs
 	void OutputRoundEnd();

--- a/mp/src/game/server/neo/neo_game_config.h
+++ b/mp/src/game/server/neo/neo_game_config.h
@@ -27,5 +27,3 @@ public:
 	COutputEvent m_OnRoundEnd;
 	COutputEvent m_OnRoundStart;
 };
-
-CNEOGameConfig* CNEOGameConfig::s_pGameRulesToConfig = nullptr;

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -2880,7 +2880,7 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 	UserMessageBegin(filter, "RoundResult");
 	WRITE_STRING(team == TEAM_JINRAI ? "jinrai" : team == TEAM_NSF ? "nsf" : "tie");	// which team won
 	WRITE_FLOAT(gpGlobals->curtime);													// when did they win
-	if(iWinReason != 8)
+	if(iWinReason != NEO_VICTORY_MAPIO)
 	{ 
 		WRITE_STRING(victoryMsg);															// extra message (who capped or last kill or who got the most points or whatever)
 	}

--- a/mp/src/game/shared/neo/neo_gamerules.cpp
+++ b/mp/src/game/shared/neo/neo_gamerules.cpp
@@ -1232,6 +1232,11 @@ void CNEORules::SetWinningDMPlayer(CNEO_Player *pWinner)
 		return;
 	}
 
+	if (CNEOGameConfig::s_pGameRulesToConfig)
+	{
+		CNEOGameConfig::s_pGameRulesToConfig->OutputRoundEnd();
+	}
+
 	SetRoundStatus(NeoRoundStatus::PostRound);
 	char victoryMsg[128];
 	// TODO: Per client since client has neo_name settings
@@ -2746,6 +2751,11 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 		return;
 	}
 
+	if (CNEOGameConfig::s_pGameRulesToConfig)
+	{
+		CNEOGameConfig::s_pGameRulesToConfig->OutputRoundEnd();
+	}
+
 	if (bForceMapReset)
 	{
 		RestartGame();
@@ -2855,6 +2865,8 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 		case NEO_VICTORY_STALEMATE:
 			V_sprintf_safe(victoryMsg, "TIE\n");
 			break;
+		case NEO_VICTORY_MAPIO:
+			break;
 		default:
 			V_sprintf_safe(victoryMsg, "Unknown Neotokyo victory reason %i\n", iWinReason);
 			Warning("%s", victoryMsg);
@@ -2868,7 +2880,10 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 	UserMessageBegin(filter, "RoundResult");
 	WRITE_STRING(team == TEAM_JINRAI ? "jinrai" : team == TEAM_NSF ? "nsf" : "tie");	// which team won
 	WRITE_FLOAT(gpGlobals->curtime);													// when did they win
-	WRITE_STRING(victoryMsg);															// extra message (who capped or last kill or who got the most points or whatever)
+	if(iWinReason != 8)
+	{ 
+		WRITE_STRING(victoryMsg);															// extra message (who capped or last kill or who got the most points or whatever)
+	}
 	MessageEnd();
 
 	EmitSound_t soundParams;
@@ -3519,6 +3534,11 @@ void CNEORules::SetRoundStatus(NeoRoundStatus status)
 		if (status == NeoRoundStatus::RoundLive)
 		{
 			UTIL_CenterPrintAll("- GO! GO! GO! -\n");
+
+			if (CNEOGameConfig::s_pGameRulesToConfig)
+			{
+				CNEOGameConfig::s_pGameRulesToConfig->OutputRoundStart();
+			}
 		}
 #endif
 	}

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -119,6 +119,18 @@ enum NeoRoundStatus {
 	Pause,
 };
 
+enum NeoWinReason {
+	NEO_VICTORY_GHOST_CAPTURE = 0,
+	NEO_VICTORY_VIP_ESCORT,
+	NEO_VICTORY_VIP_ELIMINATION,
+	NEO_VICTORY_TEAM_ELIMINATION,
+	NEO_VICTORY_TIMEOUT_WIN_BY_NUMBERS,
+	NEO_VICTORY_POINTS,
+	NEO_VICTORY_FORFEIT,
+	NEO_VICTORY_STALEMATE, // Not actually a victory
+	NEO_VICTORY_MAPIO
+};
+
 class CNEORules : public CHL2MPRules, public CGameEventListener
 {
 public:
@@ -276,19 +288,6 @@ public:
 	// See https://steamcommunity.com/groups/ANPA/discussions/0/1482109512299590948/
 	// (and NT Discord) for discussions.
 	virtual const unsigned char* GetEncryptionKey(void) OVERRIDE { return (unsigned char*)"tBA%-ygc"; }
-
-	enum
-	{
-		NEO_VICTORY_GHOST_CAPTURE = 0,
-		NEO_VICTORY_VIP_ESCORT,
-		NEO_VICTORY_VIP_ELIMINATION,
-		NEO_VICTORY_TEAM_ELIMINATION,
-		NEO_VICTORY_TIMEOUT_WIN_BY_NUMBERS,
-		NEO_VICTORY_POINTS,
-		NEO_VICTORY_FORFEIT,
-		NEO_VICTORY_STALEMATE, // Not actually a victory
-		NEO_VICTORY_MAPIO
-	};
 
 	int GetGhosterTeam() const { return m_iGhosterTeam; }
 	int GetGhosterPlayer() const { return m_iGhosterPlayer; }

--- a/mp/src/game/shared/neo/neo_gamerules.h
+++ b/mp/src/game/shared/neo/neo_gamerules.h
@@ -286,7 +286,8 @@ public:
 		NEO_VICTORY_TIMEOUT_WIN_BY_NUMBERS,
 		NEO_VICTORY_POINTS,
 		NEO_VICTORY_FORFEIT,
-		NEO_VICTORY_STALEMATE // Not actually a victory
+		NEO_VICTORY_STALEMATE, // Not actually a victory
+		NEO_VICTORY_MAPIO
 	};
 
 	int GetGhosterTeam() const { return m_iGhosterTeam; }


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
This adds three inputs and two outputs to neo_game_config to give mappers greater control over the game, potentially to add custom win conditions or special effects.

FireTeamWin - Ends the round with the team specified in the parameter as the winner (2 = Jinrai, 3 = NSF)
FireDMPlayerWin - Ends the round in deathmatch with the activating player as the winner
FireRoundTie - Ends the round as a tie

OnRoundEnd - Fired when any team wins or ties
OnRoundStart - Fired after "- GO! GO! GO! -"

In a scenario where the winning team is ambiguious, the mapper can have an output go through two team filters to then trigger FireTeamWin. I did not check the team of the activator to deterimine the winner instead as this can be more restrictive in some scenarios
I will make an FGD entry for this filter as it is mostly unknown to mappers it appears

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #552 

