### PR TITLE
trigger_serverragdoll applies to players

### DIFF
--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1942,7 +1942,10 @@ void CNEO_Player::AddPoints(int score, bool bAllowNegativeScore)
 
 void CNEO_Player::Event_Killed( const CTakeDamageInfo &info )
 {
-	CreateRagdollEntity();
+	if (!m_bForceServerRagdoll)
+	{
+		CreateRagdollEntity();
+	}
 
 	// Calculate force for weapon drop
 	Vector forceVector = CalcDamageForceVector(info);
@@ -2049,7 +2052,7 @@ void CNEO_Player::SetDeadModel(const CTakeDamageInfo& info)
 
 	int deadModelType = -1;
 
-	if (!m_bAllowGibbing) // Prevent gibbing if a custom player model has been set via I/O
+	if (!m_bAllowGibbing || m_bForceServerRagdoll) // Prevent gibbing if a custom player model has been set via I/O or the ragdoll is serverside
 	{
 		return;
 	}

--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -4875,10 +4875,10 @@ void CServerRagdollTrigger::Spawn( void )
 void CServerRagdollTrigger::StartTouch(CBaseEntity *pOther)
 {
 	BaseClass::StartTouch( pOther );
-
+#ifndef NEO
 	if ( pOther->IsPlayer() )
 		return;
-
+#endif
 	CBaseCombatCharacter *pCombatChar = pOther->MyCombatCharacterPointer();
 
 	if ( pCombatChar )
@@ -4890,10 +4890,10 @@ void CServerRagdollTrigger::StartTouch(CBaseEntity *pOther)
 void CServerRagdollTrigger::EndTouch(CBaseEntity *pOther)
 {
 	BaseClass::EndTouch( pOther );
-
+#ifndef NEO
 	if ( pOther->IsPlayer() )
 		return;
-
+#endif
 	CBaseCombatCharacter *pCombatChar = pOther->MyCombatCharacterPointer();
 
 	if ( pCombatChar )


### PR DESCRIPTION
## Description
`trigger_serverragdoll` can be used to make the ragdolls of players simulate serverside to prevent them from falling through dynamic objects. This could previously only be used for NPCs

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

