### PR TITLE
Fix broken unicode text in player squad list

### DIFF
--- a/src/game/client/neo/ui/neo_hud_ammo.cpp
+++ b/src/game/client/neo/ui/neo_hud_ammo.cpp
@@ -143,7 +143,6 @@ void CNEOHud_Ammo::DrawAmmo() const
 			V_sprintf_safe(clipsText, "%d", numClips);
 		}
 
-		textLen = V_strlen(clipsText);
 		wchar_t unicodeClipsText[maxLen]{ L'\0' };
 		g_pVGuiLocalize->ConvertANSIToUnicode(clipsText, unicodeClipsText, sizeof(unicodeClipsText));
 
@@ -153,7 +152,7 @@ void CNEOHud_Ammo::DrawAmmo() const
 
 		surface()->GetTextSize(m_hTextFont, unicodeClipsText, fontWidth, fontHeight);
 		surface()->DrawSetTextPos(digit2_xpos + xpos - fontWidth, digit2_ypos + ypos);
-		surface()->DrawPrintText(unicodeClipsText, textLen);
+		surface()->DrawPrintText(unicodeClipsText, V_wcslen(unicodeClipsText));
 	}
 
 	const char* ammoChar = nullptr;
@@ -187,7 +186,7 @@ void CNEOHud_Ammo::DrawAmmo() const
 
 			surface()->DrawSetTextFont(m_hBulletFont);
 			surface()->DrawSetTextPos(icon_xpos + xpos, icon_ypos + ypos);
-			surface()->DrawPrintText(unicodeFireModeText, V_strlen(fireModeText));
+			surface()->DrawPrintText(unicodeFireModeText, V_wcslen(unicodeFireModeText));
 
 			surface()->GetTextSize(m_hBulletFont, unicodeFireModeText, fireModeWidth, fireModeHeight);
 		}

--- a/src/game/client/neo/ui/neo_hud_friendly_marker.cpp
+++ b/src/game/client/neo/ui/neo_hud_friendly_marker.cpp
@@ -170,7 +170,7 @@ void CNEOHud_FriendlyMarker::DrawPlayer(Color teamColor, C_NEO_Player *player, c
 				int textWidth, textHeight;
 				surface()->GetTextSize(m_hFont, textUTF, textWidth, textHeight);
 				surface()->DrawSetTextPos(x - (textWidth / 2), y + (drawOutline ? 0 : m_iMarkerHeight) + textYOffset);
-				surface()->DrawPrintText(textUTF, V_strlen(textASCII));
+				surface()->DrawPrintText(textUTF, V_wcslen(textUTF));
 				textYOffset += textHeight;
 			};
 

--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -733,7 +733,7 @@ int CNEOHud_RoundState::DrawPlayerRow(int playerIndex, const int yOffset, bool s
 	surface()->GetTextSize(m_hOCRSmallFont, m_wszPlayersAliveUnicode, fontWidth, fontHeight);
 	surface()->DrawSetTextColor(isAlive ? COLOR_FADED_WHITE : COLOR_DARK_FADED_WHITE);
 	surface()->DrawSetTextPos(8, yOffset);
-	surface()->DrawPrintText(wSquadMateText, Q_strlen(squadMateText));
+	surface()->DrawPrintText(wSquadMateText, V_wcslen(wSquadMateText));
 
 	return yOffset + fontHeight;
 }


### PR DESCRIPTION
## Description
Before:
![before](https://github.com/user-attachments/assets/9ae2ff74-946a-48f1-9376-1731eef602b0)
After (never mind the wrong Linux font):
![after](https://github.com/user-attachments/assets/aa3b8747-a8c1-4018-a32c-c9e34e3eb324)

Related PR: #1081

## Toolchain
- Linux GCC Native [Arch, g++ (GCC) 15.1.1 20250425]

