### PR TITLE
Round win/tie center hud element not resizing on resolution change fix

### DIFF
--- a/game/neo/scripts/HudLayout.res
+++ b/game/neo/scripts/HudLayout.res
@@ -945,6 +945,8 @@
 		"ypos"	"0"
 		"wide"	"640"
 		"tall"	"480"
+		"image_y_offset" "60"
+		"text_y_offset" "420"
 	}
 
 	neo_iff


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Turns out these proportional_ypos / width / etc variables don't change when the resolution is changed while the game is running unless they have an entry in HudLayout.res
