### PR TITLE
Improve VS Studio 2022 instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,9 @@ See [README.md](README.md) in this repo for setting up your build environment (c
 To be safe and avoid problems with VAC, it's recommended to add a [-insecure](https://developer.valvesoftware.com/wiki/Command_Line_Options) launch flag before attaching your debugger.
 
 #### VS2022 + CMake (Windows)
-In the CMake Target View, right-click "client (shared library)" and click on "Add Debug Configuration". This should show a json file. Then, make sure it's similar to this (changing the game path to where you have it):
+In the CMake Target View, right-click "client (shared library)" and click on "Add Debug Configuration". This should show a json file. If this doesn't work, try to instead view the main CMakeLists.txt file in the *Folder View*, and choose the corresponding "Add Debug Configuration" menu option from there, instead.
+
+Then, make sure it's similar to this (changing the game path to where you have it):
 
 ```
 {


### PR DESCRIPTION


## Description
Improve the documentation for setting up VS 2022 debugging, since the current instructions using the CMake Targets View can apparently fail for some unknown reason.

## Toolchain
- Windows MSVC VS2022


