### PR TITLE
Fix picking up the ghost with use key

### DIFF
--- a/mp/src/game/client/hud_pdump.cpp
+++ b/mp/src/game/client/hud_pdump.cpp
@@ -63,6 +63,9 @@ void CPDumpPanel::ApplySchemeSettings( vgui::IScheme *pScheme )
 	BaseClass::ApplySchemeSettings( pScheme );
 
 	SetProportional( false );
+#ifdef NEO
+	SetBounds(0, 0, ScreenWidth(), ScreenHeight());
+#endif // NEO
 	SetPaintBackgroundEnabled( false );
 }
 

--- a/mp/src/game/server/hl2/hl2_player.cpp
+++ b/mp/src/game/server/hl2/hl2_player.cpp
@@ -3031,15 +3031,21 @@ void CHL2_Player::PlayerUse ( void )
 
 			if ( ( pWeapon != NULL ) && ( Weapon_CanSwitchTo( pWeapon ) ) )
 			{
+#ifndef NEO
+				// NEO TODO (Adam) this disables picking up ammunition from weapons with the use key, which we probably don't want anyway, but if we do work out why ghost weapon is of the same type as our primaryweapons like zr68s
 				//Try to take ammo or swap the weapon
 				if ( Weapon_OwnsThisType( pWeapon->GetClassname(), pWeapon->GetSubType() ) )
 				{
 					Weapon_EquipAmmoOnly( pWeapon );
 				}
 				else
+#endif // NEO
 				{
 					Weapon_DropSlot( pWeapon->GetSlot() );
 					Weapon_Equip( pWeapon );
+#ifdef NEO
+					pWeapon->RemoveEffects(EF_BONEMERGE);
+#endif // NEO
 				}
 
 				usedSomething = true;

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -7539,6 +7539,9 @@ void CBasePlayer::Weapon_DropSlot( int weaponSlot )
 			// If the slots match, it's already occupied
 			if ( pWeapon->GetSlot() == weaponSlot )
 			{
+#ifdef NEO
+				pWeapon->AddEffects( EF_BONEMERGE );
+#endif //NEO
 				Weapon_Drop( pWeapon, NULL, NULL );
 			}
 		}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

If had primary holstered, primary will no longer fall through the ground, and ghost will not be stuck to hands when picking up with use key. Also fixed cl_pdump because the command was not taking up the entire screen and a lot of the information was getting cut off