### PR TITLE
Fix incorrect version info string display in main menu

### DIFF
--- a/mp/src/game/client/neo/ui/neo_root.cpp
+++ b/mp/src/game/client/neo/ui/neo_root.cpp
@@ -520,7 +520,7 @@ void CNeoRoot::OnMainLoop(const NeoUI::Mode eMode)
 		surface()->GetTextSize(g_uiCtx.fonts[NeoUI::FONT_NTNORMAL].hdl, BUILD_DISPLAY, textWidth, textHeight);
 
 		surface()->DrawSetTextPos(g_uiCtx.iMarginX, tall - textHeight - g_uiCtx.iMarginY);
-		surface()->DrawPrintText(BUILD_DISPLAY, *BUILD_DISPLAY_SIZE);
+		surface()->DrawPrintText(BUILD_DISPLAY, wcslen(BUILD_DISPLAY));
 	}
 }
 

--- a/mp/src/game/shared/neo/neo_version_info.cpp.in
+++ b/mp/src/game/shared/neo/neo_version_info.cpp.in
@@ -11,8 +11,4 @@ const char* OS_BUILD = "@OS_BUILD@";
 const char* COMPILER_ID = "@COMPILER_ID@";
 const char* COMPILER_VERSION = "@COMPILER_VERSION@";
 const char* GIT_LATESTTAG = "@GIT_LATESTTAG@";
-
-inline const wchar_t INTERN_BUILD_DISPLAY[] = L"Build: @GIT_LATESTTAG@ (@BUILD_DATE_SHORT@_@GIT_HASH@, @OS_BUILD@)";
-const wchar_t* BUILD_DISPLAY = INTERN_BUILD_DISPLAY;
-static const int INTERN_BUILD_DISPLAY_SIZE = sizeof(INTERN_BUILD_DISPLAY) / sizeof(wchar_t);
-const int* BUILD_DISPLAY_SIZE = &INTERN_BUILD_DISPLAY_SIZE;
+const wchar_t* BUILD_DISPLAY = L"Build: @GIT_LATESTTAG@ (@BUILD_DATE_SHORT@_@GIT_HASH@, @OS_BUILD@)";

--- a/mp/src/game/shared/neo/neo_version_info.h
+++ b/mp/src/game/shared/neo/neo_version_info.h
@@ -10,4 +10,3 @@ extern const char* COMPILER_ID;
 extern const char* COMPILER_VERSION;
 extern const char* GIT_LATESTTAG;
 extern const wchar_t* BUILD_DISPLAY;
-extern const int* BUILD_DISPLAY_SIZE;


### PR DESCRIPTION
## Description
Before:
![before](https://github.com/user-attachments/assets/3589314e-ce0e-4cbc-9e06-5641ae36fd5b)
After:
![after](https://github.com/user-attachments/assets/b8e08c5e-4898-42d8-bb92-a2962e161e1b)

## Toolchain
- Windows MSVC VS2022