### PR TITLE
World pos hud elements ignore texture size

### DIFF
--- a/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
@@ -18,8 +18,11 @@
 
 using vgui::surface;
 
-ConVar neo_ghost_beacon_scale_toggle("neo_ghost_beacon_scale_toggle", "0", FCVAR_ARCHIVE,
-	"Toggles the scaling of ghost beacons.", true, 0, true, 1);
+ConVar neo_ghost_beacon_scale("neo_ghost_beacon_scale", "1", FCVAR_ARCHIVE,
+	"Ghost beacons scale.", true, 0.01, false, 0);
+
+ConVar neo_ghost_beacon_scale_with_distance("neo_ghost_beacon_scale_with_distance", "0", FCVAR_ARCHIVE,
+	"Toggles the scaling of ghost beacons with distance.", true, 0, true, 1);
 
 ConVar neo_ghost_beacon_alpha("neo_ghost_beacon_alpha", "150", FCVAR_ARCHIVE,
 	"Alpha channel transparency of HUD ghost beacons.", true, 0, true, 255);
@@ -152,14 +155,14 @@ void CNEOHud_GhostBeacons::DrawPlayer(const Vector& playerPos) const
 	auto dist = m_pGhost->DistanceToPos(playerPos);	//Move this to some util
 	auto distInMeters = dist * METERS_PER_INCH;
 
-	float scale = neo_ghost_beacon_scale_toggle.GetBool() ? (neo_ghost_beacon_scale_baseline.GetInt() / dist) : 0.5;
-	constexpr float HALF_BASE_TEX_LENGTH = 64;
+	float scale = neo_ghost_beacon_scale.GetFloat();
+	constexpr float HALF_BASE_TEX_LENGTH = 32;
 	float halfBeaconLength = HALF_BASE_TEX_LENGTH * scale;
 
 	int posX, posY;
-	Vector ghostBeaconOffset = Vector(0, 0, 32); // The center of the player
+	Vector ghostBeaconOffset = Vector(0, 0, neo_ghost_beacon_scale_with_distance.GetBool() ? 32 : 48); // The center of the player, or raise slightly if not scaling
 	GetVectorInScreenSpace(playerPos, posX, posY, &ghostBeaconOffset);
