### PR TITLE
More lenient lean around corners, harsher unlean when running into a wall

### DIFF
--- a/src/game/shared/neo/neo_predicted_viewmodel.cpp
+++ b/src/game/shared/neo/neo_predicted_viewmodel.cpp
@@ -391,7 +391,10 @@ float CNEOPredictedViewModel::lean(CNEO_Player *player){
 
 	if (diff != 0)
 	{
-		if (leanObstacle && abs(m_flLeanRatio) > abs(leanRatio))
+		bool currentGreaterThanZero = m_flLeanRatio > 0;
+		bool targetGreaterThanZero = leanRatio > 0;
+		bool sameSide = (currentGreaterThanZero && targetGreaterThanZero) || (!currentGreaterThanZero && !targetGreaterThanZero);
+		if (leanObstacle && sameSide && abs(m_flLeanRatio) > abs(leanRatio))
 		{ // If running into a wall, bring us back immediately to minimize camera clipping through wall. A bit jarring maybe, but maybe running your head into a wall should be
 			m_flLeanRatio = leanRatio;
 		}

--- a/src/game/shared/neo/neo_predicted_viewmodel.h
+++ b/src/game/shared/neo/neo_predicted_viewmodel.h
@@ -31,7 +31,7 @@ public:
 	virtual void CalcViewModelView(CBasePlayer *pOwner,
 		const Vector& eyePosition, const QAngle& eyeAngles);
 
-	float freeRoomForLean(float leanAmount, CNEO_Player *player);
+	float freeRoomForLean(float leanAmount, CNEO_Player *player, bool &leanObstacle);
 
 	// Returns the amount of pelvis rotation expected of player bone controller.
 	float lean(CNEO_Player *player);


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

When standing right up against a wall and peeking around a corner, moving the aim point to the left of the line running perpendicular to the wall that you're standing against will cause the player to begin un-leaning immediately due to the collision with the wall, throwing the aim off. This PR allows the aim to be moved further to the left before the character begins unleaning.

![image](https://github.com/user-attachments/assets/42a9e100-9539-4eaf-b594-2cca7e48a10e)

This pr also makes unleaning when hitting an obstacle instant, to prevent the camera from clipping through the wall. It's still possible to an extend, may have to increase the trace distance but then not factor that value into the return percentage in freeroomforlean

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

