### PR TITLE
Detpack velocity again and detpack detonation time

### DIFF
--- a/src/game/client/neo/ui/neo_hud_ammo.cpp
+++ b/src/game/client/neo/ui/neo_hud_ammo.cpp
@@ -132,7 +132,7 @@ void CNEOHud_Ammo::DrawAmmo() const
 	const int numClips = ceil(abs((float)ammoCount / activeWep->GetMaxClip1())); // abs because grenades return negative values (???) // casting division to float in case we have a half-empty mag, rounding up to show the half mag as one more mag
 	const bool isSupa = activeWep->GetNeoWepBits() & NEO_WEP_SUPA7;
 		
-	if (activeWep->UsesClipsForAmmo1()) {
+	if (activeWep->UsesClipsForAmmo1() && !(activeWep->GetNeoWepBits() & NEO_WEP_DETPACK)) {
 		const int maxLen = 5;
 		char clipsText[maxLen]{ '\0' };
 		if(isSupa)
@@ -161,7 +161,7 @@ void CNEOHud_Ammo::DrawAmmo() const
 	int magSizeMax = 0;
 	int magSizeCurrent = 0;
 		
-	if (activeWep->UsesClipsForAmmo1()) 
+	if (activeWep->UsesClipsForAmmo1() && !(activeWep->GetNeoWepBits() & NEO_WEP_THROWABLE)) 
 	{
 		char fireModeText[2]{ '\0' };
 

--- a/src/game/shared/neo/weapons/weapon_detpack.cpp
+++ b/src/game/shared/neo/weapons/weapon_detpack.cpp
@@ -349,7 +349,7 @@ void CWeaponDetpack::TossDetpack(CBasePlayer* pPlayer)
 
 	vecSrc += vForward * 16;
 
-	Vector vecThrow = pPlayer->GetAbsVelocity() * 0.5;
+	Vector vecThrow = pPlayer->GetAbsVelocity();
 	m_pDetpack = static_cast<CNEODeployedDetpack*>(NEODeployedDetpack_Create(vecSrc, vec3_angle, vecThrow, AngularImpulse(600, random->RandomInt(-1200, 1200), 0), pPlayer));
 
 	if (m_pDetpack)

--- a/src/game/shared/neo/weapons/weapon_detpack.cpp
+++ b/src/game/shared/neo/weapons/weapon_detpack.cpp
@@ -152,7 +152,7 @@ void CWeaponDetpack::PrimaryAttack(void)
 #endif
 		SendWeaponAnim(ACT_VM_PRIMARYATTACK_DEPLOYED);
 		pPlayer->DoAnimationEvent(PLAYERANIMEVENT_ATTACK_PRIMARY);
-		m_flNextPrimaryAttack = gpGlobals->curtime + (SequenceDuration() / 3);
+		m_flNextPrimaryAttack = gpGlobals->curtime + (SequenceDuration() * 0.5);
 		m_flTimeWeaponIdle = FLT_MAX;
 	}
 	else

--- a/src/game/shared/neo/weapons/weapon_detpack.cpp
+++ b/src/game/shared/neo/weapons/weapon_detpack.cpp
@@ -349,7 +349,8 @@ void CWeaponDetpack::TossDetpack(CBasePlayer* pPlayer)
 
 	vecSrc += vForward * 16;
 
-	m_pDetpack = static_cast<CNEODeployedDetpack*>(NEODeployedDetpack_Create(vecSrc, vec3_angle, vec3_origin, AngularImpulse(600, random->RandomInt(-1200, 1200), 0), pPlayer));
+	Vector vecThrow = pPlayer->GetAbsVelocity() * 0.5;
+	m_pDetpack = static_cast<CNEODeployedDetpack*>(NEODeployedDetpack_Create(vecSrc, vec3_angle, vecThrow, AngularImpulse(600, random->RandomInt(-1200, 1200), 0), pPlayer));
 
 	if (m_pDetpack)
 	{


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

player velocity but halved seems about right, detpack detonates too soon, halving instead of thirding seems about right, also don't draw some ui elements in the weapon hud element when using a detpack

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #989
- fixes #991