### PR TITLE
Ready up - Add countdown stage before the match starts

### DIFF
--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -204,9 +204,18 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	const bool inSuddenDeath = NEORules()->RoundIsInSuddenDeath();
 	const bool inMatchPoint = NEORules()->RoundIsMatchPoint();
 
-	m_pWszStatusUnicode = (roundStatus == NeoRoundStatus::Warmup) ? L"Warmup" : L"";
-	if (roundStatus == NeoRoundStatus::Idle) {
+	m_pWszStatusUnicode = L"";
+	if (roundStatus == NeoRoundStatus::Idle)
+	{
 		m_pWszStatusUnicode = sv_neo_readyup_lobby.GetBool() ? L"Waiting for players to ready up" : L"Waiting for players";
+	}
+	else if (roundStatus == NeoRoundStatus::Warmup)
+	{
+		m_pWszStatusUnicode = L"Warmup";
+	}
+	else if (roundStatus == NeoRoundStatus::Countdown)
+	{
+		m_pWszStatusUnicode = L"Match is starting...";
 	}
 	else if (inSuddenDeath)
 	{
@@ -241,6 +250,10 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	{
 		m_iWszRoundUCSize = V_swprintf_safe(m_wszRoundUnicode, L"PAUSED");
 		roundTimeLeft = NEORules()->m_flPauseEnd.Get() - gpGlobals->curtime;
+	}
+	else if (NEORules()->GetRoundStatus() == NeoRoundStatus::Countdown)
+	{
+		m_iWszRoundUCSize = V_swprintf_safe(m_wszRoundUnicode, L"COUNTDOWN");
 	}
 	else
 	{
@@ -351,7 +364,8 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 		break;
 	}
 
-	if (NEORules()->GetRoundStatus() == NeoRoundStatus::Pause)
+	if (NEORules()->GetRoundStatus() == NeoRoundStatus::Pause ||
+			NEORules()->GetRoundStatus() == NeoRoundStatus::Countdown)
 	{
 		szGameTypeDescription[0] = '\0';
 	}
@@ -421,7 +435,8 @@ void CNEOHud_RoundState::DrawNeoHudElement()
 	// Draw time
 	surface()->DrawSetTextFont(m_hOCRFont);
 	surface()->GetTextSize(m_hOCRFont, m_wszTime, fontWidth, fontHeight);
-	surface()->DrawSetTextColor(NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze ?
+	surface()->DrawSetTextColor((NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze ||
+								 NEORules()->GetRoundStatus() == NeoRoundStatus::Countdown) ?
 									COLOR_RED : COLOR_WHITE);
 	surface()->DrawSetTextPos(m_iXpos - (fontWidth / 2), m_iBoxYEnd / 2 - fontHeight / 2);
 	surface()->DrawPrintText(m_wszTime, 6);

--- a/src/game/client/neo/ui/neo_hud_round_state.h
+++ b/src/game/client/neo/ui/neo_hud_round_state.h
@@ -98,6 +98,8 @@ private:
 	int m_iGraphicID[NEO_CLASS__ENUM_COUNT] = {};
 	TeamLogoColor m_teamLogoColors[TEAM__TOTAL] = {};
 
+	int m_iBeepSecsTotal = 0;
+	NeoRoundStatus m_ePrevRoundStatus = NeoRoundStatus::Idle;
 
 	CPanelAnimationVar(Color, box_color, "box_color", "200 200 200 40");
 	CPanelAnimationVarAliasType(bool, health_monochrome, "health_monochrome", "1", "bool");

--- a/src/game/server/neo/neo_client.cpp
+++ b/src/game/server/neo/neo_client.cpp
@@ -324,6 +324,8 @@ void Precache_NEO_Sounds( void )
 	CBaseEntity::PrecacheScriptSound("Victory.Draw");
 	CBaseEntity::PrecacheScriptSound("Victory.Jinrai");
 	CBaseEntity::PrecacheScriptSound("Victory.NSF");
+
+	CBaseEntity::PrecacheSound("tutorial/hitsound.wav");
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -152,7 +152,7 @@ void CNEO_Player::RequestSetClass(int newClass)
 	if (IsDead() || sv_neo_can_change_classes_anytime.GetBool() ||
 		(!m_bIneligibleForLoadoutPick && NEORules()->GetRemainingPreRoundFreezeTime(false) > 0) ||
 		(bIsTypeDM && !m_bIneligibleForLoadoutPick && GetAliveDuration() < sv_neo_dm_max_class_dur.GetFloat()) ||
-		(status == NeoRoundStatus::Idle || status == NeoRoundStatus::Warmup))
+		(status == NeoRoundStatus::Idle || status == NeoRoundStatus::Warmup || status == NeoRoundStatus::Countdown))
 	{
 		m_iNeoClass = newClass;
 		m_iNextSpawnClassChoice = -1;
@@ -2744,7 +2744,8 @@ int	CNEO_Player::OnTakeDamage_Alive(const CTakeDamageInfo& info)
 	{
 		if (sv_neo_warmup_godmode.GetBool() &&
 				(NEORules()->GetRoundStatus() == NeoRoundStatus::Idle ||
-				 NEORules()->GetRoundStatus() == NeoRoundStatus::Warmup))
+				 NEORules()->GetRoundStatus() == NeoRoundStatus::Warmup ||
+				 NEORules()->GetRoundStatus() == NeoRoundStatus::Countdown))
 		{
 			return 0;
 		}
@@ -2890,7 +2891,7 @@ ConVar sv_neo_time_alive_until_cant_change_loadout("sv_neo_time_alive_until_cant
 void CNEO_Player::GiveLoadoutWeapon(void)
 {
 	const NeoRoundStatus status = NEORules()->GetRoundStatus();
-	if (!(status == NeoRoundStatus::Idle || status == NeoRoundStatus::Warmup) &&
+	if (!(status == NeoRoundStatus::Idle || status == NeoRoundStatus::Warmup || status == NeoRoundStatus::Countdown) &&
 		(IsObserver() || IsDead() || m_bIneligibleForLoadoutPick
 		 || m_aliveTimer.IsGreaterThen(sv_neo_time_alive_until_cant_change_loadout.GetFloat())))
 	{

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -848,39 +848,6 @@ void CNEORules::Think(void)
 		return;
 	}
 
-	if (m_nRoundStatus == NeoRoundStatus::Countdown && gpGlobals->curtime > (m_flPrevCountdownBeep + 1.0f))
-	{
-		EmitSound_t soundParams;
-		soundParams.m_nChannel = CHAN_AUTO;
-		soundParams.m_SoundLevel = SNDLVL_NONE;
-		soundParams.m_flVolume = 0.33f;
-		soundParams.m_pSoundName = "tutorial/hitsound.wav";
-		soundParams.m_bWarnOnDirectWaveReference = false;
-		soundParams.m_bEmitCloseCaption = false;
-
-		for (int i = 1; i <= gpGlobals->maxClients; ++i)
-		{
-			CBasePlayer* basePlayer = UTIL_PlayerByIndex(i);
-			auto player = static_cast<CNEO_Player*>(basePlayer);
-			if (player)
-			{
-				if (!player->IsBot() || player->IsHLTV())
-				{
-					const char* volStr = engine->GetClientConVarValue(i, snd_victory_volume.GetName());
-					const float jingleVolume = volStr ? atof(volStr) : 0.33f;
-					soundParams.m_flVolume = jingleVolume;
-
-					CRecipientFilter soundFilter;
-					soundFilter.AddRecipient(basePlayer);
-					soundFilter.MakeReliable();
-					player->EmitSound(soundFilter, i, soundParams);
-				}
-			}
-		}
-
-		m_flPrevCountdownBeep = gpGlobals->curtime;
-	}
-
 	const bool bIsIdleState = m_nRoundStatus == NeoRoundStatus::Idle
 			|| m_nRoundStatus == NeoRoundStatus::Warmup
 			|| m_nRoundStatus == NeoRoundStatus::Countdown;

--- a/src/game/shared/neo/neo_gamerules.h
+++ b/src/game/shared/neo/neo_gamerules.h
@@ -419,7 +419,6 @@ private:
 	int m_iEntPrevCapSize = 0;
 	int m_iPrintHelpCounter = 0;
 	bool m_bGamemodeTypeBeenInitialized = false;
-	float m_flPrevCountdownBeep = 0.0f;
 #endif
 	CNetworkVar(int, m_nRoundStatus);
 	CNetworkVar(int, m_iHiddenHudElements);

--- a/src/game/shared/neo/neo_gamerules.h
+++ b/src/game/shared/neo/neo_gamerules.h
@@ -121,6 +121,7 @@ enum NeoRoundStatus {
 	RoundLive,
 	PostRound,
 	Pause,
+	Countdown,
 };
 
 enum NeoWinReason {
@@ -418,6 +419,7 @@ private:
 	int m_iEntPrevCapSize = 0;
 	int m_iPrintHelpCounter = 0;
 	bool m_bGamemodeTypeBeenInitialized = false;
+	float m_flPrevCountdownBeep = 0.0f;
 #endif
 	CNetworkVar(int, m_nRoundStatus);
 	CNetworkVar(int, m_iHiddenHudElements);


### PR DESCRIPTION

<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* A round status that goes between when all teams are fully ready and before the first round goes live
* Also beep sound (clientside) during countdown

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1022

