### PR TITLE
Disable thermal vision view model override when using xray

### DIFF
--- a/mp/src/game/shared/neo/neo_predicted_viewmodel.cpp
+++ b/mp/src/game/shared/neo/neo_predicted_viewmodel.cpp
@@ -225,6 +225,7 @@ void CNEOPredictedViewModel::ClientThink()
 }
 
 extern ConVar mat_neo_toc_test;
+extern ConVar glow_outline_effect_enable;
 int CNEOPredictedViewModel::DrawModel(int flags)
 {
 	auto pPlayer = static_cast<C_NEO_Player*>(GetOwner());
@@ -254,7 +255,7 @@ int CNEOPredictedViewModel::DrawModel(int flags)
 			
 			return 0;
 		}
-		if (pPlayer->GetClass() == NEO_CLASS_SUPPORT && pPlayer->IsInVision())
+		if (pPlayer->GetClass() == NEO_CLASS_SUPPORT && pPlayer->IsInVision() && !glow_outline_effect_enable.GetBool())
 		{
 			IMaterial* pass = materials->FindMaterial("dev/thermal_view_model", TEXTURE_GROUP_MODEL);
 			Assert(pass && !pass->IsErrorMaterial());


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

when using xray while spectating a support in thermals, their viewmodel glows white. No longer