### PR TITLE
fix floating viewmodels, skip unwanted observer modes, consistent observer mode on joining as spectator or spectating player, consistent info_player_start view position

### DIFF
--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -1101,6 +1101,7 @@ extern ConVar glow_outline_effect_enable;
 void C_NEO_Player::PreThink( void )
 {
 	BaseClass::PreThink();
+	engine->Con_NPrintf(0, "Observer Mode: %i", GetObserverMode());
 
 	CalculateSpeed();
 

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -1101,7 +1101,6 @@ extern ConVar glow_outline_effect_enable;
 void C_NEO_Player::PreThink( void )
 {
 	BaseClass::PreThink();
-	engine->Con_NPrintf(0, "Observer Mode: %i", GetObserverMode());
 
 	CalculateSpeed();
 

--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -395,11 +395,7 @@ void CHL2MP_Player::Spawn(void)
 
 	BaseClass::Spawn();
 
-#ifdef NEO
-	if ( !IsObserver() && GetTeamNumber() != TEAM_UNASSIGNED )
-#else
 	if ( !IsObserver() )
-#endif // NEO
 	{
 		pl.deadflag = false;
 		RemoveSolidFlags( FSOLID_NOT_SOLID );

--- a/src/game/server/neo/neo_client.cpp
+++ b/src/game/server/neo/neo_client.cpp
@@ -101,8 +101,7 @@ void FinishClientPutInServer( CNEO_Player *pPlayer )
 
 	// NEO TODO (Rain): Team selection HUD here.
 
-	// If player chooses to spectate upon joining, start in free roam mode.
-	pPlayer->StartObserverMode(OBS_MODE_ROAMING);
+	pPlayer->StartObserverMode(OBS_MODE_FIXED);
 }
 
 /*

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -600,10 +600,10 @@ void CNEO_Player::Spawn(void)
 	SetTransmitState(FL_EDICT_PVSCHECK);
 
 	SetPlayerTeamModel();
-	SetViewOffset(VEC_VIEW_NEOSCALE(this));
 	if (teamNumber == TEAM_JINRAI || teamNumber == TEAM_NSF)
 	{
 		GiveLoadoutWeapon();
+		SetViewOffset(VEC_VIEW_NEOSCALE(this));
 	}
 
 	if (teamNumber == TEAM_UNASSIGNED && gpGlobals->eLoadType != MapLoad_Background)
@@ -1661,6 +1661,7 @@ void CNEO_Player::CreateViewModel( int index )
 			DispatchSpawn(vm);
 			vm->FollowEntity(this, false);
 			m_hViewModel.Set(index, vm);
+			vm->AddEffects(EF_NODRAW);
 		}
 	}
 
@@ -1685,6 +1686,7 @@ void CNEO_Player::CreateViewModel( int index )
 		vmm->SetParent(vm);
 		DispatchSpawn(vmm);
 		m_hViewModel.Set(MUZZLE_FLASH_VIEW_MODEL_INDEX, vmm);
+		vmm->AddEffects(EF_NODRAW);
 	}
 }
 
@@ -2510,6 +2512,11 @@ void CNEO_Player::StopObserverMode()
 	BaseClass::StopObserverMode();
 }
 
+bool CNEO_Player::ModeWantsSpectatorGUI(int iMode)
+{ 
+	return iMode != OBS_MODE_FIXED;
+}
+
 bool CNEO_Player::CanHearAndReadChatFrom( CBasePlayer *pPlayer )
 {
 	return BaseClass::CanHearAndReadChatFrom(pPlayer);
@@ -2596,7 +2603,8 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 	}
 
 	const bool suicidePlayerIfAlive = sv_neo_change_suicide_player.GetBool();
-	if (iTeam == TEAM_SPECTATOR || iTeam == TEAM_UNASSIGNED)
+	bool changedTeams = false;
+	if (iTeam == TEAM_SPECTATOR)
 	{
 		if (!mp_allowspectators.GetInt())
 		{
@@ -2620,6 +2628,11 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 			}
 		}
 
+		// StartObserverMode and State_Transition will check whether we are on the Spectator team to decide whether to enforce certain camera modes, easier if we switch teams beforehand
+		CHL2_Player::ChangeTeam(iTeam, false, justJoined);
+		changedTeams = true;
+
+		State_Transition(STATE_OBSERVER_MODE);
 		// Default to free fly camera if there's nobody to spectate
 		if (justJoined || GetNumOtherPlayersConnected(this) == 0)
 		{
@@ -2627,9 +2640,11 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 		}
 		else
 		{
-			StartObserverMode(m_iObserverLastMode);
+			StartObserverMode(OBS_MODE_IN_EYE);
 		}
-
+	}
+	else if (iTeam == TEAM_UNASSIGNED)
+	{
 		State_Transition(STATE_OBSERVER_MODE);
 	}
 	else if (iTeam == TEAM_JINRAI || iTeam == TEAM_NSF)
@@ -2671,9 +2686,12 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 		SetPlayerTeamModel();
 	}
 
-	// We're skipping over HL2MP player because we don't care about
-	// deathmatch rules or Combine/Rebels model stuff.
-	CHL2_Player::ChangeTeam(iTeam, false, justJoined);
+	if (!changedTeams)
+	{
+		// We're skipping over HL2MP player because we don't care about
+		// deathmatch rules or Combine/Rebels model stuff.
+		CHL2_Player::ChangeTeam(iTeam, false, justJoined);
+	}
 	NEORules()->m_bThinkCheckClantags = true;
 
 	return true;

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -2662,7 +2662,11 @@ bool CNEO_Player::ProcessTeamSwitchRequest(int iTeam)
 			}
 		}
 
-		StopObserverMode();
+		CHL2_Player::ChangeTeam(iTeam, false, justJoined);
+		changedTeams = true;
+		
+		// If we're not allowed to be in the currect observer mode, this will give us a new observer mode.
+		SetObserverMode(GetObserverMode());
 	}
 	else
 	{

--- a/src/game/server/neo/neo_player.h
+++ b/src/game/server/neo/neo_player.h
@@ -116,6 +116,7 @@ public:
 
 	virtual bool StartObserverMode(int mode) OVERRIDE;
 	virtual void StopObserverMode(void) OVERRIDE;
+	virtual bool ModeWantsSpectatorGUI(int iMode) override;
 
 	virtual bool	CanHearAndReadChatFrom(CBasePlayer *pPlayer) OVERRIDE;
 

--- a/src/game/shared/gamerules.cpp
+++ b/src/game/shared/gamerules.cpp
@@ -191,10 +191,11 @@ CBaseEntity *CGameRules::GetPlayerSpawnSpot( CBasePlayer *pPlayer )
 	CBaseEntity *pSpawnSpot = pPlayer->EntSelectSpawnPoint();
 	Assert( pSpawnSpot );
 #ifdef NEO
-	Vector spawnPosition = pSpawnSpot->GetAbsOrigin() + Vector(0, 0, 1);
-	if (!Q_strcmp( pSpawnSpot->m_iClassname.ToCStr(), "info_player_start" ) )
-	{
-		spawnPosition += Vector(0, 0, 64);
+	Vector spawnPosition = pSpawnSpot->GetAbsOrigin();
+	if ( !Q_strcmp( pSpawnSpot->m_iClassname.ToCStr(), "info_player_start" ) )
+	{ // at the map preview position, we want everyone's eyes to be in the same position NEO TODO (Adam) should we remove this offset and make the info_player_start origin the camera origin? Would need to move all info_player_start s 
+		// in the base maps, and the current info_player_start preview model wouldn't make as much sense (a small camera looking box would then be better), but would be easier for mappers to get the right position
+		spawnPosition = spawnPosition - pPlayer->GetViewOffset() + Vector(0, 0, 65);
 	}
 	pPlayer->SetLocalOrigin( spawnPosition );
 #else


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

This PR does a few things:

1. Remove floating view models. The only way to trigger this issue that I've found so far is to open up a map, go straight to spectator and start spectating a bot through their eyes, while looking towards the map origin. Since we didn't join any of the game teams, our character did not yet have a chance to un-equip their weapons and so the corresponding viewmodels did not have the EF_NODRAW flag. Setting this flag on viewmodel creation fixes this problem.
2. TEAM_UNASSIGNED observer mode. I decided to make the OBS_MODE_FIXED a kind of team_unassigned exclusive. I use it to decide whether to draw the spectate_gui, and I try to avoid it at all cost for players who are in spectate (though there are still ways of getting in that mode as a spectator if things go wrong). As a spectator, I changed how we put the player into observer mode so they should always default to freecam, avoid obs_mode_fixed and avoid observer modes related to tracking players if there are no players worth observing. Changing the ordering of when the player is put on the team and the observer mode is set ensures we do not struggle to find a valid observing target as a result of the rules specifying which observer mode we are allowed to enter.
3. Map preview camera position. When the player initially spawns and is set to team unassigned, their view offset is 0 0 0, but once the game starts their offset is set to their class view offset even though they are not playing. I've changed the neoplayer spawn function to only set this offset if the player is on a game team, and also changed the behavior when spawning in the info_player_start position to position the players camera at the same height always. This is not parity but I think this is much better. I don't think info_player_start was intended for players to ever spawn in as a playing player, so we could probably remove this offset and change the entity positions in all the maps so the origin of the entity is where the player view will be, but that's something for the future I think.

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #273
- fixes #797
- related #976
