### PR TITLE
Func_rotating moving sound fix

### DIFF
--- a/src/game/server/bmodels.cpp
+++ b/src/game/server/bmodels.cpp
@@ -921,6 +921,9 @@ void CFuncRotating::UpdateSpeed( float flNewSpeed )
 				m_flSpeed = 0.0f;
 
 				SetLocalAngles( m_angStart );
+#ifdef NEO
+				StopSound(entindex(), CHAN_STATIC, STRING(m_NoiseRunning));
+#endif
 			}
 			else if ( fabs( angDelta ) > 90.0f )
 			{
@@ -1307,6 +1310,9 @@ void CFuncRotating::InputStop( inputdata_t &inputdata )
 {
 	m_bStopAtStartPos = false;
 	SetTargetSpeed( 0 );
+#ifdef NEO
+	StopSound(entindex(), CHAN_STATIC, STRING(m_NoiseRunning));
+#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Hamfisted fix to prevent looping move sounds from playing when the entity isn't moving

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022


