### PR TITLE
Disable screen overlays when in vision modes

### DIFF
--- a/mp/src/game/client/viewrender.cpp
+++ b/mp/src/game/client/viewrender.cpp
@@ -77,6 +77,11 @@
 // Projective textures
 #include "C_Env_Projected_Texture.h"
 
+#ifdef NEO
+// For removing screen overlays when in vision modes
+#include "c_neo_player.h"
+#endif
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
@@ -1217,8 +1222,12 @@ IMaterial *CViewRender::GetScreenOverlayMaterial( )
 void CViewRender::PerformScreenOverlay( int x, int y, int w, int h )
 {
 	VPROF("CViewRender::PerformScreenOverlay()");
-
+#ifdef NEO
+	C_NEO_Player* pLocalPlayer = C_NEO_Player::GetLocalNEOPlayer();
+	if (m_ScreenOverlayMaterial && !pLocalPlayer->m_bInVision)
+#else
 	if (m_ScreenOverlayMaterial)
+#endif
 	{
 		tmZone( TELEMETRY_LEVEL0, TMZF_NONE, "%s", __FUNCTION__ );
 


### PR DESCRIPTION
## Description
Will hide screen overlays (from env_screenoverlay, r_screenoverlay, or any other means) when the player is using their vision mode
Did this because it can mess with brightness in vision modes, especially with NV where the environment is very dark.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022




