### PR TITLE
Networked crosshair

### DIFF
--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -1264,7 +1264,8 @@ void MusicVol_ChangeCallback(IConVar *cvar, const char *pOldVal, float flOldVal)
 #ifdef NEO
 extern void NeoToggleConsoleEnforce();
 
-static void NeoName_ChangeCallback(IConVar *cvar, [[maybe_unused]] const char *pOldVal, [[maybe_unused]] float flOldVal)
+template <int STR_LIMIT_SIZE>
+static void NeoConVarStrLimitChangeCallback(IConVar *cvar, [[maybe_unused]] const char *pOldVal, [[maybe_unused]] float flOldVal)
 {
 	static bool bStaticCallbackChangedCVar = false;
 	if (bStaticCallbackChangedCVar)
@@ -1272,34 +1273,14 @@ static void NeoName_ChangeCallback(IConVar *cvar, [[maybe_unused]] const char *p
 		return;
 	}
 
-	ConVarRef cvr_neo_name(cvar->GetName());
-	if (V_strlen(cvr_neo_name.GetString()) >= MAX_PLAYER_NAME_LENGTH)
+	ConVarRef cvarRef(cvar);
+	if (V_strlen(cvarRef.GetString()) >= STR_LIMIT_SIZE)
 	{
 		bStaticCallbackChangedCVar = true;
-		char mutStr[MAX_PLAYER_NAME_LENGTH];
-		V_strcpy_safe(mutStr, cvr_neo_name.GetString());
+		char mutStr[STR_LIMIT_SIZE];
+		V_strcpy_safe(mutStr, cvarRef.GetString());
 		Q_UnicodeRepair(mutStr);
-		cvr_neo_name.SetValue(mutStr);
-		bStaticCallbackChangedCVar = false;
-	}
-}
-
-static void NeoClantag_ChangeCallback(IConVar *cvar, [[maybe_unused]] const char *pOldVal, [[maybe_unused]] float flOldVal)
-{
-	static bool bStaticCallbackChangedCVar = false;
-	if (bStaticCallbackChangedCVar)
-	{
-		return;
-	}
-
-	ConVarRef cvr_neo_clantag(cvar->GetName());
-	if (V_strlen(cvr_neo_clantag.GetString()) >= NEO_MAX_CLANTAG_LENGTH)
-	{
-		bStaticCallbackChangedCVar = true;
-		char mutStr[NEO_MAX_CLANTAG_LENGTH];
-		V_strcpy_safe(mutStr, cvr_neo_clantag.GetString());
-		Q_UnicodeRepair(mutStr);
-		cvr_neo_clantag.SetValue(mutStr);
+		cvarRef.SetValue(mutStr);
 		bStaticCallbackChangedCVar = false;
 	}
 }
@@ -1423,8 +1404,9 @@ void CHLClient::PostInit()
 	if (g_pCVar)
 	{
 		g_pCVar->FindVar("snd_musicvolume")->InstallChangeCallback(MusicVol_ChangeCallback);
-		g_pCVar->FindVar("neo_name")->InstallChangeCallback(NeoName_ChangeCallback);
-		g_pCVar->FindVar("neo_clantag")->InstallChangeCallback(NeoClantag_ChangeCallback);
+		g_pCVar->FindVar("neo_name")->InstallChangeCallback(NeoConVarStrLimitChangeCallback<MAX_PLAYER_NAME_LENGTH>);
+		g_pCVar->FindVar("neo_clantag")->InstallChangeCallback(NeoConVarStrLimitChangeCallback<NEO_MAX_CLANTAG_LENGTH>);
+		g_pCVar->FindVar("cl_neo_crosshair")->InstallChangeCallback(NeoConVarStrLimitChangeCallback<NEO_XHAIR_SEQMAX>);
 		g_pCVar->FindVar("sv_use_steam_networking")->SetValue(false);
 	}
 	else

--- a/src/game/client/hud_crosshair.h
+++ b/src/game/client/hud_crosshair.h
@@ -35,7 +35,12 @@ public:
 
 #ifdef NEO
 	bool m_bRefreshCrosshair = true;
