### PR TITLE
Configurable Xray

### DIFF
--- a/src/game/client/clientmode_shared.cpp
+++ b/src/game/client/clientmode_shared.cpp
@@ -85,6 +85,7 @@ extern ConVar replay_rendersetting_renderglow;
 CLIENTEFFECT_REGISTER_BEGIN(PrecachePostProcessingEffectsGlow)
 CLIENTEFFECT_MATERIAL("dev/glow_color")
 CLIENTEFFECT_MATERIAL("dev/halo_add_to_screen")
+CLIENTEFFECT_MATERIAL("dev/halo_add_to_screen_outline")
 CLIENTEFFECT_REGISTER_END_CONDITIONAL(engine->GetDXSupportLevel() >= 90)
 #endif
 #define ACHIEVEMENT_ANNOUNCEMENT_MIN_TIME 10

--- a/src/game/client/glow_outline_effect.cpp
+++ b/src/game/client/glow_outline_effect.cpp
@@ -212,8 +212,6 @@ void CGlowObjectManager::ApplyEntityGlowEffects( const CViewSetup *pSetup, int n
 
 	int iNumGlowObjects = 0;
 
-	m_GlowObjectDefinitions.Sort();
-
 	for ( int i = 0; i < m_GlowObjectDefinitions.Count(); ++ i )
 	{
 		if ( m_GlowObjectDefinitions[i].IsUnused() || !m_GlowObjectDefinitions[i].ShouldDraw( nSplitScreenSlot ) )

--- a/src/game/client/glow_outline_effect.cpp
+++ b/src/game/client/glow_outline_effect.cpp
@@ -212,6 +212,8 @@ void CGlowObjectManager::ApplyEntityGlowEffects( const CViewSetup *pSetup, int n
 
 	int iNumGlowObjects = 0;
 
+	m_GlowObjectDefinitions.Sort();
+
 	for ( int i = 0; i < m_GlowObjectDefinitions.Count(); ++ i )
 	{
 		if ( m_GlowObjectDefinitions[i].IsUnused() || !m_GlowObjectDefinitions[i].ShouldDraw( nSplitScreenSlot ) )
@@ -365,7 +367,7 @@ void CGlowObjectManager::ApplyEntityGlowEffects( const CViewSetup *pSetup, int n
 		if (alpha)
 		{
 			stencilStateDisable.SetStencilState( pRenderContext );
-			pDimVar->SetFloatValue(glow_outline_effect_center_alpha.GetFloat());
+			pDimVar->SetFloatValue(alpha);
 			pRenderContext->DrawScreenSpaceRectangle(pMatHaloAddToScreen, 0, 0, nViewportWidth+1, nViewportHeight+1,
 				0, 0, pRtQuarterSize1->GetActualWidth(), pRtQuarterSize1->GetActualHeight(),
 				pRtQuarterSize1->GetActualWidth(),

--- a/src/game/client/glow_outline_effect.cpp
+++ b/src/game/client/glow_outline_effect.cpp
@@ -21,6 +21,8 @@
 #ifdef GLOWS_ENABLE
 
 #ifdef NEO
+ConVar glow_outline_effect_center_alpha("glow_outline_effect_center_alpha", "0.05f", FCVAR_ARCHIVE, "Opacity of the part of the glow effect drawn on top of the player model", true, 0.f, true, 1.f);
+
 extern ConVar mp_forcecamera;
 static void glowOutlineEffectToggleCallBack(IConVar* var, const char* pOldValue, float flOldValue)
 {
@@ -43,7 +45,9 @@ static void glowOutlineEffectToggleCallBack(IConVar* var, const char* pOldValue,
 }
 #endif // NEO
 ConVar glow_outline_effect_enable( "glow_outline_effect_enable", "0", 0, "Enable entity outline glow effects.", glowOutlineEffectToggleCallBack);
-#ifndef NEO
+#ifdef NEO
+ConVar glow_outline_effect_width( "glow_outline_effect_width", "0.5f", FCVAR_ARCHIVE, "Width of glow outline effect in screen space.", true, 0.f, false, 0.f);
+#else
 ConVar glow_outline_effect_width( "glow_outline_width", "10.0f", FCVAR_CHEAT, "Width of glow outline effect in screen space." );
 #endif // NEO
 
@@ -311,7 +315,11 @@ void CGlowObjectManager::ApplyEntityGlowEffects( const CViewSetup *pSetup, int n
 	pRenderContext->GetViewport( nViewportX, nViewportY, nViewportWidth, nViewportHeight );
 
 	// Get material and texture pointers
+#ifdef NEO
+	ITexture *pRtQuarterSize1 = materials->FindTexture( FULL_FRAME_TEXTURE, TEXTURE_GROUP_RENDER_TARGET );
+#else
 	ITexture *pRtQuarterSize1 = materials->FindTexture( "_rt_SmallFB1", TEXTURE_GROUP_RENDER_TARGET );
+#endif //NEO
 
 	{
 		//=======================================================================================================//
@@ -320,6 +328,9 @@ void CGlowObjectManager::ApplyEntityGlowEffects( const CViewSetup *pSetup, int n
 		// stencil bits set in the range we care about.                                                          //
 		//=======================================================================================================//
 		IMaterial *pMatHaloAddToScreen = materials->FindMaterial( "dev/halo_add_to_screen", TEXTURE_GROUP_OTHER, true );
+#ifdef NEO
+		IMaterial *pMatHaloAddToScreenOutline = materials->FindMaterial( "dev/halo_add_to_screen_outline", TEXTURE_GROUP_OTHER, true );
+#endif // NEO
 
 		// Do not fade the glows out at all (weight = 1.0)
 		IMaterialVar *pDimVar = pMatHaloAddToScreen->FindVar( "$C0_X", NULL );
@@ -329,7 +340,7 @@ void CGlowObjectManager::ApplyEntityGlowEffects( const CViewSetup *pSetup, int n
 		ShaderStencilState_t stencilState;
 		stencilState.m_bEnable = true;
 		stencilState.m_nWriteMask = 0x0; // We're not changing stencil
-		stencilState.m_nTestMask = 0xFF;
+		stencilState.m_nTestMask = 0xFF; 
 		stencilState.m_nReferenceValue = 0x0;
 		stencilState.m_CompareFunc = STENCILCOMPARISONFUNCTION_EQUAL;
 		stencilState.m_PassOp = STENCILOPERATION_KEEP;
@@ -339,23 +350,27 @@ void CGlowObjectManager::ApplyEntityGlowEffects( const CViewSetup *pSetup, int n
 
 		// Draw quad
 #ifdef NEO
-		pRenderContext->DrawScreenSpaceRectangle( pMatHaloAddToScreen, 0, 0, nViewportWidth, nViewportHeight,
-			-0.25f, -0.25f, nSrcWidth / 4 - 1, nSrcHeight / 4 - 1,
-			pRtQuarterSize1->GetActualWidth(),
-			pRtQuarterSize1->GetActualHeight() );
+		const float outlineWidth = glow_outline_effect_width.GetFloat();
+		if (outlineWidth)
+		{
+			IMaterialVar* pOutlineVar = pMatHaloAddToScreenOutline->FindVar("$C0_X", NULL);
+			pOutlineVar->SetFloatValue(outlineWidth);
+			pRenderContext->DrawScreenSpaceRectangle(pMatHaloAddToScreenOutline, 0, 0, nViewportWidth+1, nViewportHeight+1,
+				0, 0, pRtQuarterSize1->GetActualWidth(), pRtQuarterSize1->GetActualHeight(),
+				pRtQuarterSize1->GetActualWidth(),
+				pRtQuarterSize1->GetActualHeight());
+		}
 
-		pRenderContext->DrawScreenSpaceRectangle(pMatHaloAddToScreen, 0, 0, nViewportWidth, nViewportHeight,
-			0.25f, 0.25f, nSrcWidth / 4 - 1, nSrcHeight / 4 - 1,
-			pRtQuarterSize1->GetActualWidth(),
-			pRtQuarterSize1->GetActualHeight());
-
-		stencilStateDisable.SetStencilState( pRenderContext );
-
-		pDimVar->SetFloatValue(0.15f);
-		pRenderContext->DrawScreenSpaceRectangle(pMatHaloAddToScreen, 0, 0, nViewportWidth, nViewportHeight,
-			0, 0, nSrcWidth / 4 - 1, nSrcHeight / 4 - 1,
-			pRtQuarterSize1->GetActualWidth(),
-			pRtQuarterSize1->GetActualHeight());
+		const float alpha = glow_outline_effect_center_alpha.GetFloat();
+		if (alpha)
+		{
+			stencilStateDisable.SetStencilState( pRenderContext );
+			pDimVar->SetFloatValue(glow_outline_effect_center_alpha.GetFloat());
+			pRenderContext->DrawScreenSpaceRectangle(pMatHaloAddToScreen, 0, 0, nViewportWidth+1, nViewportHeight+1,
+				0, 0, pRtQuarterSize1->GetActualWidth(), pRtQuarterSize1->GetActualHeight(),
+				pRtQuarterSize1->GetActualWidth(),
+				pRtQuarterSize1->GetActualHeight());
+		}
 #else
 		pRenderContext->DrawScreenSpaceRectangle(pMatHaloAddToScreen, 0, 0, nViewportWidth, nViewportHeight,
 			0.0f, -0.5f, nSrcWidth / 4 - 1, nSrcHeight / 4 - 1,

--- a/src/materialsystem/stdshaders/include/neo_haloaddoutline_ps20b.inc
+++ b/src/materialsystem/stdshaders/include/neo_haloaddoutline_ps20b.inc
@@ -1,0 +1,42 @@
+// ALL SKIP STATEMENTS THAT AFFECT THIS SHADER!!!
+// defined $HDRTYPE && defined $HDRENABLED && !$HDRTYPE && $HDRENABLED
+// defined $PIXELFOGTYPE && defined $WRITEWATERFOGTODESTALPHA && ( $PIXELFOGTYPE != 1 ) && $WRITEWATERFOGTODESTALPHA
+// defined $LIGHTING_PREVIEW && defined $HDRTYPE && $LIGHTING_PREVIEW && $HDRTYPE != 0
+// defined $LIGHTING_PREVIEW && defined $FASTPATHENVMAPTINT && $LIGHTING_PREVIEW && $FASTPATHENVMAPTINT
+// defined $LIGHTING_PREVIEW && defined $FASTPATHENVMAPCONTRAST && $LIGHTING_PREVIEW && $FASTPATHENVMAPCONTRAST
+// defined $LIGHTING_PREVIEW && defined $FASTPATH && $LIGHTING_PREVIEW && $FASTPATH
+// ($FLASHLIGHT || $FLASHLIGHTSHADOWS) && $LIGHTING_PREVIEW
+
+#pragma once
+#include "shaderlib/cshader.h"
+class neo_haloaddoutline_ps20b_Static_Index
+{
+public:
+	neo_haloaddoutline_ps20b_Static_Index(  )
+	{
+	}
+
+	int GetIndex() const
+	{
+		return 0;
+	}
+};
+
+#define shaderStaticTest_neo_haloaddoutline_ps20b 1
+
+
+class neo_haloaddoutline_ps20b_Dynamic_Index
+{
+public:
+	neo_haloaddoutline_ps20b_Dynamic_Index(  )
+	{
+	}
+
+	int GetIndex() const
+	{
+		return 0;
+	}
+};
+
+#define shaderDynamicTest_neo_haloaddoutline_ps20b 1
+

--- a/src/materialsystem/stdshaders/neo_haloaddoutline_ps2x.fxc
+++ b/src/materialsystem/stdshaders/neo_haloaddoutline_ps2x.fxc
@@ -1,0 +1,34 @@
+//======= Copyright © 1996-2006, Valve Corporation, All rights reserved. ======
+
+#include "common_ps_fxc.h"
+
+sampler TexSampler : register( s0 );
+sampler TexRed : register( s1 );
+sampler TexGreen : register( s2 );
+sampler TexBlue : register( s3 );
+
+float g_flOutlineWidth : register( c0 );
+float2 g_vPixelSize : register( c4 );
+
+struct PS_INPUT
+{
+	float2 baseTexCoord : TEXCOORD0; // Base texture coordinate
+};
+
+float4 main( PS_INPUT i ) : COLOR
+{
+	float2 vOffset = g_flOutlineWidth * g_vPixelSize.xy;
+
+	// Take the max of 4 offset texture samples
+	float4 result;
+	result.rgba = tex2D( TexSampler, i.baseTexCoord.xy + float2( vOffset.x, vOffset.y ) );
+	result.rgba = max( result.rgba, tex2D( TexSampler, i.baseTexCoord.xy + float2( vOffset.x, -vOffset.y ) ) );
+	result.rgba = max( result.rgba, tex2D( TexSampler, i.baseTexCoord.xy + float2( -vOffset.x, vOffset.y ) ) );
+	result.rgba = max( result.rgba, tex2D( TexSampler, i.baseTexCoord.xy + float2( -vOffset.x, -vOffset.y ) ) );
+
+	// Store max color component in alpha for alpha blend of one/invSrcAlpha
+	float flLuminance = max( result.r, max( result.g, result.b ) );
+	result.a = flLuminance;
+
+	return result.rgba;
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

[NeoAssets PR](https://github.com/NeotokyoRebuild/neoAssets/pull/53)

Switched to a full frame buffer for the outline, for a more accurate player outline Made a copy of the haloaddoutline_ps20b shader, with the only difference being the width of the shader now being configurable from the material and/or in code via convar. Also made the opacity of the fill shader a convar too, this way both can be configured and disabled with values of 0
