### PR TITLE
Spread parity errata.

### DIFF
--- a/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/mp/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -271,7 +271,7 @@ protected:
 	virtual void UpdateInaccuracy(void);
 	virtual float GetAccuracyPenalty() const { return 0.8; }
 	virtual float GetMaxAccuracyPenalty() const { return 1.0; }
-	virtual float GetAccuracyPenaltyDecay() const { return 1.2; }
+	virtual float GetAccuracyPenaltyDecay();
 	virtual float GetFastestDryRefireTime() const { Assert(false); return 0; } // Should never call this base class; implement in children.
 
 protected:


### PR DESCRIPTION
## Description
* Add missing crouch spread modifier. In OGNT the inaccuracy decays faster while crouching, which is something I initially missed.
* Fix Jitte hip fire spread. No idea how I entered that so wrong, it was correct in my tables. Max hip spread decreased from 10 -> 7 degrees.
* Add experimental dynamic view kick toggle (_sv_neo_dynamic_viewkick_, default off). Basically this makes it so the view kick is proportional to the inaccuracy. Doesn't make much difference at inaccuracy scale 1, but is massive at lower values.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #107, #560