-	CrosshairInfo m_crosshairInfo;
+	CrosshairInfo m_crosshairInfo = {};
+
+	// m_szLocalStrPlayersCrosshair is just for crosshair refresh checks
+	char m_szLocalStrPlayersCrosshair[MAX_PLAYERS][NEO_XHAIR_SEQMAX] = {};
+	CrosshairInfo m_playersCrosshairInfos[MAX_PLAYERS] = {};
+	float m_aflLastCheckedPlayersCrosshair[MAX_PLAYERS] = {};
 #endif
 
 	virtual void	SetCrosshairAngle( const QAngle& angle );

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -95,6 +95,7 @@ IMPLEMENT_CLIENTCLASS_DT(C_NEO_Player, DT_NEO_Player, CNEO_Player)
 	RecvPropInt(RECVINFO(m_NeoFlags)),
 	RecvPropString(RECVINFO(m_szNeoName)),
 	RecvPropString(RECVINFO(m_szNeoClantag)),
+	RecvPropString(RECVINFO(m_szNeoCrosshair)),
 	RecvPropInt(RECVINFO(m_szNameDupePos)),
 	RecvPropBool(RECVINFO(m_bClientWantNeoName)),
 
@@ -503,6 +504,7 @@ C_NEO_Player::C_NEO_Player()
 	m_iNeoStar = NEO_DEFAULT_STAR;
 	V_memset(m_szNeoName.GetForModify(), 0, sizeof(m_szNeoName));
 	V_memset(m_szNeoClantag.GetForModify(), 0, sizeof(m_szNeoClantag));
+	V_memset(m_szNeoCrosshair.GetForModify(), 0, sizeof(m_szNeoCrosshair));
 
 	m_iLoadoutWepChoice = NEORules()->GetForcedWeapon() >= 0 ? NEORules()->GetForcedWeapon() : 0;
 	m_iNextSpawnClassChoice = -1;

--- a/src/game/client/neo/c_neo_player.h
+++ b/src/game/client/neo/c_neo_player.h
@@ -215,6 +215,7 @@ public:
 
 	CNetworkString(m_szNeoName, MAX_PLAYER_NAME_LENGTH);
 	CNetworkString(m_szNeoClantag, NEO_MAX_CLANTAG_LENGTH);
+	CNetworkString(m_szNeoCrosshair, NEO_XHAIR_SEQMAX);
 	CNetworkVar(int, m_szNameDupePos);
 	CNetworkVar(bool, m_bClientWantNeoName);
 

--- a/src/game/client/neo/ui/neo_hud_crosshair.cpp
+++ b/src/game/client/neo/ui/neo_hud_crosshair.cpp
@@ -7,6 +7,7 @@
 #include "ui/neo_root.h"
 
 ConVar cl_neo_crosshair("cl_neo_crosshair", CL_NEO_CROSSHAIR_DEFAULT, FCVAR_ARCHIVE | FCVAR_USERINFO, "Serialized crosshair setting");
+ConVar cl_neo_crosshair_network("cl_neo_crosshair_network", "1", FCVAR_ARCHIVE | FCVAR_CLIENTDLL, "Network crosshair - 0 = disable, 1 = show other players' crosshairs", true, 0.0f, true, 1.0f);
 
 static const char *INTERNAL_CROSSHAIR_FILES[CROSSHAIR_STYLE__TOTAL] = { "vgui/hud/crosshair", "vgui/hud/crosshair_b", "" };
 const char **CROSSHAIR_FILES = INTERNAL_CROSSHAIR_FILES;

--- a/src/game/client/neo/ui/neo_hud_crosshair.h
+++ b/src/game/client/neo/ui/neo_hud_crosshair.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "neo_player_shared.h"
+
 static constexpr int CROSSHAIR_MAX_SIZE = 100;
 static constexpr int CROSSHAIR_MAX_THICKNESS = 25;
 static constexpr int CROSSHAIR_MAX_GAP = 25;
@@ -26,13 +28,14 @@ enum NeoHudCrosshairSizeType
 };
 
 extern ConVar cl_neo_crosshair;
+extern ConVar cl_neo_crosshair_network;
 
 extern const char **CROSSHAIR_FILES;
 extern const wchar_t **CROSSHAIR_LABELS;
 extern const wchar_t **CROSSHAIR_SIZETYPE_LABELS;
 
