### PR TITLE
Supa7 viewmodel reset during reload, and grenade viewmodel throw animation during pin pull animation fixes

### DIFF
--- a/src/game/shared/neo/weapons/weapon_grenade.cpp
+++ b/src/game/shared/neo/weapons/weapon_grenade.cpp
@@ -194,7 +194,7 @@ void CWeaponGrenade::ItemPostFrame(void)
 			switch (m_AttackPaused)
 			{
 			case GRENADE_PAUSED_PRIMARY:
-				if (!(pOwner->m_nButtons & IN_ATTACK))
+				if (!(pOwner->m_nButtons & IN_ATTACK) && gpGlobals->curtime >= m_flNextPrimaryAttack)
 				{
 					ThrowGrenade(pOwner);
 

--- a/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
+++ b/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
@@ -171,7 +171,7 @@ void CWeaponSmokeGrenade::ItemPostFrame(void)
 			switch (m_AttackPaused)
 			{
 			case GRENADE_PAUSED_PRIMARY:
-				if (!(pOwner->m_nButtons & IN_ATTACK))
+				if (!(pOwner->m_nButtons & IN_ATTACK) && gpGlobals->curtime >= m_flNextPrimaryAttack)
 				{
 					ThrowGrenade(pOwner);
 

--- a/src/game/shared/neo/weapons/weapon_supa7.cpp
+++ b/src/game/shared/neo/weapons/weapon_supa7.cpp
@@ -522,7 +522,11 @@ void CWeaponSupa7::ItemPostFrame(void)
 				}
 			}
 		}
-		WeaponIdle();
+
+		if (!m_bInReload)
+		{
+			WeaponIdle();
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Small tweaks to the supa7 and grenades to make the viewmodel animations smoother.

For the supa7, this fixes the problem where tapping the reload button quickly right after firing causes the weapon to return to the idle viewmodel animation for a split second during the reload.

Here is a video showing the problem
https://github.com/user-attachments/assets/a186665f-2dfc-4f3a-9012-351a3bb96598


For the grenades, this fixes the problem where tapping the attack key to throw a grenade causes the grenade throw animation to be played in the middle of the pin pull animation. difficult to replicate, I had the most success replicating this by tapping the attack key quickly towards the end of the ACT_VM_DRAW animation

Here is a video where the second throw has this animation discrepancy
https://github.com/user-attachments/assets/b1f36b9e-275a-4446-8b60-041fb1a4a53a
