### PR TITLE
[Regression Fix] Active weapons falling through floor on death

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -1371,9 +1371,11 @@ void CHL2MP_Player::Event_Killed( const CTakeDamageInfo &info )
 	CTakeDamageInfo subinfo = info;
 	subinfo.SetDamageForce( m_vecTotalBulletForce );
 
+#ifndef NEO
 	// Note: since we're dead, it won't draw us on the client, but we don't set EF_NODRAW
 	// because we still want to transmit to the clients in our PVS.
 	CreateRagdollEntity();
+#endif // NEO
 
 	DetonateTripmines();
 

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1925,8 +1925,6 @@ void CNEO_Player::Event_Killed( const CTakeDamageInfo &info )
 			Weapon_DropOnDeath(pWep, forceVector, info.GetAttacker());
 		}
 	}
-	
-	BaseClass::Event_Killed(info);
 
 	if (!IsBot() && !IsHLTV())
 	{
@@ -1937,6 +1935,8 @@ void CNEO_Player::Event_Killed( const CTakeDamageInfo &info )
 	{
 		GetGlobalTeam(NEORules()->GetOpposingTeam(this))->AddScore(1);
 	}
+
+	BaseClass::Event_Killed(info);
 
 	// Handle Corpse and Gibs
 	if (!m_bCorpseSet) // Event_Killed can be called multiple times, only set the dead model and spawn gibs once

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1896,7 +1896,7 @@ void CNEO_Player::AddPoints(int score, bool bAllowNegativeScore)
 
 void CNEO_Player::Event_Killed( const CTakeDamageInfo &info )
 {
-	BaseClass::Event_Killed(info);
+	CreateRagdollEntity();
 
 	// Calculate force for weapon drop
 	Vector forceVector = CalcDamageForceVector(info);
@@ -1925,6 +1925,8 @@ void CNEO_Player::Event_Killed( const CTakeDamageInfo &info )
 			Weapon_DropOnDeath(pWep, forceVector, info.GetAttacker());
 		}
 	}
+	
+	BaseClass::Event_Killed(info);
 
 	if (!IsBot() && !IsHLTV())
 	{


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Move ragdoll creation from hl2mp_player::Event_Killed to neo_player::Event_Killed, move call to baseclass Event_Killed to after our custom weapon dropping code is ran, back to where it was originally

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1028