-#define CL_NEO_CROSSHAIR_DEFAULT "2;0;-1;0;2;0.000;1;2;0;0;1;0;0;"
-static constexpr const int NEO_XHAIR_SEQMAX = 256;
+#define CL_NEO_CROSSHAIR_DEFAULT "2;0;-1;0;6;0.000;2;4;0;0;1;0;0;"
+// NEO_XHAIR_SEQMAX defined in neo_player_shared.h instead
 
 enum NeoXHairSegment
 {

--- a/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/src/game/client/neo/ui/neo_root_settings.cpp
@@ -426,6 +426,7 @@ void NeoSettingsRestore(NeoSettings *ns, const NeoSettings::Keys::Flags flagsKey
 			ImportCrosshair(&pCrosshair->info, CL_NEO_CROSSHAIR_DEFAULT);
 		}
 		pCrosshair->eClipboardInfo = XHAIREXPORTNOTIFY_NONE;
+		pCrosshair->bNetworkCrosshair = cvr->cl_neo_crosshair_network.GetBool();
 	}
 }
 
@@ -607,6 +608,7 @@ void NeoSettingsSave(const NeoSettings *ns)
 		char szSequence[NEO_XHAIR_SEQMAX];
 		ExportCrosshair(&pCrosshair->info, szSequence);
 		cvr->cl_neo_crosshair.SetValue(szSequence);
+		cvr->cl_neo_crosshair_network.SetValue(pCrosshair->bNetworkCrosshair);
 	}
 
 	engine->ClientCmd_Unrestricted("host_writeconfig");
@@ -887,59 +889,70 @@ void NeoSettings_Crosshair(NeoSettings *ns)
 		}
 		vgui::surface()->DrawSetColor(g_uiCtx.normalBgColor);
 
