### PR TITLE
muzzle light, toc flash and grenade angular impulse

### DIFF
--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1092,14 +1092,6 @@ void CNEO_Player::PreThink(void)
 	}
 }
 
-ConVar sv_neo_cloak_color_r("sv_neo_cloak_color_r", "1", FCVAR_CHEAT, "Thermoptic cloak flash color (red channel).", true, 0.0f, true, 255.0f);
-ConVar sv_neo_cloak_color_g("sv_neo_cloak_color_g", "1", FCVAR_CHEAT, "Thermoptic cloak flash color (green channel).", true, 0.0f, true, 255.0f);
-ConVar sv_neo_cloak_color_b("sv_neo_cloak_color_b", "4", FCVAR_CHEAT, "Thermoptic cloak flash color (blue channel).", true, 0.0f, true, 255.0f);
-ConVar sv_neo_cloak_color_radius("sv_neo_cloak_color_radius", "80", FCVAR_CHEAT, "Thermoptic cloak flash effect radius.", true, 0.0f, true, 2056.0f);
-ConVar sv_neo_cloak_time("sv_neo_cloak_time", "0.5", FCVAR_CHEAT, "How long should the thermoptic flash be visible, in seconds.", true, 0.0f, true, 1.0f);
-ConVar sv_neo_cloak_decay("sv_neo_cloak_decay", "150", FCVAR_CHEAT, "After the cloak time, how quickly should the flash effect disappear.", true, 0.f, true, 2056.f);
-ConVar sv_neo_cloak_exponent("sv_neo_cloak_exponent", "16", FCVAR_CHEAT, "Cloak flash lighting exponent.", true, 0.0f, false, 0.0f);
-
 void CNEO_Player::PlayCloakSound(bool removeLocalPlayer)
 {
 	CRecipientFilter filter;
@@ -1168,14 +1160,14 @@ void CNEO_Player::CloakFlash(float time)
 	CRecipientFilter filter;
 	filter.AddRecipientsByPVS(GetAbsOrigin());
 
-	g_NEO_TE_TocFlash.r = sv_neo_cloak_color_r.GetInt();
-	g_NEO_TE_TocFlash.g = sv_neo_cloak_color_g.GetInt();
-	g_NEO_TE_TocFlash.b = sv_neo_cloak_color_b.GetInt();
-	g_NEO_TE_TocFlash.m_vecOrigin = GetAbsOrigin() + Vector(0, 0, 4);
-	g_NEO_TE_TocFlash.exponent = sv_neo_cloak_exponent.GetInt();
-	g_NEO_TE_TocFlash.m_fRadius = sv_neo_cloak_color_radius.GetFloat();
-	g_NEO_TE_TocFlash.m_fTime = time ? time : sv_neo_cloak_time.GetFloat();
-	g_NEO_TE_TocFlash.m_fDecay = sv_neo_cloak_decay.GetFloat();
+	g_NEO_TE_TocFlash.r = 64;
+	g_NEO_TE_TocFlash.g = 64;
+	g_NEO_TE_TocFlash.b = 255;
+	g_NEO_TE_TocFlash.m_vecOrigin = GetAbsOrigin();
+	g_NEO_TE_TocFlash.exponent = 10;
+	g_NEO_TE_TocFlash.m_fRadius = 96;
+	g_NEO_TE_TocFlash.m_fTime = time ? time : 0.5;
+	g_NEO_TE_TocFlash.m_fDecay = 192;
 
 	g_NEO_TE_TocFlash.Create(filter);
 }

