### PR TITLE
Spectate viewmodel missing in some situations

### DIFF
--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -1310,7 +1310,7 @@ void C_NEO_Player::PostThink(void)
 
 	if (IsLocalPlayer())
 	{
-		neo_this_client_speed.SetValue(MIN(GetAbsVelocity().Length2D() / GetNormSpeed(), 1.0f));
+	neo_this_client_speed.SetValue(MIN(GetAbsVelocity().Length2D() / GetNormSpeed(), 1.0f));
 	}
 
 	if (!IsAlive())
@@ -1366,16 +1366,6 @@ void C_NEO_Player::PostThink(void)
 				.a = 255,
 			};
 			vieweffects->Fade(sfade);
-
-			auto target = GetObserverTarget();
-			if (!IsValidObserverTarget(target))
-			{
-				auto nextTarget = FindNextObserverTarget(false);
-				if (nextTarget && nextTarget != target)
-				{
-					SetObserverTarget(nextTarget);
-				}
-			}
 		}
 		return;
 	}
@@ -1741,40 +1731,6 @@ float C_NEO_Player::GetSprintSpeed(void) const
 	default:
 		return NEO_BASE_SPEED; // No generic sprint modifier; default speed.
 	}
-}
-
-void C_NEO_Player::CalcChaseCamView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov)
-{
-	if (!HandleDeathSpecCamSwitch(eyeOrigin, eyeAngles, fov))
-	{
-		BaseClass::CalcChaseCamView(eyeOrigin, eyeAngles, fov);
-	}
-}
-
-void C_NEO_Player::CalcInEyeCamView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov)
-{
-	if (!HandleDeathSpecCamSwitch(eyeOrigin, eyeAngles, fov))
-	{
-		BaseClass::CalcInEyeCamView(eyeOrigin, eyeAngles, fov);
-	}
-}
-
-bool C_NEO_Player::HandleDeathSpecCamSwitch(Vector& eyeOrigin, QAngle& eyeAngles, float& fov)
-{
-	fov = GetFOV(); // jic the caller relies on us initializing this
-	auto target = GetObserverTarget();
-	if (!IsValidObserverTarget(target))
-	{
-		auto nextTarget = FindNextObserverTarget(false);
-		if (nextTarget && nextTarget != target)
-		{
-			SetObserverTarget(nextTarget);
-		}
-		VectorCopy(EyePosition(), eyeOrigin);
-		VectorCopy(EyeAngles(), eyeAngles);
-		return true;
-	}
-	return false;
 }
 
 float C_NEO_Player::GetActiveWeaponSpeedScale() const

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -1310,7 +1310,7 @@ void C_NEO_Player::PostThink(void)
 
 	if (IsLocalPlayer())
 	{
-	neo_this_client_speed.SetValue(MIN(GetAbsVelocity().Length2D() / GetNormSpeed(), 1.0f));
+		neo_this_client_speed.SetValue(MIN(GetAbsVelocity().Length2D() / GetNormSpeed(), 1.0f));
 	}
 
 	if (!IsAlive())

--- a/src/game/client/neo/c_neo_player.h
+++ b/src/game/client/neo/c_neo_player.h
@@ -103,9 +103,6 @@ public:
 	virtual const Vector GetPlayerMins(void) const OVERRIDE;
 	virtual const Vector GetPlayerMaxs(void) const OVERRIDE;
 
-	virtual void CalcChaseCamView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov) override;
-	virtual void CalcInEyeCamView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov) override;
-
 	float CloakPower_CurrentVisualPercentage(void) const;
 
 	float GetNormSpeed_WithActiveWepEncumberment(void) const;
@@ -125,8 +122,6 @@ public:
 
 private:
 	float GetActiveWeaponSpeedScale() const;
-
-	bool HandleDeathSpecCamSwitch(Vector& eyeOrigin, QAngle& eyeAngles, float& fov);
 
 public:
 	float m_flSpecFOV = 0.0f;

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1316,6 +1316,35 @@ void CNEO_Player::PostThink(void)
 			m_bInLean = NEO_LEAN_NONE;
 		}
 
+		auto observerMode = GetObserverMode();
+		if (observerMode == OBS_MODE_CHASE || observerMode == OBS_MODE_IN_EYE)
+		{
+			auto target = GetObserverTarget();
+			if (!IsValidObserverTarget(target))
+			{
+				auto nextTarget = FindNextObserverTarget(false);
+				if (nextTarget && nextTarget != target)
+				{
+					SetObserverTarget(nextTarget);
+				}
+			}
+		}
+
+		if ((observerMode == OBS_MODE_DEATHCAM || observerMode == OBS_MODE_NONE) && gpGlobals->curtime >= (GetDeathTime() + DEATH_ANIMATION_TIME))
+		{ // We switch observer mode to none to view own body in third person so assume should still be changing observer targets
+			auto target = GetObserverTarget();
+			if (!IsValidObserverTarget(target))
+			{
+				auto nextTarget = FindNextObserverTarget(false);
+				if (nextTarget && nextTarget != target)
+				{
+					SetObserverTarget(nextTarget);
+				}
+			}
+			SetObserverMode(OBS_MODE_IN_EYE);
+		}
+
+
 		return;
 	}
 	else

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -2782,7 +2782,12 @@ bool CBasePlayer::IsValidObserverTarget(CBaseEntity * target)
 
 	if ( player->m_lifeState == LIFE_DEAD || player->m_lifeState == LIFE_DYING )
 	{
+#ifdef NEO
+		constexpr int DEATH_SPEC_TIME = 3.0f; // OGNT switches spectator targets much faster than the DEATH_ANIMATION_TIME
+		if ((player->m_flDeathTime + DEATH_SPEC_TIME) < gpGlobals->curtime)
+#else
 		if ( (player->m_flDeathTime + DEATH_ANIMATION_TIME ) < gpGlobals->curtime )
+#endif // NEO
 		{
 			return false;	// allow watching until 3 seconds after death to see death animation
 		}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Moves calls to setspectatetarget server side to avoid mismatch between client and server spectatetarget

(NOTE) This does not fix the viewmodels not showing up sometimes on bots when bot_attack is set to 1

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1058
- fixes #929