-		if (pCrosshair->info.iStyle == CROSSHAIR_STYLE_CUSTOM)
+		NeoUI::SetPerRowLayout(4);
 		{
-			NeoUI::SetPerRowLayout(4);
+			const bool bExportPressed = NeoUI::Button(L"Export to clipboard").bPressed;
+			const bool bImportPressed = NeoUI::Button(L"Import from clipboard").bPressed;
+			const bool bDefaultPressed = NeoUI::Button(L"Reset to default").bPressed;
+
+			if (bExportPressed || bImportPressed)
 			{
-				const bool bExportPressed = NeoUI::Button(L"Export to clipboard").bPressed;
-				const bool bImportPressed = NeoUI::Button(L"Import from clipboard").bPressed;
-				if (bExportPressed || bImportPressed)
+				char szClipboardCrosshair[NEO_XHAIR_SEQMAX] = {}; // zero-init
+				if (bExportPressed)
 				{
-					char szClipboardCrosshair[NEO_XHAIR_SEQMAX] = {}; // zero-init
-					if (bExportPressed)
+					// NEO NOTE (nullsystem): On Windows, SetClipboardText sets from char * looks fine
+					ExportCrosshair(&pCrosshair->info, szClipboardCrosshair);
+					vgui::system()->SetClipboardText(szClipboardCrosshair, V_strlen(szClipboardCrosshair));
+					pCrosshair->eClipboardInfo = XHAIREXPORTNOTIFY_EXPORT_TO_CLIPBOARD;
+				}
+				else // bImportPressed
+				{
+					bool bImported = false;
+					if (vgui::system()->GetClipboardTextCount() > 0)
 					{
-						// NEO NOTE (nullsystem): On Windows, SetClipboardText sets from char * looks fine
-						ExportCrosshair(&pCrosshair->info, szClipboardCrosshair);
-						vgui::system()->SetClipboardText(szClipboardCrosshair, V_strlen(szClipboardCrosshair));
-						pCrosshair->eClipboardInfo = XHAIREXPORTNOTIFY_EXPORT_TO_CLIPBOARD;
-					}
-					else // bImportPressed
-					{
-						bool bImported = false;
-						if (vgui::system()->GetClipboardTextCount() > 0)
-						{
 #ifdef WIN32
-							// NEO NOTE (nullsystem): On Windows, GetClipboardText char * returns UTF-16 arranged bytes, differs from Set...
-							wchar_t wszClipboardCrosshair[NEO_XHAIR_SEQMAX] = {};
-							const int iClipboardWSZBytes = vgui::system()->GetClipboardText(0, wszClipboardCrosshair, NEO_XHAIR_SEQMAX);
-							const int iClipboardBytes = (iClipboardWSZBytes > 0)
-									? g_pVGuiLocalize->ConvertUnicodeToANSI(wszClipboardCrosshair, szClipboardCrosshair, sizeof(szClipboardCrosshair))
-									: 0;
+						// NEO NOTE (nullsystem): On Windows, GetClipboardText char * returns UTF-16 arranged bytes, differs from Set...
+						wchar_t wszClipboardCrosshair[NEO_XHAIR_SEQMAX] = {};
+						const int iClipboardWSZBytes = vgui::system()->GetClipboardText(0, wszClipboardCrosshair, NEO_XHAIR_SEQMAX);
+						const int iClipboardBytes = (iClipboardWSZBytes > 0)
+								? g_pVGuiLocalize->ConvertUnicodeToANSI(wszClipboardCrosshair, szClipboardCrosshair, sizeof(szClipboardCrosshair))
+								: 0;
 #else
-							const int iClipboardBytes = vgui::system()->GetClipboardText(0, szClipboardCrosshair, NEO_XHAIR_SEQMAX);
+						const int iClipboardBytes = vgui::system()->GetClipboardText(0, szClipboardCrosshair, NEO_XHAIR_SEQMAX);
 #endif
-							if (iClipboardBytes > 0)
+						if (iClipboardBytes > 0)
+						{
+							bImported = ImportCrosshair(&pCrosshair->info, szClipboardCrosshair);
+							if (bImported)
 							{
-								bImported = ImportCrosshair(&pCrosshair->info, szClipboardCrosshair);
+								ns->bModified = true;
 							}
 						}
-						pCrosshair->eClipboardInfo = bImported
-								? XHAIREXPORTNOTIFY_IMPORT_TO_CLIPBOARD
-								: XHAIREXPORTNOTIFY_IMPORT_TO_CLIPBOARD_ERROR;
 					}
+					pCrosshair->eClipboardInfo = bImported
+							? XHAIREXPORTNOTIFY_IMPORT_TO_CLIPBOARD
+							: XHAIREXPORTNOTIFY_IMPORT_TO_CLIPBOARD_ERROR;
 				}
 			}
 
-			NeoUI::SetPerRowLayout(1);
+			if (bDefaultPressed)
 			{
-				static constexpr const wchar_t *ARWSZ_XHAIREXPORTNOTIFY_STR[XHAIREXPORTNOTIFY__TOTAL] = {
-					L"", 													// XHAIREXPORTNOTIFY_NONE
-					L"Exported crosshair to clipboard", 					// XHAIREXPORTNOTIFY_EXPORT_TO_CLIPBOARD
-					L"Imported crosshair from clipboard", 					// XHAIREXPORTNOTIFY_IMPORT_TO_CLIPBOARD
-					L"ERROR: Unable to import crosshair from clipboard", 	// XHAIREXPORTNOTIFY_IMPORT_TO_CLIPBOARD_ERROR
-				};
-				NeoUI::Label(ARWSZ_XHAIREXPORTNOTIFY_STR[pCrosshair->eClipboardInfo]);
+				ImportCrosshair(&pCrosshair->info, CL_NEO_CROSSHAIR_DEFAULT);
+				pCrosshair->eClipboardInfo = XHAIREXPORTNOTIFY_RESET_TO_DEFAULT;
+				ns->bModified = true;
 			}
+		}
+
+		NeoUI::SetPerRowLayout(1);
+		{
+			static constexpr const wchar_t *ARWSZ_XHAIREXPORTNOTIFY_STR[XHAIREXPORTNOTIFY__TOTAL] = {
+				L"", 													// XHAIREXPORTNOTIFY_NONE
+				L"Exported crosshair to clipboard", 					// XHAIREXPORTNOTIFY_EXPORT_TO_CLIPBOARD
+				L"Imported crosshair from clipboard", 					// XHAIREXPORTNOTIFY_IMPORT_TO_CLIPBOARD
+				L"ERROR: Unable to import crosshair from clipboard", 	// XHAIREXPORTNOTIFY_IMPORT_TO_CLIPBOARD_ERROR
+				L"Crosshair reset to default",							// XHAIREXPORTNOTIFY_RESET_TO_DEFAULT
+			};
+			NeoUI::Label(ARWSZ_XHAIREXPORTNOTIFY_STR[pCrosshair->eClipboardInfo]);
 		}
 	}
 	NeoUI::EndSection();
