### PR TITLE
Update team selection menu labels on players joining teams and teams scoring

### DIFF
--- a/src/game/client/neo/game_controls/neo_teammenu.h
+++ b/src/game/client/neo/game_controls/neo_teammenu.h
@@ -31,7 +31,7 @@ class MouseCode;
 
 // NOTE: this class name must match its res file description.
 class CNeoTeamMenu : public vgui::Frame,
-    public IViewPortPanel
+    public IViewPortPanel, public CGameEventListener
 {
     DECLARE_CLASS_SIMPLE( CNeoTeamMenu, vgui::Frame );
 
@@ -48,6 +48,9 @@ public:
 	virtual void ShowPanel( bool bShow );
 
 	GameActionSet_t GetPreferredActionSet() override { return GAME_ACTION_SET_IN_GAME_HUD; }
+
+    // IGameEventListener interface:
+    virtual void FireGameEvent(IGameEvent* event);
 
     // both vgui::Frame and IViewPortPanel define these, so explicitly define them here as passthroughs to vgui
 	vgui::VPANEL GetVPanel( void ) { return BaseClass::GetVPanel(); }

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -2854,6 +2854,13 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 		if (!bDontAddScore)
 		{
 			winningTeam->IncrementRoundsWon();
+			IGameEvent* event = gameeventmanager->CreateEvent("team_score");
+			if (event)
+			{
+				event->SetInt("teamid", winningTeam->GetTeamNumber());
+				event->SetInt("score", winningTeam->GetRoundsWon());
+				gameeventmanager->FireEvent(event);
+			}
 		}
 	}
 


### PR DESCRIPTION
Updates these values when players join teams and leave or disconnect, and when teams score

![image](https://github.com/user-attachments/assets/2b0de346-c4fb-4b73-949f-1620af125c75)