-	if (neo_ghost_beacon_scale_toggle.GetBool())
+	if (neo_ghost_beacon_scale_with_distance.GetBool())
 	{
 		int pos2X, pos2Y;
 		Vector ghostBeaconOffset2 = Vector(0, 0, 64); // The top of the player

--- a/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
@@ -18,16 +18,10 @@
 
 using vgui::surface;
 
-// NEO HACK (Rain): This is a sort of magic number to help with screenspace hud elements
-// scaling in world space. There's most likely some nicer and less confusing way to do this.
-// Check which files make reference to this, if you decide to tweak it.
-ConVar neo_ghost_beacon_scale_baseline("neo_ghost_beacon_scale_baseline", "150", FCVAR_USERINFO,
-	"Distance in HU where ghost marker is same size as player.", true, 0, true, 9999);
-
-ConVar neo_ghost_beacon_scale_toggle("neo_ghost_beacon_scale_toggle", "0", FCVAR_USERINFO,
+ConVar neo_ghost_beacon_scale_toggle("neo_ghost_beacon_scale_toggle", "0", FCVAR_ARCHIVE,
 	"Toggles the scaling of ghost beacons.", true, 0, true, 1);
 
-ConVar neo_ghost_beacon_alpha("neo_ghost_beacon_alpha", "150", FCVAR_USERINFO,
+ConVar neo_ghost_beacon_alpha("neo_ghost_beacon_alpha", "150", FCVAR_ARCHIVE,
 	"Alpha channel transparency of HUD ghost beacons.", true, 0, true, 255);
 
 ConVar neo_ghost_delay_secs("neo_ghost_delay_secs", "3.3", FCVAR_CHEAT | FCVAR_REPLICATED,

--- a/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
@@ -165,20 +165,16 @@ void CNEOHud_GhostBeacons::DrawPlayer(const Vector& playerPos) const
 	int posX, posY;
 	Vector ghostBeaconOffset = Vector(0, 0, 32); // The center of the player
 	GetVectorInScreenSpace(playerPos, posX, posY, &ghostBeaconOffset);
-	if (neo_ghost_beacon_scale_toggle.GetInt() == 0)
-	{ // This is more intuitive than the previous version, but the size of the element remains constant regardless of camera rotation, 
-		// whereas players themselves become bigger the closer they are to the edge of the screen
+	if (neo_ghost_beacon_scale_toggle.GetBool())
+	{
 		int pos2X, pos2Y;
 		Vector ghostBeaconOffset2 = Vector(0, 0, 64); // The top of the player
 		GetVectorInScreenSpace(playerPos, pos2X, pos2Y, &ghostBeaconOffset2);
-		halfBeaconLength = (pos2Y - posY) * 0.5;
+		halfBeaconLength = (posY - pos2Y) * 0.5;
 	}
 	
-	char m_szBeaconTextANSI[4 + 1];
 	wchar_t m_wszBeaconTextUnicode[4 + 1];
-
-	V_snprintf(m_szBeaconTextANSI, sizeof(m_szBeaconTextANSI), "%02d m", FastFloatToSmallInt(dist * METERS_PER_INCH));
-	g_pVGuiLocalize->ConvertANSIToUnicode(m_szBeaconTextANSI, m_wszBeaconTextUnicode, sizeof(m_wszBeaconTextUnicode));
+	V_snwprintf(m_wszBeaconTextUnicode, ARRAYSIZE(m_wszBeaconTextUnicode), L"%02d m", FastFloatToSmallInt(dist * METERS_PER_INCH));
 
 	int alpha = distInMeters < 35 ? neo_ghost_beacon_alpha.GetInt() : neo_ghost_beacon_alpha.GetInt() * ((45 - distInMeters) / 10);
 	surface()->DrawSetTextColor(255, 255, 255, alpha);
@@ -186,7 +182,7 @@ void CNEOHud_GhostBeacons::DrawPlayer(const Vector& playerPos) const
 	int textWidth, textHeight;
 	surface()->GetTextSize(m_hFont, m_wszBeaconTextUnicode, textWidth, textHeight);
 	surface()->DrawSetTextPos(posX - (textWidth / 2), posY + halfBeaconLength);
-	surface()->DrawPrintText(m_wszBeaconTextUnicode, sizeof(m_szBeaconTextANSI));
+	surface()->DrawPrintText(m_wszBeaconTextUnicode, V_wcslen(m_wszBeaconTextUnicode));
 
 	surface()->DrawSetColor(255, 20, 20, alpha);
 	surface()->DrawSetTexture(m_hTex);

--- a/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_beacons.cpp
@@ -167,7 +167,7 @@ void CNEOHud_GhostBeacons::DrawPlayer(const Vector& playerPos) const
 		int pos2X, pos2Y;
 		Vector ghostBeaconOffset2 = Vector(0, 0, 64); // The top of the player
 		GetVectorInScreenSpace(playerPos, pos2X, pos2Y, &ghostBeaconOffset2);
-		halfBeaconLength = (posY - pos2Y) * 0.5;
+		halfBeaconLength = (posY - pos2Y) * 0.5 * scale;
 	}
 	
 	wchar_t m_wszBeaconTextUnicode[4 + 1];

--- a/src/game/client/neo/ui/neo_hud_ghost_beacons.h
+++ b/src/game/client/neo/ui/neo_hud_ghost_beacons.h
@@ -27,7 +27,6 @@ protected:
 	virtual ConVar* GetUpdateFrequencyConVar() const override;
 
 private:
-	int m_iBeaconTextureWidth, m_iBeaconTextureHeight;
 	C_WeaponGhost* m_pGhost;
 	float m_flNextAllowGhostShowTime;
 	bool m_bHoldingGhost = false;

--- a/src/game/client/neo/ui/neo_hud_ghost_cap_point.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_cap_point.cpp
@@ -8,9 +8,9 @@
 #include "c_neo_player.h"
 #include "neo_gamerules.h"
 
-ConVar neo_ghost_cap_point_hud_scale_factor("neo_ghost_cap_point_hud_scale_factor", "1", FCVAR_USERINFO,
+ConVar neo_ghost_cap_point_hud_scale_factor("neo_ghost_cap_point_hud_scale_factor", "1", FCVAR_ARCHIVE,
 	"Ghost cap HUD element scaling factor", true, 0.01, false, 0);
-ConVar cl_neo_hud_center_ghost_cap_size("cl_neo_hud_center_ghost_cap_size", "12.5", FCVAR_USERINFO,
+ConVar cl_neo_hud_center_ghost_cap_size("cl_neo_hud_center_ghost_cap_size", "12.5", FCVAR_ARCHIVE,
 	"HUD center size in percentage to fade ghost cap point.", true, 1, false, 0);
 
 NEO_HUD_ELEMENT_DECLARE_FREQ_CVAR(GhostCapPoint, 0.01)

--- a/src/game/client/neo/ui/neo_hud_ghost_cap_point.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_cap_point.cpp
@@ -8,7 +8,7 @@
 #include "c_neo_player.h"
 #include "neo_gamerules.h"
 
-ConVar neo_ghost_cap_point_hud_scale_factor("neo_ghost_cap_point_hud_scale_factor", "0.33", FCVAR_USERINFO,
+ConVar neo_ghost_cap_point_hud_scale_factor("neo_ghost_cap_point_hud_scale_factor", "1", FCVAR_USERINFO,
 	"Ghost cap HUD element scaling factor", true, 0.01, false, 0);
 ConVar cl_neo_hud_center_ghost_cap_size("cl_neo_hud_center_ghost_cap_size", "12.5", FCVAR_USERINFO,
 	"HUD center size in percentage to fade ghost cap point.", true, 1, false, 0);
@@ -36,7 +36,6 @@ CNEOHud_GhostCapPoint::CNEOHud_GhostCapPoint(const char *pElementName, vgui::Pan
 	m_hCapTex = vgui::surface()->CreateNewTextureID();
 	Assert(m_hCapTex > 0);
 	vgui::surface()->DrawSetTextureFile(m_hCapTex, "vgui/hud/ctg/g_beacon_arrow_down", 1, false);
-	vgui::surface()->DrawGetTextureSize(m_hCapTex, m_iCapTexWidth, m_iCapTexHeight);
 
 	SetVisible(false);
 }
@@ -55,17 +54,20 @@ void CNEOHud_GhostCapPoint::ApplySchemeSettings(vgui::IScheme *pScheme)
 	m_viewCentreSize = widerAxis * (cl_neo_hud_center_ghost_cap_size.GetFloat() / 100.0f);
 }
 
+extern ConVar cl_neo_hud_worldpos_verbose;
 void CNEOHud_GhostCapPoint::UpdateStateForNeoHudElementDraw()
 {
 	auto *player = C_NEO_Player::GetLocalNEOPlayer();
 	if (!player) return;
 
-	const bool playerIsPlaying = (player->GetTeamNumber() == TEAM_JINRAI || player->GetTeamNumber() == TEAM_NSF);
-	if (playerIsPlaying)
+	m_flDistance = METERS_PER_INCH * player->GetAbsOrigin().DistTo(m_vecMyPos);
+	if (cl_neo_hud_worldpos_verbose.GetBool())
 	{
-		m_flDistance = METERS_PER_INCH * player->GetAbsOrigin().DistTo(m_vecMyPos);
-		V_snprintf(m_szMarkerText, sizeof(m_szMarkerText), "RETRIEVAL ZONE DISTANCE: %.0f m", m_flDistance);
-		g_pVGuiLocalize->ConvertANSIToUnicode(m_szMarkerText, m_wszMarkerTextUnicode, sizeof(m_wszMarkerTextUnicode));
+		V_snwprintf(m_wszMarkerTextUnicode, ARRAYSIZE(m_wszMarkerTextUnicode), L"RETRIEVAL ZONE DISTANCE: %.0f m", m_flDistance);
+	}
+	else
+	{
+		V_snwprintf(m_wszMarkerTextUnicode, ARRAYSIZE(m_wszMarkerTextUnicode), L"%.0f m", m_flDistance);
 	}
 }
 
@@ -97,9 +99,7 @@ void CNEOHud_GhostCapPoint::DrawNeoHudElement()
 
 	const float scale = neo_ghost_cap_point_hud_scale_factor.GetFloat();
 
-	const int offset_X = x - ((m_iCapTexWidth / 2) * scale);
-	const int offset_Y = y - ((m_iCapTexHeight / 2) * scale);
-
+	constexpr float HALF_BASE_TEX_LENGTH = 64;
 	if (playerIsPlaying)
 	{
 		const float fadeTextMultiplier = GetFadeValueTowardsScreenCentre(x, y);
@@ -111,8 +111,8 @@ void CNEOHud_GhostCapPoint::DrawNeoHudElement()
 			vgui::surface()->DrawSetColor(COLOR_TRANSPARENT);
 			vgui::surface()->DrawSetTextColor(FadeColour(COLOR_TINTGREY, fadeTextMultiplier));
 			vgui::surface()->DrawSetTextFont(m_hFont);
-			vgui::surface()->DrawSetTextPos(x - (xWide / 2), offset_Y + (m_iCapTexHeight * scale) + (yTall / 2));
-			vgui::surface()->DrawPrintText(m_wszMarkerTextUnicode, sizeof(m_szMarkerText));
+			vgui::surface()->DrawSetTextPos(x - (xWide / 2), y + (HALF_BASE_TEX_LENGTH * scale));
+			vgui::surface()->DrawPrintText(m_wszMarkerTextUnicode, V_wcslen(m_wszMarkerTextUnicode));
 		}
 	}
 
@@ -130,14 +130,12 @@ void CNEOHud_GhostCapPoint::DrawNeoHudElement()
 		targetColor[3] = alpha;
 		vgui::surface()->DrawSetColor(targetColor);
 
-		const int offset_X2 = x - ((m_iCapTexWidth / 2) * m_fMarkerScalesCurrent[i] * scale);
-		const int offset_Y2 = y - ((m_iCapTexHeight / 2) * m_fMarkerScalesCurrent[i] * scale);
-
+		const float halfArrowLength = HALF_BASE_TEX_LENGTH * m_fMarkerScalesCurrent[i] * scale;
 		vgui::surface()->DrawTexturedRect(
-			offset_X2,
-			offset_Y2,
-			offset_X2 + (m_iCapTexWidth * m_fMarkerScalesCurrent[i] * scale),
-			offset_Y2 + (m_iCapTexHeight * m_fMarkerScalesCurrent[i] * scale));
+			x - halfArrowLength,
+			y - halfArrowLength,
+			x + halfArrowLength,
+			y + halfArrowLength);
 	}
 
 	// The increase and decrease in alpha over 6 seconds
@@ -150,12 +148,13 @@ void CNEOHud_GhostCapPoint::DrawNeoHudElement()
 	targetColor[3] = alpha6;
 
 	// The main arrow that stays the same size but dissappears and reappears on a 6 second loop
+	const float halfArrowLength = HALF_BASE_TEX_LENGTH * scale;
 	vgui::surface()->DrawSetColor(targetColor);
 	vgui::surface()->DrawTexturedRect(
-		offset_X,
-		offset_Y,
-		offset_X + (m_iCapTexWidth * scale),
-		offset_Y + (m_iCapTexHeight * scale));
+		x - halfArrowLength,
+		y - halfArrowLength,
+		x + halfArrowLength,
+		y + halfArrowLength);
 }
 
 void CNEOHud_GhostCapPoint::Paint()

--- a/src/game/client/neo/ui/neo_hud_ghost_cap_point.h
+++ b/src/game/client/neo/ui/neo_hud_ghost_cap_point.h
@@ -27,15 +27,12 @@ public:
 private:
 	int m_iPosX = 0;
 	int m_iPosY = 0;
-	int m_iCapTexWidth = 0;
-	int m_iCapTexHeight = 0;
 	int m_flMyRadius = 0;
 	int m_iCapTeam = TEAM_INVALID;
 	float m_flDistance = 0.0f;
 	float m_flCapTexScale = 1.0f;
 	float m_fMarkerScalesStart[4] = { 0.78f, 0.6f, 0.38f, 0.0f };
 	float m_fMarkerScalesCurrent[4] = { 0.78f, 0.6f, 0.38f, 0.0f };
-	char m_szMarkerText[64 + 1] = {};
 	wchar_t m_wszMarkerTextUnicode[64 + 1] = {};
 	Vector m_vecMyPos = Vector(0, 0, 0);
 	vgui::HFont m_hFont = 0UL;

--- a/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
@@ -23,7 +23,7 @@
 
 using vgui::surface;
 
-ConVar neo_ghost_marker_hud_scale_factor("neo_ghost_marker_hud_scale_factor", "0.5", FCVAR_USERINFO,
+ConVar neo_ghost_marker_hud_scale_factor("neo_ghost_marker_hud_scale_factor", "1", FCVAR_USERINFO,
 	"Ghost marker HUD element scaling factor", true, 0.01, false, 0);
 ConVar cl_neo_hud_center_ghost_marker_size("cl_neo_hud_center_ghost_marker_size", "12.5", FCVAR_USERINFO,
 	"HUD center size in percentage to fade ghost marker.", true, 1, false, 0);
@@ -36,17 +36,6 @@ NEO_HUD_ELEMENT_DECLARE_FREQ_CVAR(GhostMarker, 0.01)
 CNEOHud_GhostMarker::CNEOHud_GhostMarker(const char* pElemName, vgui::Panel* parent)
 	: CNEOHud_WorldPosMarker(pElemName, parent)
 {
-	{
-		int i;
-		for (i = 0; i < sizeof(m_szMarkerText) - 1; ++i)
-		{
-			m_szMarkerText[i] = ' ';
-		}
-		m_szMarkerText[i] = '\0';
-	}
-
-	g_pVGuiLocalize->ConvertANSIToUnicode(m_szMarkerText, m_wszMarkerTextUnicode, sizeof(m_wszMarkerTextUnicode));
-
 	SetAutoDelete(true);
 	m_iHideHudElementNumber = NEO_HUD_ELEMENT_GHOST_MARKER;
 
@@ -66,8 +55,6 @@ CNEOHud_GhostMarker::CNEOHud_GhostMarker(const char* pElemName, vgui::Panel* par
 	m_hTex = surface()->CreateNewTextureID();
 	Assert(m_hTex > 0);
 	surface()->DrawSetTextureFile(m_hTex, "vgui/hud/ctg/g_beacon_circle", 1, false);
-
-	surface()->DrawGetTextureSize(m_hTex, m_iMarkerTexWidth, m_iMarkerTexHeight);
 
 	SetVisible(false);
 
@@ -93,21 +80,25 @@ void CNEOHud_GhostMarker::ApplySchemeSettings(vgui::IScheme *pScheme)
 	m_viewCentreSize = widerAxis * (cl_neo_hud_center_ghost_marker_size.GetFloat() / 100.0f);
 }
 
+extern ConVar cl_neo_hud_worldpos_verbose;
 void CNEOHud_GhostMarker::UpdateStateForNeoHudElementDraw()
 {
 	if (m_ghostInPVS && (!NEORules()->GhostExists() || NEORules()->IsRoundOver()))
 	{
 		m_ghostInPVS = nullptr;
 	}
-	if (NEORules()->GetGhosterPlayer())
-	{
-		memset(m_wszMarkerTextUnicode, 0, sizeof(m_wszMarkerTextUnicode));
-	}
-	else
+
+	if (!NEORules()->GetGhosterPlayer())
 	{
 		const float flDistMeters = METERS_PER_INCH * C_NEO_Player::GetLocalPlayer()->GetAbsOrigin().DistTo(NEORules()->GetGhostPos());
-		V_snprintf(m_szMarkerText, sizeof(m_szMarkerText), "GHOST DISTANCE: %.0fm", flDistMeters);
-		g_pVGuiLocalize->ConvertANSIToUnicode(m_szMarkerText, m_wszMarkerTextUnicode, sizeof(m_wszMarkerTextUnicode));
+		if (cl_neo_hud_worldpos_verbose.GetBool())
+		{
+			V_snwprintf(m_wszMarkerTextUnicode, ARRAYSIZE(m_wszMarkerTextUnicode), L"GHOST DISTANCE: %.0fm", flDistMeters);
+		}
+		else
+		{
+			V_snwprintf(m_wszMarkerTextUnicode, ARRAYSIZE(m_wszMarkerTextUnicode), L"%.0fm", flDistMeters);
+		}
 	}
 }
 
@@ -160,7 +151,7 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 		Assert(m_ghostInPVS);
 	}
 
-	bool hideText = false;
+	bool hideText = NEORules()->GetGhosterPlayer();
 	Color ghostColor = COLOR_GREY;
 	const int iGhostingTeam = NEORules()->GetGhosterTeam();
 	const int iClientTeam = localPlayer->GetTeamNumber();
@@ -175,9 +166,6 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 		{
 			// Otherwise show ghosting team color (if friendly or spec)
 			ghostColor = (iGhostingTeam == TEAM_JINRAI) ? COLOR_JINRAI : COLOR_NSF;
-
-			// Use the friendly HUD text for distance display instead if spectator team or same team
-			hideText = (iClientTeam < FIRST_GAME_TEAM || iGhostingTeam == iClientTeam);
 		}
 	}
 
@@ -216,19 +204,6 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 	int iPosX, iPosY;
 	GetVectorInScreenSpace(ghostPos, iPosX, iPosY);
 
-	const float fadeMultiplier = GetFadeValueTowardsScreenCentre(iPosX, iPosY);
-	if (!hideText && fadeMultiplier > 0.001f)
-	{
-		auto adjustedGrey = Color(COLOR_GREY.r(), COLOR_GREY.b(), COLOR_GREY.g(), COLOR_GREY.a() * fadeMultiplier);
-	
-		surface()->DrawSetTextColor(adjustedGrey);
-		surface()->DrawSetTextFont(m_hFont);
-		int textSizeX, textSizeY;
-		surface()->GetTextSize(m_hFont, m_wszMarkerTextUnicode, textSizeX, textSizeY);
-		surface()->DrawSetTextPos(iPosX - (textSizeX / 2), iPosY + (2 * textSizeY));
-		surface()->DrawPrintText(m_wszMarkerTextUnicode, sizeof(m_szMarkerText));
-	}
-
 	const float scale = neo_ghost_marker_hud_scale_factor.GetFloat();
 
 	// The increase and decrease in alpha over 6 seconds
@@ -238,13 +213,13 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 		alpha6 = 1 - alpha6;
 	alpha6 = 128 * alpha6;
 
+	constexpr float HALF_BASE_TEX_LENGTH = 64;
 	for (int i = 0; i < 4; i++) {
 		m_fMarkerScalesCurrent[i] = (remainder(gpGlobals->curtime, 2) / 2) + 0.5 + m_fMarkerScalesStart[i];
 		if (m_fMarkerScalesCurrent[i] > 1)
 			m_fMarkerScalesCurrent[i] -= 1;
 
-		const int offset_X = iPosX - ((m_iMarkerTexWidth * 0.5f * m_fMarkerScalesCurrent[i]) * scale);
-		const int offset_Y = iPosY - ((m_iMarkerTexHeight * 0.5f * m_fMarkerScalesCurrent[i]) * scale);
+		const float halfCurrentCircle = HALF_BASE_TEX_LENGTH * m_fMarkerScalesCurrent[i] * scale;
 
 		int alpha = 64 + alpha6;
 		if (m_fMarkerScalesCurrent[i] > 0.5)
@@ -255,12 +230,24 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 		surface()->DrawSetColor(ghostColor);
 		surface()->DrawSetTexture(m_hTex);
 		surface()->DrawTexturedRect(
-			offset_X,
-			offset_Y,
-			offset_X + (m_iMarkerTexWidth * m_fMarkerScalesCurrent[i] * scale),
-			offset_Y + (m_iMarkerTexHeight * m_fMarkerScalesCurrent[i] * scale));
+			iPosX - halfCurrentCircle,
+			iPosY - halfCurrentCircle,
+			iPosX + halfCurrentCircle,
+			iPosY + halfCurrentCircle);
 	}
