### PR TITLE
Hide third person muzzle flash for spectators in eye, simplify particle emission, fix first person muzzle flash not rotating, rotate muzzle flash with viewmodel roation

### DIFF
--- a/src/game/shared/neo/neo_predicted_viewmodel_muzzleflash.cpp
+++ b/src/game/shared/neo/neo_predicted_viewmodel_muzzleflash.cpp
@@ -29,13 +29,11 @@ BEGIN_NETWORK_TABLE(CNEOPredictedViewModelMuzzleFlash, DT_NEOPredictedViewModelM
 #ifndef CLIENT_DLL
 SendPropEHandle(SENDINFO_NAME(m_hMoveParent, moveparent)),
 SendPropBool(SENDINFO(m_bActive)),
-SendPropInt(SENDINFO(m_iAngleZ)),
 SendPropInt(SENDINFO(m_iAngleZIncrement)),
 SendPropBool(SENDINFO(m_bScaleChangeFlag))
 #else
 RecvPropInt(RECVINFO_NAME(m_hNetworkMoveParent, moveparent), 0, RecvProxy_IntToMoveParent),
 RecvPropBool(RECVINFO(m_bActive)),
-RecvPropInt(RECVINFO(m_iAngleZ)),
 RecvPropInt(RECVINFO(m_iAngleZIncrement)),
 RecvPropEHandle(RECVINFO(m_bScaleChangeFlag), RecvProxy_ScaleChangeFlag)
 #endif
@@ -45,7 +43,6 @@ END_NETWORK_TABLE()
 BEGIN_PREDICTION_DATA(CNEOPredictedViewModelMuzzleFlash)
 DEFINE_PRED_FIELD(m_hNetworkMoveParent, FIELD_EHANDLE, FTYPEDESC_INSENDTABLE),
 DEFINE_PRED_FIELD(m_bActive, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE),
-DEFINE_PRED_FIELD(m_iAngleZ, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),
 DEFINE_PRED_FIELD(m_iAngleZIncrement, FIELD_INTEGER, FTYPEDESC_INSENDTABLE),
 DEFINE_PRED_FIELD(m_bScaleChangeFlag, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE),
 END_PREDICTION_DATA()
@@ -58,7 +55,9 @@ constexpr const char* MUZZLE_FLASH_ENTITY_MODEL = "models/effect/fpmf/fpmf01.mdl
 CNEOPredictedViewModelMuzzleFlash::CNEOPredictedViewModelMuzzleFlash()
 {
 	m_bActive = true;
+#ifdef CLIENT_DLL
 	m_iAngleZ = 0;
+#endif // CLIENT_DLL
 	m_iAngleZIncrement = -5;
 	m_flTimeSwitchOffMuzzleFlash = gpGlobals->curtime;
 	m_bScaleChangeFlag = false;
@@ -108,7 +107,7 @@ int CNEOPredictedViewModelMuzzleFlash::DrawModel(int flags)
 		vm->GetAttachment(iAttachment, localOrigin, localAngle);
 		UncorrectViewModelAttachment(localOrigin); // Need position of muzzle without fov modifications & viewmodel offset
 		m_iAngleZ = (m_iAngleZ + m_iAngleZIncrement) % 360; // NEOTODO (Adam) ? Speed of rotation depends on how often DrawModel() is called. Should this be tied to global time?
-		localAngle.z = m_iAngleZ;
+		localAngle.z += m_iAngleZ;
 		SetAbsOrigin(localOrigin);
 		SetAbsAngles(localAngle);
 
@@ -145,6 +144,9 @@ void CNEOPredictedViewModelMuzzleFlash::UpdateMuzzleFlashProperties(CBaseCombatW
 		return;
 	}
 
+#ifdef CLIENT_DLL
+	m_iAngleZ = 0;
+#endif // CLIENT_DLL
 	const auto neoWepBits = neoWep->GetNeoWepBits();
 	if (neoWepBits & (NEO_WEP_THROWABLE | NEO_WEP_GHOST | NEO_WEP_KNIFE | NEO_WEP_SUPPRESSED))
 	{
@@ -154,7 +156,6 @@ void CNEOPredictedViewModelMuzzleFlash::UpdateMuzzleFlashProperties(CBaseCombatW
 	{
 		m_bActive = true;
 		m_nSkin = 1;
-		m_iAngleZ = 0;
 		m_iAngleZIncrement = -100;
 		SetModelScale(0.75);
 		m_bScaleChangeFlag = !m_bScaleChangeFlag;
@@ -163,7 +164,6 @@ void CNEOPredictedViewModelMuzzleFlash::UpdateMuzzleFlashProperties(CBaseCombatW
 	{
 		m_bActive = true;
 		m_nSkin = 1;
-		m_iAngleZ = 0;
 		m_iAngleZIncrement = -90;
 		SetModelScale(2);
 		m_bScaleChangeFlag = !m_bScaleChangeFlag;
@@ -172,7 +172,6 @@ void CNEOPredictedViewModelMuzzleFlash::UpdateMuzzleFlashProperties(CBaseCombatW
 	{
 		m_bActive = true;
 		m_nSkin = 0;
-		m_iAngleZ = 0;
 		m_iAngleZIncrement = -90;
 		SetModelScale(0.75);
 		m_bScaleChangeFlag = !m_bScaleChangeFlag;
@@ -181,7 +180,6 @@ void CNEOPredictedViewModelMuzzleFlash::UpdateMuzzleFlashProperties(CBaseCombatW
 	{
 		m_bActive = true;
 		m_nSkin = 0;
-		m_iAngleZ = 0;
 		m_iAngleZIncrement = -100;
 		SetModelScale(0.6);
 		m_bScaleChangeFlag = !m_bScaleChangeFlag;
@@ -190,7 +188,6 @@ void CNEOPredictedViewModelMuzzleFlash::UpdateMuzzleFlashProperties(CBaseCombatW
 	{
 		m_bActive = true;
 		m_nSkin = 0;
-		m_iAngleZ = 0;
 		m_iAngleZIncrement = -90;
 		SetModelScale(0.75);
 		m_bScaleChangeFlag = !m_bScaleChangeFlag;

--- a/src/game/shared/neo/neo_predicted_viewmodel_muzzleflash.h
+++ b/src/game/shared/neo/neo_predicted_viewmodel_muzzleflash.h
@@ -44,7 +44,6 @@ public:
 	bool	m_bScaleChangeFlag;
 #else
 	CNetworkVar(bool, m_bActive);
-	CNetworkVar(int, m_iAngleZ);
 	CNetworkVar(int, m_iAngleZIncrement);
 	CNetworkVar(bool, m_bScaleChangeFlag);
 #endif // CLIENT_DLL

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -1005,7 +1005,7 @@ void CNEOBaseCombatWeapon::ProcessMuzzleFlashEvent()
 	el->color.exponent = 5;
 
 	// Muzzle flash particle
-	DispatchMuzzleParticleEffect(iAttachment);
+	ParticleProp()->Create("ntr_muzzle_source", PATTACH_POINT_FOLLOW, iAttachment);
 }
 
 void CNEOBaseCombatWeapon::DrawCrosshair()
@@ -1036,11 +1036,6 @@ void CNEOBaseCombatWeapon::DrawCrosshair()
 	{
 		crosshair->ResetCrosshair();
 	}
-}
-
-void CNEOBaseCombatWeapon::DispatchMuzzleParticleEffect(int iAttachment)
-{
-	CNewParticleEffect* pMuzzleFlashParticle = ParticleProp()->Create("ntr_muzzle_source", PATTACH_POINT_FOLLOW, iAttachment);
 }
 
 static inline bool ShouldDrawLocalPlayerViewModel(void)

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -961,8 +961,17 @@ bool CNEOBaseCombatWeapon::CanBePickedUpByClass(int classId)
 #ifdef CLIENT_DLL
 void CNEOBaseCombatWeapon::ProcessMuzzleFlashEvent()
 {
-	if (GetPlayerOwner() == NULL)
+	C_BasePlayer *owner = GetPlayerOwner();
+	if (!owner)
 		return; // If using a view model in first person, muzzle flashes are not processed until the player drops their weapon. In that case, do not play a muzzle flash effect. Need to change how this is calculated if we want to allow dropped weapons to cook off for example
+
+	C_BasePlayer *localPlayer = UTIL_PlayerByIndex(GetLocalPlayerIndex());
+	if (!localPlayer)
+		return;
+
+	// bIsVisible in function calling ProcessMuzzleFlashEvent is set to true even though this weapon may not be drawn? Probably same reason for the same check in C_BaseCombatWeapon::DrawModel
+	if (localPlayer->IsObserver() && localPlayer->GetObserverMode() == OBS_MODE_IN_EYE && localPlayer->GetObserverTarget() == owner)
+		return;
 
 	if ((GetNeoWepBits() & NEO_WEP_SUPPRESSED))
 		return;
@@ -1029,25 +1038,9 @@ void CNEOBaseCombatWeapon::DrawCrosshair()
 	}
 }
 
-void CNEOBaseCombatWeapon::DispatchMuzzleParticleEffect(int iAttachment) {
-	static constexpr char particleName[] = "ntr_muzzle_source";
-	constexpr bool resetAllParticlesOnEntity = false;
-	const ParticleAttachment_t iAttachType = ParticleAttachment_t::PATTACH_POINT_FOLLOW;
-
-	CEffectData	data;
-
-	data.m_nHitBox = GetParticleSystemIndex(particleName);
-	data.m_hEntity = this;
-	data.m_fFlags |= PARTICLE_DISPATCH_FROM_ENTITY;
-	data.m_vOrigin = GetAbsOrigin();
-	data.m_nDamageType = iAttachType;
-	data.m_nAttachmentIndex = iAttachment;
-
-	if (resetAllParticlesOnEntity)
-		data.m_fFlags |= PARTICLE_DISPATCH_RESET_PARTICLES;
-
-	CSingleUserRecipientFilter filter(UTIL_PlayerByIndex(GetLocalPlayerIndex()));
-	te->DispatchEffect(filter, 0.0, data.m_vOrigin, "ParticleEffect", data);
+void CNEOBaseCombatWeapon::DispatchMuzzleParticleEffect(int iAttachment)
+{
+	CNewParticleEffect* pMuzzleFlashParticle = ParticleProp()->Create("ntr_muzzle_source", PATTACH_POINT_FOLLOW, iAttachment);
 }
 
 static inline bool ShouldDrawLocalPlayerViewModel(void)

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -195,7 +195,6 @@ public:
 
 	virtual Activity GetPrimaryAttackActivity(void) override;
 #ifdef CLIENT_DLL
-	void DispatchMuzzleParticleEffect(int iAttachment);
 	virtual void ProcessMuzzleFlashEvent(void) override;
 	void DrawCrosshair() override;
 #endif


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

The function in C_BaseAnimating that calls CNEOBaseCombatWeapon::ProcessMuzzleFlashEvent is supposed to exit early if the weapon isn't visible to the local player, but this doesn't work for weapons which are hidden to spectators in first person observer mode. This seems to be at least known about considering the check in C_BaseCombatWeapon::DrawModel, so adding the same check to CNEOBaseCombatWeapon::ProcessMuzzleFlashEvent to exit early.

When trying to figure out why third person muzzle flashes were being drawn at world origin as well (turned out to be a particle error), I figured out a way to emit a particle client side only thats much simpler (see how "vortigaunt_beam_charge" is being emitted). Since we don't need to pass anything to the one and only particle controller in ntr_muzzle_source since we're using an attachment point, it becomes a one liner.

I also noticed two problems with the first person muzzle flash.
- When using viewmodel only rotation, the muzzle flash does not rotate with the viewmodel. This is contrary to what a player would expect, as a muzzle flash is generated in part by the shape of a muzzle device. If a muzzle device is rotated in relation to a camera, then the muzzle flash would rotate too. Adding the muzzle flash rotation onto the initial rotation instead of overwriting it fixes this.
- The first person muzzle flash rotation wasn't working. I'm certain this worked in the past, probably an issue with the muzzle flash current angle not being set server side. Since this variable doesn't really need to be networked, only reset to 0 when changing weapons, I removed it from the send table and receive tables which fixes the problem. In the future I imagine both the view model and view model muzzle flash should should be entirely predicted client side, since we should be able to work out all the viewmodel properties from the current active weapon of the local player or target player, as soon as we work out how to work around the server changing our active weapon for us.

