### PR TITLE
NeoUI Loading screen - Do not hold pointer to panels

### DIFF
--- a/src/game/client/neo/ui/neo_loading.h
+++ b/src/game/client/neo/ui/neo_loading.h
@@ -2,6 +2,7 @@
 
 #include "ui/neo_ui.h"
 #include <vgui_controls/EditablePanel.h>
+#include <tier1/ilocalize.h>
 
 /*
  * Override loading screen
@@ -21,19 +22,6 @@ public:
 	void ApplySchemeSettings(vgui::IScheme *pScheme) final;
 	void ResetSizes(const int wide, const int tall);
 	void OnMessage(const KeyValues *params, vgui::VPANEL fromPanel) final;
-	void FetchGameUIPanels();
-
-	void Paint() final;
-	void OnMainLoop(const NeoUI::Mode eMode);
-
-	NeoUI::Context m_uiCtx;
-	int m_iRowsInScreen = 0;
-	int m_iRootSubPanelWide = 0;
-
-	bool m_bValidGameUIPanels = false;
-	vgui::Frame *m_pLoadingPanel = nullptr;
-	vgui::ProgressBar *m_pProgressBarMain = nullptr;
-	vgui::Label *m_pLabelInfo = nullptr;
 
 	enum ELoadingState
 	{
@@ -42,5 +30,36 @@ public:
 
 		LOADINGSTATE__TOTAL,
 	};
-	unsigned long m_aStrIdxMap[LOADINGSTATE__TOTAL] = {};
+
+	struct RetGameUIPanels
+	{
+		vgui::Frame *pLoadingPanel; // If nullptr have no loading panels
+		vgui::ProgressBar *pProgressBarMain;
+		vgui::Label *pLabelInfo;
+		StringIndex_t aStrIdxMap[LOADINGSTATE__TOTAL];
+	};
+
+	static RetGameUIPanels FetchGameUIPanels();
+
+	void Paint() final;
+
+	// NEO JANK (nullsystem): Keeping a pointer to the panels on an OnMessage then
+	// using it later may not be reliable, so instead have an OnThink to refetch it
+	// from time to time. Limited to only when g_pNeoRoot->m_bOnLoadingScreen and
+	// at an interval.
+	void OnThink();
+
+	NeoUI::Context m_uiCtx;
+	int m_iRowsInScreen = 0;
+	int m_iRootSubPanelWide = 0;
+
+	struct LoadingInfos
+	{
+		float flProgressBarMain;
+		wchar_t wszTitle[256];
+		wchar_t wszLabelInfo[1024];
+		StringIndex_t aStrIdxMap[LOADINGSTATE__TOTAL];
+		StringIndex_t iStrIdx;
+	};
+	LoadingInfos m_info = {};
 };


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Instead, fetch panels on OnThink (250ms intervals) and just copy over the panels text/values data instead
* I cannot reproduce the crash Nbc66 having but I think this could at least mitigate the invalid pointer issue
* Panel fetching at an 250ms interval so shouldn't be too much of a performance issue, plus requiring it to be within activate/deactivate states
* Should be more robust as NeoUI widgets just fetches from plain data that's always in allocation


## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - Gentoo Linux/GCC 14.2.1

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1176

