### PR TITLE
Dryfire behaviour parity and zr68l sprinting viewmodel fix

### DIFF
--- a/mp/src/game/shared/basecombatweapon_shared.cpp
+++ b/mp/src/game/shared/basecombatweapon_shared.cpp
@@ -1404,7 +1404,7 @@ bool CBaseCombatWeapon::ReloadOrSwitchWeapons( void )
 		if ( UsesClipsForAmmo1() && !AutoFiresFullClip() && 
 			 (m_iClip1 == 0) && 
 			 (GetWeaponFlags() & ITEM_FLAG_NOAUTORELOAD) == false && 
-			 m_flNextPrimaryAttack < gpGlobals->curtime && 
+			 m_flNextPrimaryAttack < gpGlobals->curtime &&
 			 m_flNextSecondaryAttack < gpGlobals->curtime )
 		{
 			// if we're successfully reloading, we're done

--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -496,7 +496,9 @@ void CNEOBaseCombatWeapon::ProcessAnimationEvents()
 		m_flNextSecondaryAttack = m_flNextPrimaryAttack;
 	};
 
-	if (!m_bLowered && !m_bInReload && !m_bRoundBeingChambered &&
+	// NEO JANK (Adam) Why do we have to bombard the zr68l viewmodel with SendWeaponAnim(ACT_VM_IDLE_LOWERED) during sprint to make it act normally? Breakpoint in SendWeaponAnim isn't triggered by anything else after this animation is sent while sprinting
+	const bool loweredCheck = GetNeoWepBits() & NEO_WEP_ZR68_L ? true : !m_bLowered;
+	if (loweredCheck && !m_bInReload && !m_bRoundBeingChambered &&
 		(pOwner->IsSprinting() || pOwner->GetMoveType() == MOVETYPE_LADDER))
 	{
 		m_bLowered = true;
@@ -589,17 +591,31 @@ void CNEOBaseCombatWeapon::ItemPostFrame(void)
 		}
 	}
 
+	if (!bFired && (pOwner->m_afButtonPressed & IN_ATTACK))
+	{
+		if (!IsMeleeWeapon() &&
+			((UsesClipsForAmmo1() && m_iClip1 <= 0) || (!UsesClipsForAmmo1() && m_iPrimaryAmmoCount <= 0)))
+		{
+			DryFire();
+			m_flLastAttackTime = gpGlobals->curtime - 3.f;
+		}
+		else if (pOwner->GetWaterLevel() == 3 && m_bFiresUnderwater == false)
+		{
+			// This weapon doesn't fire underwater
+			WeaponSound(EMPTY);
+			m_flNextPrimaryAttack = gpGlobals->curtime + 0.2;
+			m_flLastAttackTime = gpGlobals->curtime - 3.f;
+			return;
+		}
+	}
+
 	if (!bFired && (pOwner->m_nButtons & IN_ATTACK) && (m_flNextPrimaryAttack <= gpGlobals->curtime))
 	{
 		// Clip empty? Or out of ammo on a no-clip weapon?
 		if (!IsMeleeWeapon() &&
 			((UsesClipsForAmmo1() && m_iClip1 <= 0) || (!UsesClipsForAmmo1() && m_iPrimaryAmmoCount <= 0)))
 		{
-			if (m_bRoundChambered) // bolt action rifles can have this value set to false, prevents empty clicking when holding the attack button when looking through scope to prevent bolting/reloading
-			{
-				HandleFireOnEmpty();
-			}
-			else
+			if (!(GetNeoWepBits() & NEO_WEP_SRS))
 			{
 				DryFire();
 			}
@@ -654,9 +670,13 @@ void CNEOBaseCombatWeapon::ItemPostFrame(void)
 	if (!(((pOwner->m_nButtons & IN_ATTACK) && !(pOwner->IsSprinting())) || (pOwner->m_nButtons & IN_ATTACK2) || (CanReload() && pOwner->m_nButtons & IN_RELOAD)))
 	{
 		// no fire buttons down or reloading
-		if (!ReloadOrSwitchWeapons() && (m_bInReload == false))
+		if (m_flTimeWeaponIdle <= gpGlobals->curtime)
 		{
 			WeaponIdle();
+		}
+		if (m_flLastAttackTime + 3.f < gpGlobals->curtime)
+		{
+			ReloadOrSwitchWeapons();
 		}
 	}
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

3 Seconds of delay after running out of ammunition before automatic reload kicks in, unless you dryfire specifically by pressing the attack key down (instead of holding the attack key down) after you've already run out of ammunition. Also fixes to the srs clicking when holding down the attack key to prevent the bolt from being cycled automatically after running out of ammunition (thought I already fixed this but I guess no?)

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #567