### PR TITLE
correct class team on class selection menu, disable cancel button when unassigned

### DIFF
--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -323,7 +323,7 @@ public:
 			return;
 		}
 
-		if (command.ArgC() > 1 && !command.FindArg("skipTeamCheck"))
+		if (!command.FindArg("skipTeamCheck"))
 		{ // A smarter way to do this might be to assign the buttons for class and weapons menu to unique commands that check the current team and call this commandcallback
 			auto team = GetLocalPlayerTeam();
 			if(team < FIRST_GAME_TEAM)

--- a/src/game/client/neo/game_controls/neo_classmenu.cpp
+++ b/src/game/client/neo/game_controls/neo_classmenu.cpp
@@ -104,6 +104,7 @@ CNeoClassMenu::CNeoClassMenu(IViewPort *pViewPort)
 	SetTitleBarVisible(false);
 
 	FindButtons();
+	ListenForGameEvent("player_team");
 }
 
 CNeoClassMenu::~CNeoClassMenu()
@@ -118,6 +119,24 @@ CNeoClassMenu::~CNeoClassMenu()
 	m_pAssault_Button->SetAutoDelete(true);
 	m_pSupport_Button->SetAutoDelete(true);
 	m_pBack_Button->SetAutoDelete(true);
+}
+
+void CNeoClassMenu::FireGameEvent(IGameEvent* event)
+{
+	//const char* type = event->GetName();
+
+	//if (!Q_strcmp(type, "player_team"))
+	{ // player joined a new team
+		const int playerIndex = engine->GetPlayerForUserID(event->GetInt("userid"));
+		if (playerIndex != GetLocalPlayerIndex())
+		{
+			return;
+		}
+
+		const int team = event->GetInt("team");
+		// Local player joined a new team, update images
+		UpdateSkinImages(-1, team);
+	}
 }
 
 void CNeoClassMenu::FindButtons()
@@ -242,14 +261,14 @@ void CNeoClassMenu::OnKeyCodeReleased(vgui::KeyCode code)
 	//BaseClass::OnKeyCodeReleased(code);
 }
 
-void CNeoClassMenu::UpdateSkinImages(int classNumber = -1)
+void CNeoClassMenu::UpdateSkinImages(int classNumber, int overrideTeamNumber)
 {
 	C_NEO_Player* player = C_NEO_Player::GetLocalNEOPlayer();
 	if (!player)
 	{
 		return;
 	}
-	int teamNumber = player->GetTeamNumber() - 2;
+	int teamNumber = overrideTeamNumber != -1 ? overrideTeamNumber - 2 : player->GetTeamNumber() - 2;
 	if (teamNumber < 0 || teamNumber>1)
 	{ // player hasn't joined jinrai or nsf yet, do not update images
 		return;

--- a/src/game/client/neo/game_controls/neo_classmenu.h
+++ b/src/game/client/neo/game_controls/neo_classmenu.h
@@ -30,7 +30,7 @@ class MouseCode;
 
 // NOTE: this class name must match its res file description.
 class CNeoClassMenu : public vgui::Frame,
-    public IViewPortPanel
+    public IViewPortPanel, public CGameEventListener
 {
     DECLARE_CLASS_SIMPLE( CNeoClassMenu, vgui::Frame );
 
@@ -47,6 +47,9 @@ public:
 	virtual void ShowPanel( bool bShow );
 
 	GameActionSet_t GetPreferredActionSet() override { return GAME_ACTION_SET_IN_GAME_HUD; }
+
+    // IGameEventListener interface:
+    virtual void FireGameEvent(IGameEvent* event);
 
     virtual void OnMessage(const KeyValues *params, vgui::VPANEL fromPanel);
 
@@ -75,7 +78,7 @@ protected:
 	void SetLabelText(const char *textEntryName, wchar_t *text);
 	void MoveLabelToFront(const char *textEntryName);
 	void FindButtons();
-	void UpdateSkinImages(int classNumber);
+	void UpdateSkinImages(int classNumber = -1, int overrideTeamNumber = -1);
 	void UpdateTimer() { }
 
     // vgui overrides

--- a/src/game/client/neo/game_controls/neo_teammenu.cpp
+++ b/src/game/client/neo/game_controls/neo_teammenu.cpp
@@ -248,7 +248,6 @@ void CNeoTeamMenu::OnCommand(const char *command)
 		engine->ClientCmd(commandBuffer);
 		return;
 	}
-
 	if (Q_stristr(commandBuffer, "jointeam") != 0) // Note using stristr, not strcmp. Equates to true when jointeam in commandBuffer
 	{ // joining jinrai or nsf
 		CloseMenu();
@@ -257,7 +256,8 @@ void CNeoTeamMenu::OnCommand(const char *command)
 		return;
 	}
 
-	if (Q_stricmp(commandBuffer, "vguicancel") == 0)
+	int localPlayerTeam = GetLocalPlayerTeam();
+	if (localPlayerTeam != TEAM_UNASSIGNED && Q_stricmp(commandBuffer, "vguicancel") == 0)
 	{ // cancel, close menu
 		CloseMenu();
 	}
@@ -329,6 +329,8 @@ void CNeoTeamMenu::ApplySchemeSettings(vgui::IScheme *pScheme)
 	m_pSpectator_Button		->AddActionSignalTarget(this);
 	m_pAutoAssign_Button	->AddActionSignalTarget(this);
 	m_pCancel_Button		->AddActionSignalTarget(this);
+
+	m_pCancel_Button		->SetEnabled(GetLocalPlayerTeam() != TEAM_UNASSIGNED);
 
 	auto pJinrai = GetGlobalTeam(TEAM_JINRAI);
 	auto pNsf = GetGlobalTeam(TEAM_NSF);

--- a/src/game/client/neo/game_controls/neo_teammenu.cpp
+++ b/src/game/client/neo/game_controls/neo_teammenu.cpp
@@ -286,6 +286,12 @@ void CNeoTeamMenu::CloseMenu()
 
 void CNeoTeamMenu::OnKeyCodeReleased(vgui::KeyCode code)
 { // Navigating using the keyboard hack
+	int localPlayerTeam = GetLocalPlayerTeam();
+	if (localPlayerTeam == TEAM_UNASSIGNED)
+	{
+		return;
+	}
+
 	if (code == g_pNeoRoot->m_ns.keys.bcTeamMenu)
 	{
 		CloseMenu();


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

the previous fix to class selection showing up in spectate plus disable cancel button when unassigned, set picture in class selection menu on team join event

for reference this is how the team selection menu looks in the original when unassigned
![image](https://github.com/user-attachments/assets/085fd2d4-d50c-4f37-b0de-85f2b5a4766b)
