### PR TITLE
Fix two bullets fired in one frame

### DIFF
--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -754,11 +754,6 @@ void CNEOBaseCombatWeapon::PrimaryAttack(void)
 	{
 		return;
 	}
-	// Can't shoot again yet
-	else if (gpGlobals->curtime - m_flLastAttackTime < GetFireRate())
-	{
-		return;
-	}
 	else if (m_iClip1 == 0)
 	{
 		if (!m_bFireOnEmpty)


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Fixes the problem commonly found in automatic weapons where two bullets are fired in the same frame. The check whether cycle time has passed in PrimaryAttack is unnecessary, we're already checking if the cycle time has passed in ItemPostFrame where we avoid doing floating point math
![Untitled](https://github.com/user-attachments/assets/8202a365-2490-444c-a017-5e92f1e609cf)

- fixes #835