### PR TITLE
Various HUD tweaks.

### DIFF
--- a/game/neo/resource/ClientScheme.res
+++ b/game/neo/resource/ClientScheme.res
@@ -708,7 +708,7 @@ Scheme
 			}
 			// It seems that 127 is the largest a font can be, so we can't make the title any bigger than this
 		}
-		
+
 		ClientTitleFontSmall
 		{
 			"1"
@@ -1111,7 +1111,7 @@ Scheme
 				"antialias" "1"
 				"custom" "1" [$OSX]
 			}
-		}	
+		}
 		NHudText
 		{
 			"1"
@@ -1161,6 +1161,77 @@ Scheme
 				"yres"	"1200 6000"
 				"antialias"	"1"
 				//"additive"	"1"
+			}
+		}
+		NHudOCRSmaller
+		{
+			"1"
+			{
+				"name"		"Neuropol2"
+				"tall"		"10"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"480 599"
+				"additive"	"1"
+			}
+			"2"
+			{
+				"name"		"Neuropol2"
+				"tall"		"12"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"600 767"
+				"additive"	"1"
+			}
+			"3"
+			{
+				"name"		"Neuropol2"
+				"tall"		"14"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"768 1023"
+				"antialias"	"1"
+				"additive"	"1"
+			}
+			"4"
+			{
+				"name"		"Neuropol2"
+				"tall"		"17"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1024 1199"
+				"antialias"	"1"
+				"additive"	"1"
+			}
+			"5"
+			{
+				"name"		"Neuropol2"
+				"tall"		"20"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1200 1440"
+				"antialias"	"1"
+				"additive"	"1"
+			}
+			"6"
+			{
+				"name"		"Neuropol2"
+				"tall"		"24"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1441 1599"
+				"antialias"	"1"
+				"additive"	"1"
+			}
+			"7"
+			{
+				"name"		"Neuropol2"
+				"tall"		"26"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1600 6000"
+				"antialias"	"1"
+				"additive"	"1"
 			}
 		}
 		NHudOCRSmall
@@ -1298,7 +1369,6 @@ Scheme
 				"antialias"	"1"
 			}
 		}
-
 		NHudOCR
 		{
 			"1"
@@ -1432,6 +1502,77 @@ Scheme
 				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
 				"yres"	"1600 6000"
 				"antialias"	"1"
+			}
+		}
+		NHudOCRLarge
+		{
+			"1"
+			{
+				"name"		"Neuropol2"
+				"tall"		"26"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"480 599"
+				"additive"	"1"
+			}
+			"2"
+			{
+				"name"		"Neuropol2"
+				"tall"		"28"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"600 767"
+				"additive"	"1"
+			}
+			"3"
+			{
+				"name"		"Neuropol2"
+				"tall"		"30"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"		"768 1023"
+				"antialias"	"1"
+				"additive"	"1"
+			}
+			"4"
+			{
+				"name"		"Neuropol2"
+				"tall"		"32"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1024 1199"
+				"antialias"	"1"
+				"additive"	"1"
+			}
+			"5"
+			{
+				"name"		"Neuropol2"
+				"tall"		"34"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1200 1440"
+				"antialias"	"1"
+				"additive"	"1"
+			}
+			"6"
+			{
+				"name"		"Neuropol2"
+				"tall"		"36"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1441 1599"
+				"antialias"	"1"
+				"additive"	"1"
+			}
+			"7"
+			{
+				"name"		"Neuropol2"
+				"tall"		"38"
+				"weight"	"600"
+				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
+				"yres"	"1600 6000"
+				"antialias"	"1"
+				"additive"	"1"
 			}
 		}
 		NHudOCRBlur

--- a/game/neo/scripts/HudLayout.res
+++ b/game/neo/scripts/HudLayout.res
@@ -11,7 +11,7 @@
 		"enabled" "1"
 
 		"PaintBackgroundType"	"2"
-		
+
 		"text_xpos" "8"
 		"text_ypos" "20"
 		"digit_xpos" "50"
@@ -28,7 +28,7 @@
 		"enabled" "1"
 
 		"PaintBackgroundType"	"2"
-		
+
 		"text_xpos" "8"
 		"text_ypos" "23"
 		"digit_xpos" "66"
@@ -57,7 +57,7 @@
 	    "text_xpos" "8"
 	    "text_ypos" "4"
 	}
-	
+
 	HudVoiceSelfStatus
 	{
 		"fieldName" "HudVoiceSelfStatus"
@@ -80,24 +80,24 @@
 		"tall" "400"
 
 		"item_wide"	"135"
-		
+
 		"show_avatar"		"0"
-		
+
 		"show_dead_icon"	"1"
 		"dead_xpos"			"1"
 		"dead_ypos"			"0"
 		"dead_wide"			"16"
 		"dead_tall"			"16"
-		
+
 		"show_voice_icon"	"1"
 		"icon_ypos"			"0"
 		"icon_xpos"			"15"
 		"icon_tall"			"16"
 		"icon_wide"			"16"
-		
+
 		"text_xpos"			"33"
 	}
-	
+
 	HudSuit [!$DECK]
 	{
 		"fieldName"		"HudSuit"
@@ -126,7 +126,7 @@
 		"enabled" "1"
 
 		"PaintBackgroundType"	"2"
-		
+
 		"text_xpos" "8"
 		"text_ypos" "23"
 		"digit_xpos" "56"
@@ -207,7 +207,7 @@
 		"digit_xpos" "42"
 		"digit_ypos" "0"
 	}
-	
+
 	HudSuitPower [!$DECK]
 	{
 		"fieldName" "HudSuitPower"
@@ -217,7 +217,7 @@
 		"ypos"	"396"
 		"wide"	"102"
 		"tall"	"26"
-		
+
 		"AuxPowerLowColor" "255 0 0 220"
 		"AuxPowerHighColor" "255 220 0 220"
 		"AuxPowerDisabledAlpha" "70"
@@ -247,7 +247,7 @@
 		"ypos"	"386"
 		"wide"	"112"
 		"tall"	"54"
-		
+
 		"AuxPowerLowColor" "255 0 0 220"
 		"AuxPowerHighColor" "255 220 0 220"
 		"AuxPowerDisabledAlpha" "70"
@@ -294,7 +294,7 @@
 		"icon_xpos"	"10"
 		"icon_ypos" 	"2"
 	}
-	
+
 	HudFlashlight
 	{
 		"fieldName" "HudFlashlight"
@@ -305,18 +305,18 @@
 		"ypos"	"436"		[$DECK]
 		"xpos_hidef"	"306"		[$X360]		// aligned to left
 		"xpos_lodef"	"c-18"		[$X360]		// centered in screen
-		"ypos"	"428"		[$X360]				
+		"ypos"	"428"		[$X360]
 		"tall"  "24" [!$DECK]
 		"tall"  "30" [$DECK]
 		"wide"	"36" [!$DECK]
 		"wide"	"46" [$DECK]
 		"font"	"WeaponIconsSmall" [!$DECK]
 		"font"	"FlashlightDeck" [$DECK]
-		
+
 		"icon_xpos"	"4"
 		"icon_ypos" "-8" [!$DECK]
 		"icon_ypos" "-12"  [$DECK]
-		
+
 		"BarInsetX" "4"
 		"BarInsetY" "18" [!$DECK]
 		"BarInsetY" "22" [$DECK]
@@ -335,7 +335,7 @@
 		"enabled" "1"
 		"DmgColorLeft" "255 0 0 0"
 		"DmgColorRight" "255 0 0 0"
-		
+
 		"dmg_xpos" "30"
 		"dmg_ypos" "100"
 		"dmg_wide" "36"
@@ -352,7 +352,7 @@
 		"Circle2Radius"	"74"
 		"DashGap"	"16"
 		"DashHeight" "4"	[$WIN32]
-		"DashHeight" "6"	[$X360]		
+		"DashHeight" "6"	[$X360]
 		"BorderThickness" "88"
 	}
 	HudWeaponSelection
@@ -563,7 +563,7 @@
 		"center_x"				"0"	// center text horizontally
 		"center_y"				"-1"	// align text on the bottom
 		"paintbackground"		"0"
-	}	
+	}
 
 	HudHintKeyDisplay
 	{
@@ -706,8 +706,8 @@
 		"tall"	 		"120"
 		"PaintBackgroundType"	"2"
 	}
-	
-	AchievementNotificationPanel	
+
+	AchievementNotificationPanel
 	{
 		"fieldName"	"AchievementNotificationPanel"
 		"visible"	"0"
@@ -715,14 +715,14 @@
 		"wide"	"0"
 		"tall"	"0"
 	}
-	
+
 	HudHintKeyDisplay
 	{
 		"fieldName"	"HudHintKeyDisplay"
 		"visible"	"0"
 		"enabled" 	"0"
 	}
-	
+
 	HUDAutoAim
 	{
 		"fieldName" "HUDAutoAim"
@@ -743,9 +743,9 @@
 		"tall"  "40"
 		"visible" "1"
 		"enabled" "1"
-		
+
 		"PaintBackgroundType"	"2"
-		
+
 		"bar_xpos"		"50"
 		"bar_ypos"		"20"
 		"bar_height"	"8"
@@ -754,14 +754,14 @@
 		"speaker_ypos"	"8"
 		"count_xpos_from_right"	"10"	// Counts from the right side
 		"count_ypos"	"8"
-		
+
 		"icon_texture"	"vgui/hud/icon_commentary"
 		"icon_xpos"		"0"
-		"icon_ypos"		"0"		
+		"icon_ypos"		"0"
 		"icon_width"	"40"
 		"icon_height"	"40"
 	}
-	
+
 	HudHDRDemo
 	{
 		"fieldName" "HudHDRDemo"
@@ -771,23 +771,23 @@
 		"tall"  "480"
 		"visible" "1"
 		"enabled" "1"
-		
+
 		"Alpha"	"255"
 		"PaintBackgroundType"	"2"
-		
+
 		"BorderColor"	"0 0 0 255"
 		"BorderLeft"	"16"
 		"BorderRight"	"16"
 		"BorderTop"		"16"
 		"BorderBottom"	"64"
 		"BorderCenter"	"0"
-		
+
 		"TextColor"		"255 255 255 255"
 		"LeftTitleY"	"422"
 		"RightTitleY"	"422"
 	}
 
-	AchievementNotificationPanel	
+	AchievementNotificationPanel
 	{
 		"fieldName"				"AchievementNotificationPanel"
 		"visible"				"1"
@@ -802,7 +802,7 @@
 	CHudVote
 	{
 		"fieldName"		"CHudVote"
-		"xpos"			"0"			
+		"xpos"			"0"
 		"ypos"			"0"
 		"wide"			"640"
 		"tall"			"480"
@@ -810,7 +810,7 @@
 		"enabled"		"1"
 		"bgcolor_override"	"0 0 0 0"
 		"PaintBackgroundType"	"0" // rounded corners
-	}	
+	}
 
 	NHudCompass
 	{
@@ -833,9 +833,9 @@
 		"tall"			"32"
 		"box_color"		"200 200 200 40"
 		"top_left_corner"	"1"
-		"top_right_corner"	"1"
+		"top_right_corner"	"0"
 		"bottom_left_corner"	"1"
-		"bottom_right_corner"	"1"
+		"bottom_right_corner"	"0"
 		"text_xpos"		"194"
 		"text_ypos"		"2"
 		"digit_as_number"	"0"
@@ -860,9 +860,9 @@
 		"wide"			"203"
 		"tall"			"32"
 		"box_color"		"200 200 200 40"
-		"top_left_corner"	"1"
+		"top_left_corner"	"0"
 		"top_right_corner"	"1"
-		"bottom_left_corner"	"1"
+		"bottom_left_corner"	"0"
 		"bottom_right_corner"	"1"
 		"healthtext_xpos"	"6"
 		"healthtext_ypos"	"2"
@@ -907,7 +907,7 @@
 		"box_color"		"200 200 200 40"
 		"health_monochrome"	"1"
 	}
-	
+
 	neo_ghost_uplink_state
 	{
 		"fieldName"		"neo_ghost_uplink_state"
@@ -916,7 +916,7 @@
 		"wide"	"640"
 		"tall"	"480"
 	}
-	
+
 	neo_ghost_marker
 	{
 		"fieldName"		"neo_ghost_marker"
@@ -925,7 +925,7 @@
 		"wide"	"640"
 		"tall"	"480"
 	}
-	
+
 	neo_ghost_beacons
 	{
 		"fieldName"		"neo_ghost_beacons"
@@ -934,7 +934,7 @@
 		"wide"	"640"
 		"tall"	"480"
 	}
-	
+
 	CNEOHud_GameEvent
 	{
 		"fieldName"		"CNEOHud_GameEvent"
@@ -943,7 +943,7 @@
 		"wide"	"640"
 		"tall"	"480"
 	}
-	
+
 	neo_iff
 	{
 		"fieldName"		"neo_iff"
@@ -961,7 +961,7 @@
 		"wide"	"142"
 		"tall"	"284"
 	}
-  
+
 	neo_ghost_startup_sequence
 	{
 		"fieldName"		"neo_ghost_startup_sequence"

--- a/src/game/client/neo/ui/neo_hud_ammo.h
+++ b/src/game/client/neo/ui/neo_hud_ammo.h
@@ -47,9 +47,9 @@ private:
 	CPanelAnimationVar(Color, box_color, "box_color", "200 200 200 40");
 
 	CPanelAnimationVarAliasType(bool, top_left_corner, "top_left_corner", "1", "bool");
-	CPanelAnimationVarAliasType(bool, top_right_corner, "top_right_corner", "1", "bool");
+	CPanelAnimationVarAliasType(bool, top_right_corner, "top_right_corner", "0", "bool");
 	CPanelAnimationVarAliasType(bool, bottom_left_corner, "bottom_left_corner", "1", "bool");
-	CPanelAnimationVarAliasType(bool, bottom_right_corner, "bottom_right_corner", "1", "bool");
+	CPanelAnimationVarAliasType(bool, bottom_right_corner, "bottom_right_corner", "0", "bool");
 
 	CPanelAnimationVarAliasType(int, text_xpos, "text_xpos", "194", "proportional_xpos");
 	CPanelAnimationVarAliasType(int, text_ypos, "text_ypos", "2", "proportional_ypos");

--- a/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
+++ b/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.cpp
@@ -154,7 +154,7 @@ void CNEOHud_HTA::DrawHTA() const
 		surface()->DrawPrintText(L"THERM-OPTIC", 11);
 		surface()->DrawSetTextColor(m_sprintTextColor);
 		surface()->DrawSetTextPos(sprinttext_xpos + xpos, sprinttext_ypos + ypos);
-		surface()->DrawPrintText(L"AUX", 3);
+		surface()->DrawPrintText(L"AUX POWER", 9);
 	}
 
 	int fontWidth, fontHeight;

--- a/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.h
+++ b/src/game/client/neo/ui/neo_hud_health_thermoptic_aux.h
@@ -44,9 +44,9 @@ private:
 	CPanelAnimationVarAliasType(float, enabled, "enabled", "1", "proportional_float");
 	CPanelAnimationVar(Color, m_boxColor, "box_color", "200 200 200 40");
 
-	CPanelAnimationVarAliasType(bool, top_left_corner, "top_left_corner", "1", "bool");
+	CPanelAnimationVarAliasType(bool, top_left_corner, "top_left_corner", "0", "bool");
 	CPanelAnimationVarAliasType(bool, top_right_corner, "top_right_corner", "1", "bool");
-	CPanelAnimationVarAliasType(bool, bottom_left_corner, "bottom_left_corner", "1", "bool");
+	CPanelAnimationVarAliasType(bool, bottom_left_corner, "bottom_left_corner", "0", "bool");
 	CPanelAnimationVarAliasType(bool, bottom_right_corner, "bottom_right_corner", "1", "bool");
 
 	CPanelAnimationVarAliasType(int, healthtext_xpos, "healthtext_xpos", "6", "proportional_xpos");

--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -29,14 +29,13 @@ DECLARE_NAMED_HUDELEMENT(CNEOHud_RoundState, NRoundState);
 
 NEO_HUD_ELEMENT_DECLARE_FREQ_CVAR(RoundState, 0.1)
 
-ConVar neo_cl_squad_hud_original("neo_cl_squad_hud_original", "0", FCVAR_ARCHIVE, "Use the old squad HUD", true, 0.0, true, 1.0);
-
-ConVar neo_cl_squad_hud_star_scale("neo_cl_squad_hud_star_scale", "0", FCVAR_ARCHIVE, "Scaling to apply from 1080p, 0 disables scaling");
+ConVar cl_neo_squad_hud_original("cl_neo_squad_hud_original", "1", FCVAR_ARCHIVE, "Use the old squad HUD", true, 0.0, true, 1.0);
+ConVar cl_neo_squad_hud_star_scale("cl_neo_squad_hud_star_scale", "0", FCVAR_ARCHIVE, "Scaling to apply from 1080p, 0 disables scaling");
 extern ConVar neo_sv_dm_win_xp;
 extern ConVar neo_cl_streamermode;
 
 namespace {
-constexpr int Y_POS = 2;
+constexpr int Y_POS = 0;
 constexpr bool STARS_HW_FILTERED = false;
 }
 
@@ -118,8 +117,10 @@ void CNEOHud_RoundState::ApplySchemeSettings(vgui::IScheme* pScheme)
 {
 	BaseClass::ApplySchemeSettings(pScheme);
 
-	m_hOCRSmallFont = pScheme->GetFont("NHudOCRSmall");
+	m_hOCRLargeFont = pScheme->GetFont("NHudOCRLarge");
 	m_hOCRFont = pScheme->GetFont("NHudOCR");
+	m_hOCRSmallFont = pScheme->GetFont("NHudOCRSmall");
+	m_hOCRSmallerFont = pScheme->GetFont("NHudOCRSmaller");
 
 	SetFgColor(COLOR_TRANSPARENT);
 	SetBgColor(COLOR_TRANSPARENT);
@@ -129,9 +130,9 @@ void CNEOHud_RoundState::ApplySchemeSettings(vgui::IScheme* pScheme)
 	surface()->GetScreenSize(res.w, res.h);
 	m_iXpos = (res.w / 2);
 
-	if (neo_cl_squad_hud_star_scale.GetFloat())
+	if (cl_neo_squad_hud_star_scale.GetFloat())
 	{
-		const float scale = neo_cl_squad_hud_star_scale.GetFloat() * (res.h / 1080.0);
+		const float scale = cl_neo_squad_hud_star_scale.GetFloat() * (res.h / 1080.0);
 		for (auto* star : m_ipStars)
 		{
 			star->SetWide(192 * scale);
@@ -147,17 +148,17 @@ void CNEOHud_RoundState::ApplySchemeSettings(vgui::IScheme* pScheme)
 	}
 
 	// Box dimensions
-	int iSmallFontWidth = 0;
+	[[maybe_unused]] int iSmallFontWidth = 0;
 	int iFontHeight = 0;
-	[[maybe_unused]] int iFontWidth = 0;
+	int iFontWidth = 0;
 	surface()->GetTextSize(m_hOCRSmallFont, L"ROUND 99", iSmallFontWidth, m_iSmallFontHeight);
 	surface()->GetTextSize(m_hOCRFont, L"ROUND 99", iFontWidth, iFontHeight);
 	m_iSmallFontHeight *= 0.85;
 	iFontHeight *= 0.85;
 
-	const int iBoxHeight = (m_iSmallFontHeight * 2) + iFontHeight;
+	const int iBoxHeight = iFontHeight + m_iSmallFontHeight * 2 + 1;
 	const int iBoxHeightHalf = (iBoxHeight / 2);
-	const int iBoxWidth = iSmallFontWidth + (iBoxHeight * 2) + 2;
+	const int iBoxWidth = iFontWidth + iBoxHeight * 2;
 	const int iBoxWidthHalf = (iBoxWidth / 2);
 	m_iLeftOffset = m_iXpos - iBoxWidthHalf;
 	m_iRightOffset = m_iXpos + iBoxWidthHalf;
@@ -170,7 +171,6 @@ void CNEOHud_RoundState::ApplySchemeSettings(vgui::IScheme* pScheme)
 		.x1 = m_iLeftOffset + iBoxHeight,
 		.y1 = Y_POS + iBoxHeight,
 	};
-
 	m_rectRightTeamTotalLogo = vgui::IntRect{
 		.x0 = m_iRightOffset - iBoxHeight,
 		.y0 = Y_POS,
@@ -178,14 +178,14 @@ void CNEOHud_RoundState::ApplySchemeSettings(vgui::IScheme* pScheme)
 		.y1 = Y_POS + iBoxHeight,
 	};
 
+	surface()->GetTextSize(m_hOCRLargeFont, L"ROUND 99", iFontWidth, iFontHeight);
 	m_posLeftTeamScore = IntPos{
 		.x = m_rectLeftTeamTotalLogo.x0 + iBoxHeightHalf,
-		.y = static_cast<int>(Y_POS + iBoxHeightHalf - ((iFontHeight / 0.85) / 2)),
+		.y = static_cast<int>(Y_POS + iBoxHeightHalf - (iFontHeight / 2)),
 	};
-
 	m_posRightTeamScore = IntPos{
 		.x = m_rectRightTeamTotalLogo.x0 + iBoxHeightHalf,
-		.y = static_cast<int>(Y_POS + iBoxHeightHalf - ((iFontHeight / 0.85) / 2)),
+		.y = static_cast<int>(Y_POS + iBoxHeightHalf - (iFontHeight / 2)),
 	};
 
 	// Clear player avatars
@@ -356,7 +356,7 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	}
 
 	C_NEO_Player* localPlayer = C_NEO_Player::GetLocalNEOPlayer();
-	if (localPlayer);
+	if (localPlayer)
 	{
 		if (NEORules()->IsRoundPreRoundFreeze() || localPlayer->m_nButtons & IN_SCORE)
 		{
@@ -382,33 +382,88 @@ void CNEOHud_RoundState::DrawNeoHudElement()
 	int fontWidth, fontHeight;
 	surface()->GetTextSize(m_hOCRFont, m_wszTime, fontWidth, fontHeight);
 
-	if (!neo_cl_squad_hud_original.GetBool())
+	// Draw Box
+	DrawNeoHudRoundedBox(m_iLeftOffset, Y_POS, m_iRightOffset, m_iBoxYEnd, box_color, top_left_corner, top_right_corner, bottom_left_corner, bottom_right_corner);
+
+	// Draw round
+	surface()->DrawSetTextColor((NEORules()->GetRoundStatus() == NeoRoundStatus::Pause) ? COLOR_RED : COLOR_FADED_WHITE);
+	surface()->DrawSetTextFont(m_hOCRSmallerFont);
+	surface()->GetTextSize(m_hOCRSmallerFont, m_wszRoundUnicode, fontWidth, fontHeight);
+	surface()->DrawSetTextPos(m_iXpos - (fontWidth / 2), 0);
+	surface()->DrawPrintText(m_wszRoundUnicode, m_iWszRoundUCSize);
+
+	// Draw round status
+	surface()->DrawSetTextColor(COLOR_WHITE);
+	surface()->DrawSetTextFont(m_hOCRSmallFont);
+	surface()->GetTextSize(m_hOCRSmallFont, m_pWszStatusUnicode, fontWidth, fontHeight);
+	surface()->DrawSetTextPos(m_iXpos - (fontWidth / 2), m_iBoxYEnd);
+	surface()->DrawPrintText(m_pWszStatusUnicode, m_iStatusUnicodeSize);
+
+	const int localPlayerTeam = GetLocalPlayerTeam();
+	const int localPlayerIndex = GetLocalPlayerIndex();
+	const bool localPlayerSpecOrNoTeam = !NEORules()->IsTeamplay() || !(localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF);
+
+	const int leftTeam = localPlayerSpecOrNoTeam ? TEAM_JINRAI : localPlayerTeam;
+	const int rightTeam = (leftTeam == TEAM_JINRAI) ? TEAM_NSF : TEAM_JINRAI;
+	const auto leftTeamInfo = m_teamLogoColors[leftTeam];
+	const auto rightTeamInfo = m_teamLogoColors[rightTeam];
+
+	// Draw total players alive (or score)
+	surface()->DrawSetTextFont(m_hOCRSmallerFont);
+	surface()->GetTextSize(m_hOCRSmallerFont, m_wszPlayersAliveUnicode, fontWidth, fontHeight);
+	surface()->DrawSetTextColor(COLOR_FADED_WHITE);
+	surface()->DrawSetTextPos(m_iXpos - (fontWidth / 2), m_ilogoSize);
+	surface()->DrawPrintText(m_wszPlayersAliveUnicode, ARRAYSIZE(m_wszPlayersAliveUnicode) - 1);
+
+	// Draw time
+	surface()->DrawSetTextFont(m_hOCRFont);
+	surface()->GetTextSize(m_hOCRFont, m_wszTime, fontWidth, fontHeight);
+	surface()->DrawSetTextColor(NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze ?
+									COLOR_RED : COLOR_WHITE);
+	surface()->DrawSetTextPos(m_iXpos - (fontWidth / 2), m_iBoxYEnd / 2 - fontHeight / 2);
+	surface()->DrawPrintText(m_wszTime, 6);
+
+	if (NEORules()->IsTeamplay())
 	{
-		// Draw Box
-		DrawNeoHudRoundedBox(m_iLeftOffset, Y_POS, m_iRightOffset, m_iBoxYEnd, box_color, false, false, true, true);
+		// Draw score logo
+		surface()->DrawSetTexture(leftTeamInfo.totalLogo);
+		surface()->DrawSetColor(COLOR_FADED_DARK);
+		surface()->DrawTexturedRect(m_rectLeftTeamTotalLogo.x0,
+									m_rectLeftTeamTotalLogo.y0,
+									m_rectLeftTeamTotalLogo.x1,
+									m_rectLeftTeamTotalLogo.y1);
 
-		// Draw round
-		surface()->DrawSetTextColor((NEORules()->GetRoundStatus() == NeoRoundStatus::Pause) ? COLOR_RED : COLOR_WHITE);
-		surface()->DrawSetTextFont(m_hOCRSmallFont);
-		surface()->GetTextSize(m_hOCRSmallFont, m_wszRoundUnicode, fontWidth, fontHeight);
-		surface()->DrawSetTextPos(m_iXpos - (fontWidth / 2), 0);
-		surface()->DrawPrintText(m_wszRoundUnicode, m_iWszRoundUCSize);
+		surface()->DrawSetTexture(rightTeamInfo.totalLogo);
+		surface()->DrawTexturedRect(m_rectRightTeamTotalLogo.x0,
+									m_rectRightTeamTotalLogo.y0,
+									m_rectRightTeamTotalLogo.x1,
+									m_rectRightTeamTotalLogo.y1);
 
-		// Draw round status
+		// Draw score
+		surface()->GetTextSize(m_hOCRLargeFont, m_wszLeftTeamScore, fontWidth, fontHeight);
+		surface()->DrawSetTextFont(m_hOCRLargeFont);
+		surface()->DrawSetTextPos(m_posLeftTeamScore.x - (fontWidth / 2), m_posLeftTeamScore.y);
+		surface()->DrawSetTextColor(leftTeamInfo.color);
+		surface()->DrawPrintText(m_wszLeftTeamScore, 2);
+
+		surface()->GetTextSize(m_hOCRLargeFont, m_wszRightTeamScore, fontWidth, fontHeight);
+		surface()->DrawSetTextPos(m_posRightTeamScore.x - (fontWidth / 2), m_posRightTeamScore.y);
+		surface()->DrawSetTextColor(rightTeamInfo.color);
+		surface()->DrawPrintText(m_wszRightTeamScore, 2);
+	}
+
+	// Draw Game Type Description
+	if (m_iGameTypeDescriptionState)
+	{
+		surface()->DrawSetTextFont(m_hOCRFont);
+		surface()->GetTextSize(m_hOCRFont, m_wszGameTypeDescription, fontWidth, fontHeight);
 		surface()->DrawSetTextColor(COLOR_WHITE);
-		surface()->GetTextSize(m_hOCRSmallFont, m_pWszStatusUnicode, fontWidth, fontHeight);
 		surface()->DrawSetTextPos(m_iXpos - (fontWidth / 2), m_iBoxYEnd);
-		surface()->DrawPrintText(m_pWszStatusUnicode, m_iStatusUnicodeSize);
+		surface()->DrawPrintText(m_wszGameTypeDescription, Q_UnicodeLength(m_wszGameTypeDescription));
+	}
 
-		const int localPlayerTeam = GetLocalPlayerTeam();
-		const int localPlayerIndex = GetLocalPlayerIndex();
-		const bool localPlayerSpecOrNoTeam = !NEORules()->IsTeamplay() || !(localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF);
-
-		const int leftTeam = localPlayerSpecOrNoTeam ? TEAM_JINRAI : localPlayerTeam;
-		const int rightTeam = (leftTeam == TEAM_JINRAI) ? TEAM_NSF : TEAM_JINRAI;
-		const auto leftTeamInfo = m_teamLogoColors[leftTeam];
-		const auto rightTeamInfo = m_teamLogoColors[rightTeam];
-
+	if (!cl_neo_squad_hud_original.GetBool())
+	{
 		// Draw players
 		if (!g_PR)
 			return;
@@ -492,123 +547,129 @@ void CNEOHud_RoundState::DrawNeoHudElement()
 				}
 			}
 		}
-
-		if (NEORules()->IsTeamplay())
-		{
-			// Draw score logo
-			surface()->DrawSetTexture(leftTeamInfo.totalLogo);
-			surface()->DrawSetColor(COLOR_FADED_DARK);
-			surface()->DrawTexturedRect(m_rectLeftTeamTotalLogo.x0,
-										m_rectLeftTeamTotalLogo.y0,
-										m_rectLeftTeamTotalLogo.x1,
-										m_rectLeftTeamTotalLogo.y1);
-
-			surface()->DrawSetTexture(rightTeamInfo.totalLogo);
-			surface()->DrawTexturedRect(m_rectRightTeamTotalLogo.x0,
-										m_rectRightTeamTotalLogo.y0,
-										m_rectRightTeamTotalLogo.x1,
-										m_rectRightTeamTotalLogo.y1);
-
-			// Draw score
-			surface()->GetTextSize(m_hOCRFont, m_wszLeftTeamScore, fontWidth, fontHeight);
-			surface()->DrawSetTextFont(m_hOCRFont);
-			surface()->DrawSetTextPos(m_posLeftTeamScore.x - (fontWidth / 2), m_posLeftTeamScore.y);
-			surface()->DrawSetTextColor(leftTeamInfo.color);
-			surface()->DrawPrintText(m_wszLeftTeamScore, 2);
-
-			surface()->GetTextSize(m_hOCRFont, m_wszRightTeamScore, fontWidth, fontHeight);
-			surface()->DrawSetTextPos(m_posRightTeamScore.x - (fontWidth / 2), m_posRightTeamScore.y);
-			surface()->DrawSetTextColor(rightTeamInfo.color);
-			surface()->DrawPrintText(m_wszRightTeamScore, 2);
-		}
-
-		// Draw total players alive (or score)
-		surface()->DrawSetTextFont(m_hOCRSmallFont);
-		surface()->GetTextSize(m_hOCRSmallFont, m_wszPlayersAliveUnicode, fontWidth, fontHeight);
-		surface()->DrawSetTextColor(COLOR_WHITE);
-		surface()->DrawSetTextPos(m_iXpos - (fontWidth / 2), m_ilogoSize);
-		surface()->DrawPrintText(m_wszPlayersAliveUnicode, ARRAYSIZE(m_wszPlayersAliveUnicode) - 1);
 	}
 	else
 	{
-		if (g_PR)
-		{
-			// Draw members of players squad in an old style list
-			const int localPlayerTeam = GetLocalPlayerTeam();
-			const int localPlayerIndex = GetLocalPlayerIndex();
-			const bool localPlayerSpec = !(localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF);
-
-			if (!localPlayerSpec && g_PR->GetStar(localPlayerIndex) != 0)
-			{
-				const int leftTeam = localPlayerSpec ? TEAM_JINRAI : localPlayerTeam;
-				const auto leftTeamInfo = m_teamLogoColors[leftTeam];
-				int leftCount = 0;
-
-				for (int i = 0; i < (MAX_PLAYERS + 1); i++)
-				{
-					if (i == localPlayerIndex)
-					{
-						continue;
-					}
-
-					if (!g_PR->IsConnected(i))
-					{
-						continue;
-					}
-
-					const int playerTeam = g_PR->GetTeam(i);
-					if (playerTeam != leftTeam)
-					{
-						continue;
-					}
-
-					const bool isSameSquad = g_PR->GetStar(i) == g_PR->GetStar(localPlayerIndex);
-					if (!isSameSquad)
-					{
-						continue;
-					}
-
-					// Draw player
-					static constexpr int SQUAD_MATE_TEXT_LENGTH = 62; // 31 characters in name without end character max plus 3 in short rank name plus 7 max in class name plus 3 max in health plus other characters
-					char squadMateText[SQUAD_MATE_TEXT_LENGTH];
-					wchar_t wSquadMateText[SQUAD_MATE_TEXT_LENGTH];
-					const char* squadMateRankName = GetRankName(g_PR->GetXP(i), true);
-					const char* squadMateClass = GetNeoClassName(g_PR->GetClass(i));
-					const int squadMateHealth = g_PR->IsAlive( i ) ? g_PR->GetHealth( i ) : 0;
-					V_snprintf(squadMateText, SQUAD_MATE_TEXT_LENGTH, "%s %s  [%s]  Integrity %i", g_PR->GetPlayerName( i ), squadMateRankName, squadMateClass, squadMateHealth);
-					g_pVGuiLocalize->ConvertANSIToUnicode(squadMateText, wSquadMateText, sizeof(wSquadMateText));
-
-					surface()->DrawSetTextFont(m_hOCRSmallFont);
-					surface()->GetTextSize(m_hOCRSmallFont, m_wszPlayersAliveUnicode, fontWidth, fontHeight);
-					surface()->DrawSetTextColor(g_PR->IsAlive( i ) ? COLOR_FADED_WHITE : COLOR_DARK_FADED_WHITE);
-					surface()->DrawSetTextPos(8, 48 + fontHeight * leftCount);
-					surface()->DrawPrintText(wSquadMateText, Q_strlen(squadMateText));
-
-					leftCount++;
-				}
-			}
-		}
-	}
-
-	// Draw time
-	surface()->DrawSetTextFont(m_hOCRFont);
-	surface()->GetTextSize(m_hOCRFont, m_wszTime, fontWidth, fontHeight);
-	surface()->DrawSetTextColor(neo_cl_squad_hud_original.GetBool() ? COLOR_FADED_WHITE : (NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze) ?
-									COLOR_RED : COLOR_WHITE);
-	surface()->DrawSetTextPos(m_iXpos - (fontWidth / 2), neo_cl_squad_hud_original.GetBool() ? Y_POS : m_iSmallFontHeight);
-	surface()->DrawPrintText(m_wszTime, 6);
-
-	// Draw Game Type Description
-	if (m_iGameTypeDescriptionState)
-	{
-		surface()->DrawSetTextFont(m_hOCRFont);
-		surface()->GetTextSize(m_hOCRFont, m_wszGameTypeDescription, fontWidth, fontHeight);
-		surface()->DrawSetTextColor(COLOR_WHITE);
-		surface()->DrawSetTextPos(m_iXpos - (fontWidth / 2), m_iBoxYEnd);
-		surface()->DrawPrintText(m_wszGameTypeDescription, Q_UnicodeLength(m_wszGameTypeDescription));
+		DrawPlayerList();
 	}
 
 	CheckActiveStar();
+}
+
+void CNEOHud_RoundState::DrawPlayerList()
+{
+	if (g_PR)
+	{
+		// Draw members of players squad in an old style list
+		const int localPlayerTeam = GetLocalPlayerTeam();
+		const int localPlayerIndex = GetLocalPlayerIndex();
+		const bool localPlayerSpec = !(localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF);
+		const int leftTeam = localPlayerSpec ? TEAM_JINRAI : localPlayerTeam;
+
+		if (localPlayerSpec)
+		{
+			return;
+		}
+
+		int offset = 52;
+		if (cl_neo_squad_hud_star_scale.GetFloat() > 0)
+		{
+			IntDim res = {};
+			surface()->GetScreenSize(res.w, res.h);
+			offset *= cl_neo_squad_hud_star_scale.GetFloat() * res.h / 1080.0f;
+		}
+
+		// Draw squad mates
+		if (g_PR->GetStar(localPlayerIndex) != 0)
+		{
+			bool squadMateFound = false;
+
+			for (int i = 0; i < (MAX_PLAYERS + 1); i++)
+			{
+				if (i == localPlayerIndex)
+				{
+					continue;
+				}
+				if (!g_PR->IsConnected(i))
+				{
+					continue;
+				}
+				const int playerTeam = g_PR->GetTeam(i);
+				if (playerTeam != leftTeam)
+				{
+					continue;
+				}
+				const bool isSameSquad = g_PR->GetStar(i) == g_PR->GetStar(localPlayerIndex);
+				if (!isSameSquad)
+				{
+					continue;
+				}
+
+				offset = DrawPlayerRow(i, offset);
+				squadMateFound = true;
+			}
+
+			if (squadMateFound)
+			{
+				offset += 12;
+			}
+		}
+		// Draw other team mates
+		for (int i = 0; i < (MAX_PLAYERS + 1); i++)
+		{
+			if (i == localPlayerIndex)
+			{
+				continue;
+			}
+			if (!g_PR->IsConnected(i))
+			{
+				continue;
+			}
+			const int playerTeam = g_PR->GetTeam(i);
+			if (playerTeam != leftTeam)
+			{
+				continue;
+			}
+			const bool isSameSquad = g_PR->GetStar(i) == g_PR->GetStar(localPlayerIndex);
+			if (isSameSquad)
+			{
+				continue;
+			}
+
+			offset = DrawPlayerRow(i, offset, true);
+		}
+	}
+}
+
+int CNEOHud_RoundState::DrawPlayerRow(int playerIndex, const int yOffset, bool small)
+{
+	// Draw player
+	static constexpr int SQUAD_MATE_TEXT_LENGTH = 62; // 31 characters in name without end character max plus 3 in short rank name plus 7 max in class name plus 3 max in health plus other characters
+	char squadMateText[SQUAD_MATE_TEXT_LENGTH];
+	wchar_t wSquadMateText[SQUAD_MATE_TEXT_LENGTH];
+	const char* squadMateRankName = GetRankName(g_PR->GetXP(playerIndex), true);
+	const char* squadMateClass = GetNeoClassName(g_PR->GetClass(playerIndex));
+	const bool isAlive = g_PR->IsAlive(playerIndex);
+	const int squadMateHealth = isAlive ? g_PR->GetHealth(playerIndex) : 0;
+
+	if (isAlive)
+	{
+		V_snprintf(squadMateText, SQUAD_MATE_TEXT_LENGTH, "%s %s  [%s]  Integrity %i", g_PR->GetPlayerName(playerIndex), squadMateRankName, squadMateClass, squadMateHealth);
+	}
+	else
+	{
+		V_snprintf(squadMateText, SQUAD_MATE_TEXT_LENGTH, "%s  [%s]  DEAD", g_PR->GetPlayerName(playerIndex), squadMateClass);
+	}
+	g_pVGuiLocalize->ConvertANSIToUnicode(squadMateText, wSquadMateText, sizeof(wSquadMateText));
+
+	int fontWidth, fontHeight;
+	surface()->DrawSetTextFont(small ? m_hOCRSmallerFont : m_hOCRSmallFont);
+	surface()->GetTextSize(m_hOCRSmallFont, m_wszPlayersAliveUnicode, fontWidth, fontHeight);
+	surface()->DrawSetTextColor(isAlive ? COLOR_FADED_WHITE : COLOR_DARK_FADED_WHITE);
+	surface()->DrawSetTextPos(8, yOffset);
+	surface()->DrawPrintText(wSquadMateText, Q_strlen(squadMateText));
+
+	return yOffset + fontHeight;
 }
 
 void CNEOHud_RoundState::DrawPlayer(int playerIndex, int teamIndex, const TeamLogoColor &teamLogoColor,
@@ -677,7 +738,7 @@ void CNEOHud_RoundState::DrawPlayer(int playerIndex, int teamIndex, const TeamLo
 			surface()->DrawSetColor(COLOR_YELLOW);
 		else
 			surface()->DrawSetColor(COLOR_WHITE);
-	}	
+	}
 	surface()->DrawFilledRect(xOffset, Y_POS + m_ilogoSize + 2, xOffset + (g_PR->GetHealth(playerIndex) / 100.0f * m_ilogoSize), Y_POS + m_ilogoSize + 6);
 }
 
@@ -734,14 +795,14 @@ void CNEOHud_RoundState::SetTextureToAvatar(int playerIndex)
 	player_info_t pi;
 	if (!engine->GetPlayerInfo(playerIndex, &pi))
 		return;
-	
+
 	if (!pi.friendsID)
 		return;
 
 	CSteamID steamIDForPlayer(pi.friendsID, 1, steamapicontext->SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual);
 	const int mapIndex = g_pNeoScoreBoard->m_mapAvatarsToImageList.Find(steamIDForPlayer);
 	if ((mapIndex == g_pNeoScoreBoard->m_mapAvatarsToImageList.InvalidIndex()))
-		return; 
+		return;
 
 	CAvatarImage* pAvIm = (CAvatarImage*)g_pNeoScoreBoard->m_pImageList->GetImage(g_pNeoScoreBoard->m_mapAvatarsToImageList[mapIndex]);
 	surface()->DrawSetTexture(pAvIm->getTextureID());

--- a/src/game/client/neo/ui/neo_hud_round_state.h
+++ b/src/game/client/neo/ui/neo_hud_round_state.h
@@ -43,13 +43,17 @@ private:
 	};
 
 	void CheckActiveStar();
+	void DrawPlayerList();
+	int DrawPlayerRow(int playerIndex, int yOffset, bool small = false);
 	void DrawPlayer(int playerIndex, int teamIndex, const TeamLogoColor &teamLogoColor,
 					const int xOffset, const bool drawHealthClass);
 	void SetTextureToAvatar(int playerIndex);
 
 private:
-	vgui::HFont m_hOCRSmallFont = 0UL;
+	vgui::HFont m_hOCRLargeFont = 0UL;
 	vgui::HFont m_hOCRFont = 0UL;