--- a/src/game/shared/neo/neo_predicted_viewmodel.cpp
+++ b/src/game/shared/neo/neo_predicted_viewmodel.cpp
@@ -507,14 +507,14 @@ void CNEOPredictedViewModel::ProcessMuzzleFlashEvent()
 {
 	Vector vAttachment;
 	QAngle dummyAngles;
-	GetAttachment(2, vAttachment, dummyAngles);
+	GetAttachment(1, vAttachment, dummyAngles);
 
 	// Make a dlight
 	dlight_t* dl = effects->CL_AllocDlight(LIGHT_INDEX_MUZZLEFLASH + index);
 	dl->origin = vAttachment;
 	dl->radius = random->RandomInt(64, 96);
-	dl->decay = dl->radius / 0.1f;
-	dl->die = gpGlobals->curtime + 0.1f;
+	dl->decay = dl->radius / 0.05f;
+	dl->die = gpGlobals->curtime + 0.05f;
 	dl->color.r = 255;
 	dl->color.g = 192;
 	dl->color.b = 64;

--- a/src/game/shared/neo/weapons/weapon_grenade.cpp
+++ b/src/game/shared/neo/weapons/weapon_grenade.cpp
@@ -267,13 +267,7 @@ void CWeaponGrenade::ThrowGrenade(CNEO_Player *pPlayer, bool isAlive, CBaseEntit
 
 	Vector vecThrow = vForward * flVel + pPlayer->GetAbsVelocity();
 
-	// Sampled angular impulses from original NT frags:
-	// x: -584, 630, -1028, 967, -466, -535 (random, seems roughly in the same (-1200, 1200) range)
-	// y: 0 (constant)
-	// z: 600 (constant)
-	// This SDK original impulse line: AngularImpulse(600, random->RandomInt(-1200, 1200), 0)
-
-	CBaseGrenadeProjectile *pGrenade = NEOFraggrenade_Create(vecSrc, vec3_angle, vecThrow, AngularImpulse(random->RandomInt(-1200, 1200), 0, 600), ((!(pPlayer->IsAlive()) || !isAlive) && pAttacker) ? pAttacker : pPlayer, false);
+	CBaseGrenadeProjectile *pGrenade = NEOFraggrenade_Create(vecSrc, vec3_angle, vecThrow, AngularImpulse(600, random->RandomInt(-1200, 1200), 0), ((!(pPlayer->IsAlive()) || !isAlive) && pAttacker) ? pAttacker : pPlayer, false);
 
 	if (pGrenade)
 	{

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -990,9 +990,9 @@ void CNEOBaseCombatWeapon::ProcessMuzzleFlashEvent()
 	// environment light
 	dlight_t* el = effects->CL_AllocDlight(LIGHT_INDEX_MUZZLEFLASH + index);
 	el->origin = vAttachment;
-	el->radius = random->RandomInt(64, 96);
-	el->decay = el->radius / 0.1f;
-	el->die = gpGlobals->curtime + 0.1f;
+	el->radius = random->RandomInt(32, 64);
+	el->decay = el->radius / 0.05f;
+	el->die = gpGlobals->curtime + 0.05f;
 	el->color.r = 255;
 	el->color.g = 192;
 	el->color.b = 64;

--- a/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
+++ b/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
@@ -244,14 +244,7 @@ void CWeaponSmokeGrenade::ThrowGrenade(CNEO_Player* pPlayer, bool isAlive, CBase
 
 	Vector vecThrow = vForward * flVel + pPlayer->GetAbsVelocity();
 
-	// Sampled angular impulses from original NT frags:
-	// (Assuming here that smokes behave the same as frags.)
-	// x: -584, 630, -1028, 967, -466, -535 (random, seems roughly in the same (-1200, 1200) range)
-	// y: 0 (constant)
-	// z: 600 (constant)
-	// This SDK original impulse line: AngularImpulse(600, random->RandomInt(-1200, 1200), 0)
-
-	CBaseGrenadeProjectile* pGrenade = NEOSmokegrenade_Create(vecSrc, vec3_angle, vecThrow, AngularImpulse(random->RandomInt(-1200, 1200), 0, 600), ((!(pPlayer->IsAlive()) || !isAlive) && pAttacker) ? pAttacker : pPlayer);
+	CBaseGrenadeProjectile* pGrenade = NEOSmokegrenade_Create(vecSrc, vec3_angle, vecThrow, AngularImpulse(600, random->RandomInt(-1200, 1200), 0), ((!(pPlayer->IsAlive()) || !isAlive) && pAttacker) ? pAttacker : pPlayer);
 
 	if (pGrenade)
 	{


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

In the case of the grenade angular impulses we were previously using the values Rain calculated in-game. Using cl_pdump the angular velocity of the grenade projectile is 0 in all directions so I'm guessing Rain observed the angular position of the projectiles over time and calculated them that way. The reason these are probably wrong I'm guessing is because the order in which the position in the x y and z direction is displayed is not the same as the order in which the impulse in the three directions is passed in in the grenade projectile creation function. Here are the values for a grenade projectile in the original

![image](https://github.com/user-attachments/assets/5ca7bd6b-4a2c-4815-ad05-dda14f69d99f)

Once the base sdk angular impulse values are substituted in in rebuild, the angular position of the projectiles looks a lot more similar (notice the zeroed out middle column). This is despite the 0 value being the last of the three values passed for the angular impulse

![image](https://github.com/user-attachments/assets/4f15b24e-1df8-4a05-8824-c526face46ad)