### PR TITLE
Bump Weapon Skip LOS check

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -994,8 +994,12 @@ bool CHL2MP_Player::BumpWeapon( CBaseCombatWeapon *pWeapon )
 	}
 #endif
 
-	// Don't let the player fetch weapons through walls (use MASK_SOLID so that you can't pickup through windows)
+#ifdef NEO
+	if( GetAbsOrigin() != pWeapon->GetAbsOrigin() && !pWeapon->FVisible( this, MASK_SOLID ) && !(GetFlags() & FL_NOTARGET) )
+#else
 	if( !pWeapon->FVisible( this, MASK_SOLID ) && !(GetFlags() & FL_NOTARGET) )
+#endif // NEO
+	// Don't let the player fetch weapons through walls (use MASK_SOLID so that you can't pickup through windows)
 	{
 		return false;
 	}

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -2825,7 +2825,7 @@ void GiveDet(CNEO_Player* pPlayer)
 		}
 		else
 		{
-			pent->SetAbsOrigin(pPlayer->EyePosition());
+			pent->SetLocalOrigin(pPlayer->GetLocalOrigin());
 			pent->AddSpawnFlags(SF_NORESPAWN);
 
 			auto pWeapon = dynamic_cast<CNEOBaseCombatWeapon*>((CBaseEntity*)pent);
@@ -2921,7 +2921,7 @@ void CNEO_Player::GiveLoadoutWeapon(void)
 		return;
 	}
 
-	pEnt->SetAbsOrigin(EyePosition());
+	pEnt->SetLocalOrigin(GetLocalOrigin());
 	pEnt->AddSpawnFlags(SF_NORESPAWN);
 
 	CNEOBaseCombatWeapon *pNeoWeapon = dynamic_cast<CNEOBaseCombatWeapon*>((CBaseEntity*)pEnt);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -6070,8 +6070,9 @@ CBaseEntity	*CBasePlayer::GiveNamedItem( const char *pszName, int iSubType )
 		Msg( "NULL Ent in GiveNamedItem!\n" );
 		return NULL;
 	}
+
 	pent->SetLocalOrigin( GetLocalOrigin() );
-	pent->AddSpawnFlags( SF_NORESPAWN );
+	pent->AddSpawnFlags(SF_NORESPAWN);
 
 	CBaseCombatWeapon *pWeapon = dynamic_cast<CBaseCombatWeapon*>( (CBaseEntity*)pent );
 	if ( pWeapon )

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -6070,11 +6070,7 @@ CBaseEntity	*CBasePlayer::GiveNamedItem( const char *pszName, int iSubType )
 		Msg( "NULL Ent in GiveNamedItem!\n" );
 		return NULL;
 	}
-#ifdef NEO
-	pent->SetAbsOrigin(EyePosition());
-#else
 	pent->SetLocalOrigin( GetLocalOrigin() );
-#endif
 	pent->AddSpawnFlags( SF_NORESPAWN );
 
 	CBaseCombatWeapon *pWeapon = dynamic_cast<CBaseCombatWeapon*>( (CBaseEntity*)pent );


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Reverts the snowfall fix that made weapons given to players spawn at their eyes  #671, and instead skip the line of sight check if the weapon a player is bumping into has the same origin as the player

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1114