@@ -960,7 +973,7 @@ void NeoSettings_Crosshair(NeoSettings *ns)
 			switch (pCrosshair->info.iESizeType)
 			{
 			case CROSSHAIR_SIZETYPE_ABSOLUTE: NeoUI::SliderInt(L"Size", &pCrosshair->info.iSize, 0, CROSSHAIR_MAX_SIZE); break;
-			case CROSSHAIR_SIZETYPE_SCREEN: NeoUI::Slider(L"Size", &pCrosshair->info.flScrSize, 0.0f, 1.0f, 5, 0.01f); break;
+			case CROSSHAIR_SIZETYPE_SCREEN: NeoUI::Slider(L"Size", &pCrosshair->info.flScrSize, 0.0f, 1.0f, 3, 0.01f); break;
 			}
 			NeoUI::SliderInt(L"Thickness", &pCrosshair->info.iThick, 0, CROSSHAIR_MAX_THICKNESS);
 			NeoUI::SliderInt(L"Gap", &pCrosshair->info.iGap, 0, CROSSHAIR_MAX_GAP);
@@ -970,6 +983,8 @@ void NeoSettings_Crosshair(NeoSettings *ns)
 			NeoUI::SliderInt(L"Circle radius", &pCrosshair->info.iCircleRad, 0, CROSSHAIR_MAX_CIRCLE_RAD);
 			NeoUI::SliderInt(L"Circle segments", &pCrosshair->info.iCircleSegments, 0, CROSSHAIR_MAX_CIRCLE_SEGMENTS);
 		}
+		NeoUI::HeadingLabel(L"NETWORKING");
+		NeoUI::RingBoxBool(L"Show other players' crosshairs", &pCrosshair->bNetworkCrosshair);
 	}
 	NeoUI::EndSection();
 }

--- a/src/game/client/neo/ui/neo_root_settings.h
+++ b/src/game/client/neo/ui/neo_root_settings.h
@@ -16,7 +16,7 @@ public:
 	// ConVarRefEx. This is mostly to prevent the setting from included
 	// for using to reset to default.
 	// Currently only used for volume as we don't want to reset it to 100%
-	// on setting default.
+	// on setting default, and crosshair as has its own default reset button.
 	ConVarRefEx(const char *pName, const bool bExcludeGlobalPtrs);
 };
 
@@ -29,6 +29,7 @@ enum XHairExportNotify
 	XHAIREXPORTNOTIFY_EXPORT_TO_CLIPBOARD,
 	XHAIREXPORTNOTIFY_IMPORT_TO_CLIPBOARD,
 	XHAIREXPORTNOTIFY_IMPORT_TO_CLIPBOARD_ERROR,
+	XHAIREXPORTNOTIFY_RESET_TO_DEFAULT,
 
 	XHAIREXPORTNOTIFY__TOTAL,
 };
@@ -145,6 +146,7 @@ struct NeoSettings
 	{
 		CrosshairInfo info;
 		XHairExportNotify eClipboardInfo;
+		bool bNetworkCrosshair;
 
 		// Textures
 		struct Texture
@@ -236,7 +238,8 @@ struct NeoSettings
 		CONVARREF_DEF(mat_monitorgamma);
 
 		// Crosshair
-		CONVARREF_DEF(cl_neo_crosshair);
+		CONVARREF_DEFNOGLOBALPTR(cl_neo_crosshair);
+		CONVARREF_DEF(cl_neo_crosshair_network);
 	};
 	CVR cvr;
 };

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -76,6 +76,7 @@ SendPropArray(SendPropInt(SENDINFO_ARRAY(m_rfAttackersHits)), m_rfAttackersHits)
 SendPropInt(SENDINFO(m_NeoFlags), 4, SPROP_UNSIGNED),
 SendPropString(SENDINFO(m_szNeoName)),
 SendPropString(SENDINFO(m_szNeoClantag)),
