### PR TITLE
OnCompetitive

### DIFF
--- a/src/game/server/neo/neo_game_config.cpp
+++ b/src/game/server/neo/neo_game_config.cpp
@@ -18,7 +18,8 @@ BEGIN_DATADESC(CNEOGameConfig)
 	DEFINE_INPUTFUNC(FIELD_VOID, "FireRoundTie", InputFireRoundTie),
 
 	DEFINE_OUTPUT(m_OnRoundEnd, "OnRoundEnd"),
-	DEFINE_OUTPUT(m_OnRoundStart, "OnRoundStart")
+	DEFINE_OUTPUT(m_OnRoundStart, "OnRoundStart"),
+	DEFINE_OUTPUT(m_OnCompetitive, "OnCompetitive")
 END_DATADESC()
 
 CNEOGameConfig* CNEOGameConfig::s_pGameRulesToConfig = nullptr;
@@ -68,4 +69,9 @@ void CNEOGameConfig::OutputRoundEnd()
 void CNEOGameConfig::OutputRoundStart()
 {
 	m_OnRoundStart.FireOutput(NULL, this);
+}
+
+void CNEOGameConfig::OutputCompetitive()
+{
+	m_OnCompetitive.FireOutput(NULL, this);
 }

--- a/src/game/server/neo/neo_game_config.h
+++ b/src/game/server/neo/neo_game_config.h
@@ -28,7 +28,9 @@ public:
 	// Outputs
 	void OutputRoundEnd();
 	void OutputRoundStart();
+	void OutputCompetitive();
 
 	COutputEvent m_OnRoundEnd;
 	COutputEvent m_OnRoundStart;
+	COutputEvent m_OnCompetitive;
 };

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -799,6 +799,11 @@ void CNEORules::CheckGameType()
 	m_bGamemodeTypeBeenInitialized = true;
 	iStaticInitOnCmd = iGamemodeEnforce;
 	iStaticInitOnRandAllow = iGamemodeRandAllow;
+
+	if (CNEOGameConfig::s_pGameRulesToConfig && sv_neo_comp.GetBool())
+	{
+		CNEOGameConfig::s_pGameRulesToConfig->OutputCompetitive();
+	}
 }
 
 void CNEORules::CheckHiddenHudElements()
@@ -2394,6 +2399,11 @@ void CNEORules::CleanUpMap()
 	MapEntity_ParseAllEntities(engine->GetMapEntitiesString(), &filter, true);
 
 	ResetGhostCapPoints();
+
+	if (CNEOGameConfig::s_pGameRulesToConfig && sv_neo_comp.GetBool())
+	{
+		CNEOGameConfig::s_pGameRulesToConfig->OutputCompetitive();
+	}
 }
 
 void CNEORules::CheckRestartGame()


### PR DESCRIPTION
## Description
Output for neo_game_config that is fired on map load and every map reset is sv_neo_comp = 1

This is added so that mappers do not need to manage multiple maps to cater for casual & competitive environments. Everything can be toggled via this output

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022



