### PR TITLE
func_detail_blocker support

### DIFF
--- a/src/game/server/effects.cpp
+++ b/src/game/server/effects.cpp
@@ -1522,6 +1522,19 @@ void CPrecipitation::Spawn( void )
 }
 #endif
 
+#ifdef NEO
+class CDetailBlocker : public CServerOnlyEntity
+{
+	DECLARE_CLASS( CDetailBlocker, CServerOnlyEntity );
+public:
+
+	CDetailBlocker() : CServerOnlyEntity() {}
+	virtual ~CDetailBlocker() {}
+};
+
+LINK_ENTITY_TO_CLASS( func_detail_blocker, CDetailBlocker );
+#endif
+
 //-----------------------------------------------------------------------------
 // EnvWind - global wind info
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Just stops the error from popping up in maps that use it.
The compiler should just delete the entity when it's done with it, but it doesn't, so

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
