### PR TITLE
Show FetchContent output by default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 set(OUTPUT_SUBDIRECTORY out)
 
+set(FETCHCONTENT_QUIET FALSE CACHE BOOL "Hide all FetchContent population output")
+
 include(cmake/utils.cmake)
 include(cmake/build_info.cmake)
 
@@ -430,6 +432,8 @@ if(NEO_GENERATE_GAMEDATA)
         gamedata-gen
         URL https://github.com/NeotokyoRebuild/gamedata-gen/releases/download/v2/gamedata-gen.zip
         URL_HASH MD5=2a988c84e7e192d33819868c37ad3150
+        GIT_PROGRESS TRUE
+        USES_TERMINAL_DOWNLOAD TRUE
     )
 
     FetchContent_MakeAvailable(gamedata-gen)
@@ -587,6 +591,8 @@ if(NEO_EXTRA_ASSETS)
         GIT_REPOSITORY https://github.com/NeotokyoRebuild/neoAssets.git
         GIT_TAG master # Replace with a commit hash or other tag to select a specific version of the assets, remove GIT_SHALLOW if using commit hash
         GIT_SHALLOW 1
+        GIT_PROGRESS TRUE
+        USES_TERMINAL_DOWNLOAD TRUE
     )
 
     FetchContent_MakeAvailable(neo_assets)


### PR DESCRIPTION
## Description
Enable the FetchContent output so developer can see the downloading process, otherwise it looks like CMake configure phase is frozen for a minute (depends on download speed) due to the size of neoAssets.

Example output:
```[cmake] [1/9] Creating directories for 'neo_assets-populate'
[cmake] [1/9] Performing download step (git clone) for 'neo_assets-populate'
[cmake] Cloning into 'neo_assets-src'...
[cmake] remote: Enumerating objects: 1212, done.        
[cmake] remote: Counting objects:   0% (1/1212)        
[cmake] remote: Counting objects:   1% (13/1212)        
...
[cmake] remote: Counting objects: 100% (1212/1212)        
[cmake] remote: Counting objects: 100% (1212/1212), done.        
[cmake] remote: Compressing objects:   0% (1/655)        
...
[cmake] remote: Compressing objects: 100% (655/655), done.        
[cmake] Receiving objects:   0% (1/1212)
[cmake] Receiving objects:   1% (13/1212), 6.31 MiB | 12.55 MiB/s
...
[cmake] Receiving objects:  99% (1200/1212), 344.15 MiB | 10.51 MiB/s
[cmake] remote: Total 1212 (delta 524), reused 1181 (delta 519), pack-reused 0 (from 0)        
[cmake] Receiving objects: 100% (1212/1212), 349.38 MiB | 10.54 MiB/s
[cmake] Receiving objects: 100% (1212/1212), 351.38 MiB | 8.79 MiB/s, done.
[cmake] Resolving deltas:   0% (0/524)
[cmake] Resolving deltas:   1% (7/524)
...
[cmake] Resolving deltas: 100% (524/524), done.
[cmake] Already on 'master'
[cmake] Your branch is up to date with 'origin/master'.
[cmake] [2/9] Performing update step for 'neo_assets-populate'
[cmake] -- Fetching latest from the remote origin
[cmake] [3/9] No patch step for 'neo_assets-populate'
[cmake] [5/9] No configure step for 'neo_assets-populate'
[cmake] [6/9] No build step for 'neo_assets-populate'
[cmake] [7/9] No install step for 'neo_assets-populate'
[cmake] [8/9] No test step for 'neo_assets-populate'
[cmake] [9/9] Completed 'neo_assets-populate'
```

## Toolchain
- Linux GCC Native [Arch, g++ (GCC) 14.2.1 20250207]