### PR TITLE
Fix players spawning inside eachother, spawnpoint features, small code cleanup

### DIFF
--- a/src/game/server/neo/neo_game_config.cpp
+++ b/src/game/server/neo/neo_game_config.cpp
@@ -36,7 +36,7 @@ void CNEOGameConfig::Spawn()
 void CNEOGameConfig::InputFireTeamWin(inputdata_t& inputData)
 {
 	int team = inputData.value.Int();
-	static_cast<CNEORules*>(g_pGameRules)->SetWinningTeam(team, NEO_VICTORY_MAPIO, false, true, false, false);
+	NEORules()->SetWinningTeam(team, NEO_VICTORY_MAPIO, false, true, false, false);
 }
 
 void CNEOGameConfig::InputFireDMPlayerWin(inputdata_t& inputData)
@@ -50,13 +50,13 @@ void CNEOGameConfig::InputFireDMPlayerWin(inputdata_t& inputData)
 
 	if (pPlayer)
     {
-        static_cast<CNEORules*>(g_pGameRules)->SetWinningDMPlayer(static_cast<CNEO_Player*>(pPlayer));
+        NEORules()->SetWinningDMPlayer(static_cast<CNEO_Player*>(pPlayer));
     }
 }
 
 void CNEOGameConfig::InputFireRoundTie(inputdata_t& inputData)
 {
-	static_cast<CNEORules*>(g_pGameRules)->SetWinningTeam(1, NEO_VICTORY_STALEMATE, false, true, true, false);
+	NEORules()->SetWinningTeam(1, NEO_VICTORY_STALEMATE, false, true, true, false);
 }
 
 // Outputs

--- a/src/game/shared/gamerules.cpp
+++ b/src/game/shared/gamerules.cpp
@@ -237,8 +237,11 @@ bool CGameRules::IsSpawnPointValid( CBaseEntity *pSpot, CBasePlayer *pPlayer  )
 	{
 		return false;
 	}
-
+#ifdef NEO
 	for ( CEntitySphereQuery sphere( pSpot->GetAbsOrigin(), 16 ); (ent = sphere.GetCurrentEntity()) != NULL; sphere.NextEntity() )
+#else
+	for ( CEntitySphereQuery sphere( pSpot->GetAbsOrigin(), 128 ); (ent = sphere.GetCurrentEntity()) != NULL; sphere.NextEntity() )
+#endif
 	{
 		// if ent is a client, don't spawn on 'em
 		if ( ent->IsPlayer() && ent != pPlayer )

--- a/src/game/shared/neo/neo_player_spawnpoint.cpp
+++ b/src/game/shared/neo/neo_player_spawnpoint.cpp
@@ -39,6 +39,14 @@ END_RECV_TABLE()
 #endif
 
 BEGIN_DATADESC(CNEOSpawnPoint)
+#ifdef GAME_DLL
+	DEFINE_KEYFIELD(m_bDisabled, FIELD_BOOLEAN, "StartDisabled"),
+
+	DEFINE_INPUTFUNC(FIELD_VOID, "Enable", InputEnable),
+	DEFINE_INPUTFUNC(FIELD_VOID, "Disable", InputDisable),
+
+	DEFINE_OUTPUT(m_OnPlayerSpawn, "OnPlayerSpawn")
+#endif
 END_DATADESC()
 
 CNEOSpawnPoint::CNEOSpawnPoint()
@@ -64,3 +72,15 @@ void CNEOSpawnPoint::Spawn()
 		GetAbsOrigin().x, GetAbsOrigin().y, GetAbsOrigin().z);
 #endif
 }
+
+#ifdef GAME_DLL
+void CNEOSpawnPoint::InputEnable(inputdata_t& inputData)
+{
+	m_bDisabled = false;
+}
+
+void CNEOSpawnPoint::InputDisable(inputdata_t& inputData)
+{
+	m_bDisabled = true;
+}
+#endif

--- a/src/game/shared/neo/neo_player_spawnpoint.h
+++ b/src/game/shared/neo/neo_player_spawnpoint.h
@@ -28,6 +28,15 @@ public:
 
 	virtual void Spawn();
 
+#ifdef GAME_DLL
+	bool m_bDisabled;
+
+	void InputEnable(inputdata_t& inputdata);
+	void InputDisable(inputdata_t& inputdata);
+
+	COutputEvent m_OnPlayerSpawn;
+#endif
+
 protected:
 	int m_iOwningTeam;
 


### PR DESCRIPTION
## Description
Title. If a player spawned at a spawn within 128 units of another spawn it would make the other spawn not valid, causing players to spawn inside other players
It might be better to have a more robust way of checking if a player has been spawned at a point but IDK.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1099 