+SendPropString(SENDINFO(m_szNeoCrosshair)),
 SendPropInt(SENDINFO(m_szNameDupePos)),
 SendPropBool(SENDINFO(m_bClientWantNeoName)),
 
@@ -114,6 +115,7 @@ DEFINE_FIELD(m_NeoFlags, FIELD_CHARACTER),
 
 DEFINE_FIELD(m_szNeoName, FIELD_STRING),
 DEFINE_FIELD(m_szNeoClantag, FIELD_STRING),
+DEFINE_FIELD(m_szNeoCrosshair, FIELD_STRING),
 DEFINE_FIELD(m_szNameDupePos, FIELD_INTEGER),
 DEFINE_FIELD(m_bClientWantNeoName, FIELD_BOOLEAN),
 
@@ -430,6 +432,7 @@ CNEO_Player::CNEO_Player()
 	V_memset(m_szNeoName.GetForModify(), 0, sizeof(m_szNeoName));
 	m_szNeoNameHasSet = false;
 	V_memset(m_szNeoClantag.GetForModify(), 0, sizeof(m_szNeoClantag));
+	V_memset(m_szNeoCrosshair.GetForModify(), 0, sizeof(m_szNeoCrosshair));
 
 	m_bInThermOpticCamo = m_bInVision = false;
 	m_bHasBeenAirborneForTooLongToSuperJump = false;

--- a/src/game/server/neo/neo_player.h
+++ b/src/game/server/neo/neo_player.h
@@ -266,6 +266,7 @@ public:
 	CNetworkVar(unsigned char, m_NeoFlags);
 	CNetworkString(m_szNeoName, MAX_PLAYER_NAME_LENGTH);
 	CNetworkString(m_szNeoClantag, NEO_MAX_CLANTAG_LENGTH);
+	CNetworkString(m_szNeoCrosshair, NEO_XHAIR_SEQMAX);
 	CNetworkVar(int, m_szNameDupePos);
 
 	// NEO NOTE (nullsystem): As dumb as client sets -> server -> client it may sound,

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -2828,6 +2828,13 @@ void CNEORules::ClientSettingsChanged(CBasePlayer *pPlayer)
 		m_bThinkCheckClantags = true;
 	}
 
+	const char *pszClNeoCrosshair = engine->GetClientConVarValue(pNEOPlayer->entindex(), "cl_neo_crosshair");
+	const char *pszOldClNeoCrosshair = pNEOPlayer->m_szNeoCrosshair.Get();
+	if (V_strcmp(pszOldClNeoCrosshair, pszClNeoCrosshair) != 0)
+	{
+		V_strncpy(pNEOPlayer->m_szNeoCrosshair.GetForModify(), pszClNeoCrosshair, NEO_XHAIR_SEQMAX);
+	}
+
 	const char *pszName = pszSteamName;
 	const char *pszOldName = pPlayer->GetPlayerName();
 

--- a/src/game/shared/neo/neo_player_shared.h
+++ b/src/game/shared/neo/neo_player_shared.h
@@ -377,4 +377,10 @@ void GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
 						 const char *pSzNeoClantag,
 						 const bool bOnlySteamNick);
 
+// NEO NOTE (nullsystem): Max string length is 
+// something like: "2;2;-16711936;1;6;1.000;25;25;5;25;1;50;50;"
+// which is ~43 for v2 serialization | 64 length is enough for now till
+// more comes in
+static constexpr const int NEO_XHAIR_SEQMAX = 64;
+
 #endif // NEO_PLAYER_SHARED_H


### PR DESCRIPTION
## Description
* Since the change to string-based serialization is applied, it's now more straightforward to implement networked crosshair
* The networking is similar to how it's done for `neo_name` and `neo_clantag` as it's just strings passed around
* `cl_neo_crosshair_network` 0 = disable viewing other players crosshair, 1 = show other players crosshair
* "Other players crosshair" meaning when you're spectating the other person in 1st person while they ADS
* NeoUI settings - Slight alterations, added set to default button but also crosshair no longer part of the full-on reset button, so like the volume setting won't reset on full-on settings reset
* NeoUI settings - Added toggle for viewing networked crosshair
* NeoUI settings - Export/Import(/Default) buttons no longer restricted to only custom
* Improved default crosshair
* Tested with 2 computers that it's generally working

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Gentoo/GCC 14.2.1

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1187