+	vgui::HFont m_hOCRSmallFont = 0UL;
+	vgui::HFont m_hOCRSmallerFont = 0UL;
 
 	int m_iXpos = 0;
 
@@ -97,6 +101,10 @@ private:
 
 	CPanelAnimationVar(Color, box_color, "box_color", "200 200 200 40");
 	CPanelAnimationVarAliasType(bool, health_monochrome, "health_monochrome", "1", "bool");
+	CPanelAnimationVarAliasType(bool, top_left_corner, "top_left_corner", "0", "bool");
+	CPanelAnimationVarAliasType(bool, top_right_corner, "top_right_corner", "0", "bool");
+	CPanelAnimationVarAliasType(bool, bottom_left_corner, "bottom_left_corner", "1", "bool");
+	CPanelAnimationVarAliasType(bool, bottom_right_corner, "bottom_right_corner", "1", "bool");
 
 private:
 	CNEOHud_RoundState(const CNEOHud_RoundState &other);

--- a/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/src/game/client/neo/ui/neo_root_settings.cpp
@@ -238,6 +238,7 @@ void NeoSettingsRestore(NeoSettings *ns, const NeoSettings::Keys::Flags flagsKey
 		pGeneral->bViewmodelRighthand = cvr->cl_righthand.GetBool();
 		pGeneral->bLeanViewmodelOnly = cvr->cl_neo_lean_viewmodel_only.GetBool();
 		pGeneral->bLeanAutomatic = cvr->cl_neo_lean_automatic.GetBool();
+		pGeneral->bShowSquadList = cvr->cl_neo_squad_hud_original.GetBool();
 		pGeneral->bShowPlayerSprays = !(cvr->cl_playerspraydisable.GetBool()); // Inverse
 		pGeneral->bShowPos = cvr->cl_showpos.GetBool();
 		pGeneral->iShowFps = cvr->cl_showfps.GetInt();
@@ -462,6 +463,7 @@ void NeoSettingsSave(const NeoSettings *ns)
 		cvr->cl_righthand.SetValue(pGeneral->bViewmodelRighthand);
 		cvr->cl_neo_lean_viewmodel_only.SetValue(pGeneral->bLeanViewmodelOnly);
 		cvr->cl_neo_lean_automatic.SetValue(pGeneral->bLeanAutomatic);
+		cvr->cl_neo_squad_hud_original.SetValue(pGeneral->bShowSquadList);
 		cvr->cl_playerspraydisable.SetValue(!pGeneral->bShowPlayerSprays); // Inverse
 		cvr->cl_showpos.SetValue(pGeneral->bShowPos);
 		cvr->cl_showfps.SetValue(pGeneral->iShowFps);
@@ -668,6 +670,7 @@ void NeoSettings_General(NeoSettings *ns)
 	NeoUI::RingBoxBool(L"Right hand viewmodel", &pGeneral->bViewmodelRighthand);
 	NeoUI::RingBoxBool(L"Lean viewmodel only", &pGeneral->bLeanViewmodelOnly);
 	NeoUI::RingBoxBool(L"Automatic leaning", &pGeneral->bLeanAutomatic);
+	NeoUI::RingBoxBool(L"Classic squad list", &pGeneral->bShowSquadList);
 	NeoUI::RingBoxBool(L"Show player spray", &pGeneral->bShowPlayerSprays);
 	NeoUI::RingBoxBool(L"Show position", &pGeneral->bShowPos);
 	NeoUI::RingBox(L"Show FPS", SHOWFPS_LABELS, ARRAYSIZE(SHOWFPS_LABELS), &pGeneral->iShowFps);

--- a/src/game/client/neo/ui/neo_root_settings.h
+++ b/src/game/client/neo/ui/neo_root_settings.h
@@ -38,6 +38,7 @@ struct NeoSettings
 		bool bViewmodelRighthand;
 		bool bLeanViewmodelOnly;
 		bool bLeanAutomatic;
+		bool bShowSquadList;
 		bool bShowPlayerSprays;
 		bool bShowPos;
 		int iShowFps;
@@ -167,6 +168,7 @@ struct NeoSettings
 		CONVARREF_DEF(cl_righthand);
 		CONVARREF_DEF(cl_neo_lean_viewmodel_only);
 		CONVARREF_DEF(cl_neo_lean_automatic);
+		CONVARREF_DEF(cl_neo_squad_hud_original);
 		CONVARREF_DEF(cl_showpos);
 		CONVARREF_DEF(cl_showfps);
 		CONVARREF_DEF(hud_fastswitch);

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -278,10 +278,10 @@ bool CNEOScoreBoard::ShowAvatars()
 	return neo_show_scoreboard_avatars.GetBool() && !neo_cl_streamermode.GetBool();
 }
 
-extern ConVar neo_cl_squad_hud_original;
+extern ConVar cl_neo_squad_hud_original;
 bool CNEOScoreBoard::UpdateAvatars()
 {
-	return !neo_cl_streamermode.GetBool() && (neo_show_scoreboard_avatars.GetBool() || !neo_cl_squad_hud_original.GetBool());
+	return !neo_cl_streamermode.GetBool() && (neo_show_scoreboard_avatars.GetBool() || !cl_neo_squad_hud_original.GetBool());
 }
 
 void CNEOScoreBoard::FireGameEvent( IGameEvent *event )


### PR DESCRIPTION
## Description
<!--
Put in description here...
-->
* _squad_hud_original_ is enabled by default.
* Display round info even when _squad_hud_original_ is enabled.
* Add _squad_hud_original_ to the settings menu as 'Classic squad list'.
* Show non-squad members in smaller text below squad members.
* Change _squad_hud_ cvar prefixes from _neo_cl_ to _cl_neo_.
* Add smaller and large HudOCR font used by the round info and classic squad list.
* Make rounded corners match OGNT, and configurable in HudLayout.res.
* Change 'AUX' to 'AUX POWER'.

![image](https://github.com/user-attachments/assets/3e275e7f-ce0b-4d34-94c0-55a7010b65ce)
![image](https://github.com/user-attachments/assets/3b691e47-0a31-4b04-a234-ba47a854c956)
![image](https://github.com/user-attachments/assets/76c808a7-8a9d-49df-9748-946037c27c70)



## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #944

