### PR TITLE
Short pause 1min, sv_neo_comp do pause cvar, print fix

### DIFF
--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1621,14 +1621,14 @@ bool CNEO_Player::ClientCommand( const CCommand &args )
 				// - If during live-round, after round finishes pausing
 				NEORules()->m_iPausingTeam = GetTeamNumber();
 				NEORules()->m_iPausingRound = NEORules()->roundNumber() + 1;
-				NEORules()->m_flPauseDur = (slot == PAUSE_MENU_SELECT_SHORT) ? 30.0f : 180.0f;
+				NEORules()->m_flPauseDur = (slot == PAUSE_MENU_SELECT_SHORT) ? 60.0f : 180.0f;
 
 				char szPauseMsg[128];
 				V_sprintf_safe(szPauseMsg, "Pause requested by %s. Pausing the match %s for %s.",
 							   (GetTeamNumber() == TEAM_JINRAI) ? "Jinrai" : "NSF",
 							   (NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze) ?
 								   "immediately" : "when the round ends",
-							   (slot == PAUSE_MENU_SELECT_SHORT) ? "30 seconds" : "3 minutes");
+							   (slot == PAUSE_MENU_SELECT_SHORT) ? "1 minute" : "3 minutes");
 				UTIL_ClientPrintAll(HUD_PRINTTALK, szPauseMsg);
 			}
 			break;


### PR DESCRIPTION



<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Short pause is now 1 min
* `sv_neo_comp 1` fixed to turn on pausing
* Fixed chat .help print limit when having both lobby and pause enabled

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Arch/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

* fixes #1070

