### PR TITLE
Grenades don't collide with players

### DIFF
--- a/mp/src/game/server/neo/neo_grenade.cpp
+++ b/mp/src/game/server/neo/neo_grenade.cpp
@@ -44,6 +44,7 @@ void CNEOGrenadeFrag::Spawn(void)
 	SetElasticity(sv_neo_grenade_cor.GetFloat());
 	SetGravity(sv_neo_grenade_gravity.GetFloat());
 	SetFriction(sv_neo_grenade_friction.GetFloat());
+	SetCollisionGroup(COLLISION_GROUP_WEAPON);
 	SetDetonateTimerLength(FLT_MAX);
 
 	SetThink(&CNEOGrenadeFrag::DelayThink);

--- a/mp/src/game/server/neo/neo_smokegrenade.cpp
+++ b/mp/src/game/server/neo/neo_smokegrenade.cpp
@@ -51,6 +51,7 @@ void CNEOGrenadeSmoke::Spawn(void)
 	SetElasticity(sv_neo_grenade_cor.GetFloat());
 	SetGravity(sv_neo_grenade_gravity.GetFloat());
 	SetFriction(sv_neo_grenade_friction.GetFloat());
+	SetCollisionGroup(COLLISION_GROUP_WEAPON);
 	SetDetonateTimerLength(FLT_MAX);
 
 	SetThink(&CNEOGrenadeSmoke::DelayThink);


### PR DESCRIPTION
Gave the smoke and frag grenade the same treatment as the detpack since that seems to be parity behaviour. There is some code in the sdk grenades to disable friendly collisions of grenade projectiles for the first x seconds of life, might want to use that if we start adding new utility which should interact with players like impact grenades and whatnot