### PR TITLE
Camera clipping at high fov

### DIFF
--- a/src/game/client/view.h
+++ b/src/game/client/view.h
@@ -22,11 +22,15 @@ class VPlane;
 
 
 // near and far Z it uses to render the world.
+#ifdef NEO
+#define VIEW_NEARZ 3
+#else
 #ifndef HL1_CLIENT_DLL
 #define VIEW_NEARZ	7
 #else
 #define VIEW_NEARZ	3
 #endif
+#endif // NEO
 //#define VIEW_FARZ	28400
 
 

--- a/src/game/shared/neo/neo_predicted_viewmodel.h
+++ b/src/game/shared/neo/neo_predicted_viewmodel.h
@@ -31,7 +31,7 @@ public:
 	virtual void CalcViewModelView(CBasePlayer *pOwner,
 		const Vector& eyePosition, const QAngle& eyeAngles);
 
-	float freeRoomForLean(float leanAmount, CNEO_Player *player, bool &leanObstacle);
+	float freeRoomForLean(float leanAmount, CNEO_Player *player);
 
 	// Returns the amount of pelvis rotation expected of player bone controller.
 	float lean(CNEO_Player *player);


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

undo parts of 1b05d97b that return camera faster during unlean due to collision, reduce camera near z plane to fix camera clipping instead

Before:
![image](https://github.com/user-attachments/assets/b4c5b9cc-00e2-48a6-8c0e-8d5aa2babdad)
After:
![image](https://github.com/user-attachments/assets/07ef32bc-82fc-4c56-ad47-596de61bf2ab)