-
+	
+	const float fadeMultiplier = GetFadeValueTowardsScreenCentre(iPosX, iPosY);
+	if (!hideText && fadeMultiplier > 0.001f)
+	{
+		auto adjustedGrey = Color(COLOR_GREY.r(), COLOR_GREY.b(), COLOR_GREY.g(), COLOR_GREY.a() * fadeMultiplier);
+	
+		surface()->DrawSetTextColor(adjustedGrey);
+		surface()->DrawSetTextFont(m_hFont);
+		int textSizeX, textSizeY;
+		surface()->GetTextSize(m_hFont, m_wszMarkerTextUnicode, textSizeX, textSizeY);
+		surface()->DrawSetTextPos(iPosX - (textSizeX / 2), iPosY + (HALF_BASE_TEX_LENGTH * scale));
+		surface()->DrawPrintText(m_wszMarkerTextUnicode, V_wcslen(m_wszMarkerTextUnicode));
+	}
 }
 
 void CNEOHud_GhostMarker::Paint()

--- a/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
@@ -23,9 +23,9 @@
 
 using vgui::surface;
 
-ConVar neo_ghost_marker_hud_scale_factor("neo_ghost_marker_hud_scale_factor", "1", FCVAR_USERINFO,
+ConVar neo_ghost_marker_hud_scale_factor("neo_ghost_marker_hud_scale_factor", "1", FCVAR_ARCHIVE,
 	"Ghost marker HUD element scaling factor", true, 0.01, false, 0);
-ConVar cl_neo_hud_center_ghost_marker_size("cl_neo_hud_center_ghost_marker_size", "12.5", FCVAR_USERINFO,
+ConVar cl_neo_hud_center_ghost_marker_size("cl_neo_hud_center_ghost_marker_size", "12.5", FCVAR_ARCHIVE,
 	"HUD center size in percentage to fade ghost marker.", true, 1, false, 0);
 
 

--- a/src/game/client/neo/ui/neo_hud_ghost_marker.h
+++ b/src/game/client/neo/ui/neo_hud_ghost_marker.h
@@ -32,9 +32,7 @@ private:
 	C_WeaponGhost *m_ghostInPVS = nullptr;
 	float m_fMarkerScalesStart[4] = { 0.78f, 0.6f, 0.38f, 0.0f };
 	float m_fMarkerScalesCurrent[4] = { 0.78f, 0.6f, 0.38f, 0.0f };
-	int m_iMarkerTexWidth, m_iMarkerTexHeight;
 
-	char m_szMarkerText[32 + 1];
 	wchar_t m_wszMarkerTextUnicode[32 + 1];
 
 	vgui::HTexture m_hTex = 0UL;

--- a/src/game/client/neo/ui/neo_hud_worldpos_marker.cpp
+++ b/src/game/client/neo/ui/neo_hud_worldpos_marker.cpp
@@ -6,8 +6,7 @@
 
 using vgui::surface;
 
-
-ConVar cl_neo_hud_centre_size("cl_neo_hud_centre_size", "25", FCVAR_USERINFO,
+ConVar cl_neo_hud_centre_size("cl_neo_hud_centre_size", "25", FCVAR_ARCHIVE,
                               "HUD centre size in percentage to fade markers.", true, 1, false, 0);
 ConVar cl_neo_hud_worldpos_verbose("cl_neo_hud_worldpos_verbose", "1", FCVAR_ARCHIVE, "Display full world pos marker string", true, 0, true, 1);
 

--- a/src/game/client/neo/ui/neo_hud_worldpos_marker.cpp
+++ b/src/game/client/neo/ui/neo_hud_worldpos_marker.cpp
@@ -9,6 +9,7 @@ using vgui::surface;
 
 ConVar cl_neo_hud_centre_size("cl_neo_hud_centre_size", "25", FCVAR_USERINFO,
                               "HUD centre size in percentage to fade markers.", true, 1, false, 0);
+ConVar cl_neo_hud_worldpos_verbose("cl_neo_hud_worldpos_verbose", "1", FCVAR_ARCHIVE, "Display full world pos marker string", true, 0, true, 1);
 
 CNEOHud_WorldPosMarker::CNEOHud_WorldPosMarker(const char* pElementName, Panel* parent)
     : CHudElement(pElementName),


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Size of elements now depends solely on convar settings for those hud elements (and resolution for the ghost beacons when scaling with distance is enabled I guess)

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #787
