### PR TITLE
fix loading ui crash getting an non valid adress for UText

### DIFF
--- a/src/game/client/neo/ui/neo_loading.cpp
+++ b/src/game/client/neo/ui/neo_loading.cpp
@@ -209,7 +209,7 @@ void CNeoLoading::OnMainLoop(const NeoUI::Mode eMode)
 		NeoUI::BeginSection(true);
 		{
 			NeoUI::Label(L"Press ESC to cancel");
-			if (m_pLabelInfo) NeoUI::Label(m_pLabelInfo->GetTextImage()->GetUText());
+			if (m_pLabelInfo) //NeoUI::Label(m_pLabelInfo->GetTextImage()->GetUText());
 			if (m_pProgressBarMain) NeoUI::Progress(m_pProgressBarMain->GetProgress(), 0.0f, 1.0f);
 		}
 		NeoUI::EndSection();


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
There is a crash that happens in the neo_loading UI which is caused by m_bInfoLabel being an invalid memory address
This fixes it by just removing the info label step 

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

