### PR TITLE
Missing Sounds in console

### DIFF
--- a/game/neo/scripts/game_sounds_weapons.txt
+++ b/game/neo/scripts/game_sounds_weapons.txt
@@ -110,6 +110,14 @@
         "wave"				"^weapons/tachi/tachi_fire.wav"
 }
 
+"weapon_tachi.special1"
+{
+	"channel"		        "CHAN_WEAPON"
+	"volume"		        "1.0"
+	"soundlevel"		        "SNDLVL_NORM"
+        "wave"			        "weapons/tachi/tachi_empty.wav"
+}
+
 
 //---------------------------
 // Kyla
@@ -1398,4 +1406,26 @@
 		"wave"	"weapons/fx/rics/ric4.wav"
 		"wave"	"weapons/fx/rics/ric5.wav"
 	}
+}
+
+// Alyx's EMP effect
+
+"AlyxEMP.Charge"
+{
+	"channel"	"CHAN_WEAPON"
+	"volume"	"0.65"
+	"soundlevel"  	"SNDLVL_90dB"
+	"pitch"		"100,120"
+	//"wave"		"weapons/stunstick/alyx_stunner_charge2.wav"
+	"wave"		"weapons/stunstick/alyx_stunner2.wav"
+}
+
+// used in smoke grenade
+"WeaponFrag.Roll"
+{
+	"channel"	"CHAN_VOICE"
+	"volume"	"0.7"
+	"soundlevel"  "SNDLVL_75dB"
+
+	"wave"	"weapons/slam/throw.wav"
 }

--- a/game/neo/scripts/game_sounds_weapons.txt
+++ b/game/neo/scripts/game_sounds_weapons.txt
@@ -1323,3 +1323,79 @@
 	"pitch"				"98,102"
 	"wave"				"^rogue/ht_ubr_fire.wav"
 }
+
+// *******
+// BULLETS
+
+"Bullets.DefaultNearmiss"
+{
+	"channel"		"CHAN_STATIC"
+	"volume"		"0.7"
+	"soundlevel"	"SNDLVL_140dB"
+	"pitch"			"PITCH_NORM"
+
+	"rndwave"
+	{
+		"wave"	">weapons/fx/nearmiss/bulletLtoR03.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR04.wav"
+		
+		"wave"	">weapons/fx/nearmiss/bulletLtoR06.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR07.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR09.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR10.wav"
+
+		"wave"	">weapons/fx/nearmiss/bulletLtoR13.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR14.wav"
+	}
+}
+
+"Bullets.GunshipNearmiss"
+{
+	"channel"		"CHAN_STATIC"
+	"volume"		"0.7"
+	"soundlevel"	"SNDLVL_140dB"
+	"pitch"			"50"
+
+	"rndwave"
+	{
+		"wave"	">weapons/fx/nearmiss/bulletLtoR03.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR04.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR05.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR06.wav"
+
+		"wave"	">weapons/fx/nearmiss/bulletLtoR11.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR12.wav"
+	}
+}
+
+"Bullets.StriderNearmiss"
+{
+	"channel"		"CHAN_STATIC"
+	"volume"		"0.7"
+	"soundlevel"	"SNDLVL_120dB"
+	"pitch"			"75"
+
+	"rndwave"
+	{
+		"wave"	">weapons/fx/nearmiss/bulletLtoR11.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR13.wav"
+		"wave"	">weapons/fx/nearmiss/bulletLtoR14.wav"
+	}
+}
+
+"FX_RicochetSound.Ricochet"
+{
+	"channel"	"CHAN_STATIC"
+	"volume"	"0.5, 0.6"
+	"soundlevel"  "SNDLVL_80dB"
+	"pitch"	"90, 110"
+
+	"rndwave"
+	{
+		"wave"	"weapons/fx/rics/ric1.wav"
+		"wave"	"weapons/fx/rics/ric2.wav"
+		"wave"	"weapons/fx/rics/ric3.wav"
+		"wave"	"weapons/fx/rics/ric4.wav"
+		"wave"	"weapons/fx/rics/ric5.wav"
+	}
+}

--- a/game/neo/scripts/surfaceproperties_hl2.txt
+++ b/game/neo/scripts/surfaceproperties_hl2.txt
@@ -1,0 +1,115 @@
+// "surface group" 
+// { 
+// "property" 	"value"
+// ...
+// }
+//
+// thickness: If this value is present, the material is not volumetrically solid
+// it means that the volume should be computed as the surface area times this
+// thickness (for automatic mass).  The inside space beneath the thickness value is air.
+//
+// physics parameters are:
+// density: this is the material density in kg / m^3 (water is 1000)
+// elasticity: This is the collision elasticity (0 - 1.0, 0.01 is soft, 1.0 is hard)
+// friction: this is the physical friction (0 - 1.0, 0.01 is slick, 1.0 is totally rough)
+// dampening: this is the physical drag on an object when in contact with this surface (0 - x, 0 none to x a lot)
+//
+// !!! Do not edit the physics properties (especially density) without the proper references !!!
+//
+// Sounds
+// 
+// stepleft: footstep sound for left foot
+// stepright: footstep sound for right foot
+// impactsoft: Physical impact sound when hitting soft surfaces
+// impacthard: Physical impact sound when hitting hard surfaces
+// scrapesmooth: Looping physics friction sound (when scraping smooth surfaces)
+// scraperough: Looping physics friction sound (when scraping rough surfaces)
+// bulletimpact: bullet impact sound
+// gamematerial: game material index (can be a single letter or a number)
+// 
+
+// NOTE: The properties of "default" will get copied into EVERY material who does not
+// 	 override them!!!
+//
+// "base" means to use the parameters from that material as a base.
+// "base" must appear as the first key in a material
+//
+
+"metalvehicle"
+{
+	"base"		"metal"
+	"thickness"	"0.1"
+	"density"	"2700"
+	"elasticity"	"0.2"
+	"friction"	"0.8"
+
+	"audioreflectivity" "0.33"
+	"audioroughnessfactor" "0.1"
+	"audioHardMinVelocity"	"500" // 500
+
+	"impactHardThreshold" "0.5"   
+  
+
+	"impacthard"	"MetalVehicle.ImpactHard"
+	"impactsoft"	"MetalVehicle.ImpactSoft"
+	"scraperough"	"MetalVehicle.ScrapeRough"
+	"scrapesmooth"	"MetalVehicle.ScrapeSmooth"
+
+
+	"gamematerial"	"M"
+}
+
+"antlionsand"
+{
+	"base"		"sand"
+
+	"gamematerial"	"N"
+}
+
+"metal_seafloorcar"
+{
+	"base"		"metal"
+	"bulletimpact"	"Metal_SeafloorCar.BulletImpact"
+}
+
+"gunship"
+{
+	"base"		"metal"
+	"friction"	"0.3"
+	"impacthard"	"Gunship.Impact"
+	"scraperough"	"Gunship.Scrape"
+}
+
+"strider"
+{
+	"base"		"metal"
+
+	"impacthard"	"Strider.Impact"
+	"scraperough"	"Strider.Scrape"
+}
+
+"antlion"
+{
+	"base"		"alienflesh"
+	
+	"gamematerial"	"A"
+}
+
+"combine_metal"
+{
+	"base"		"solidmetal"
+
+}
+
+"combine_glass"
+{
+	"base"		"glass"
+
+}
+
+"zombieflesh"
+{
+ 	"base"   	"flesh"
+ 
+ 	"impacthard"	"Flesh_Bloody.ImpactHard"
+}

--- a/game/neo/scripts/weapon_aa13.txt
+++ b/game/neo/scripts/weapon_aa13.txt
@@ -84,8 +84,8 @@ WeaponData
 		"empty"				"weapon_aa13.empty"
 		"single_shot"		"weapon_aa13.single"
 		"single_shot_npc"	"weapon_aa13.npc_single"
-		"special1"			"Weapon_aa13.Insertshell"
-		"special2"			"Weapon_aa13.Pump"
+		//"special1"			"Weapon_aa13.Insertshell"
+		//"special2"			"Weapon_aa13.Pump"
 	}
 
 	// Weapon Sprite data is loaded by the Client DLL.

--- a/game/neo/scripts/weapon_ghost.txt
+++ b/game/neo/scripts/weapon_ghost.txt
@@ -72,9 +72,9 @@ WeaponData
 		"empty"			"Weapon_Pistol.Empty"
 		"single_shot"		"Weapon_Pistol.Single"
 		"single_shot_npc"	"Weapon_Pistol.NPC_Single"
-		"special1"		"Ghost.Special1"
-		"special2"		"Ghost.Special2"
-		"special3"		"Ghost.Special3"
+		//"special1"		"Ghost.Special1"
+		//"special2"		"Ghost.Special2"
+		//"special3"		"Ghost.Special3"
 		"burst"			"Weapon_Pistol.Burst"
 	}
 

--- a/game/neo/scripts/weapon_knife.txt
+++ b/game/neo/scripts/weapon_knife.txt
@@ -62,9 +62,6 @@ WeaponData
 		
 		"melee_hit"			"Weapon_Generic.melee_swing" // Do the swoosh noise even if the hit lands
 		"melee_hit"			"Weapon_Crowbar.Melee_Hit"
-		
-		"melee_hit_world"	"Weapon_Generic.melee_swing" // Do the swoosh noise even if the hit lands
-		"melee_hit_world"	"Weapon_Crowbar.Melee_HitWorld"
 	}
 
 	// Weapon Sprite data is loaded by the Client DLL.

--- a/game/neo/scripts/weapon_mx.txt
+++ b/game/neo/scripts/weapon_mx.txt
@@ -79,7 +79,7 @@ WeaponData
 		"reload_npc"		"Weapon_mx.NPC_Reload"
 		"empty"			"Weapon_mx.Empty"
 		"single_shot"		"Weapon_mx.Fire"
-		"single_shot_npc"	"Weapon_mx.NPC_Single"
+		//"single_shot_npc"	"Weapon_mx.NPC_Single"
 		"special1"		"Weapon_Pistol.Special1"
 		"special2"		"Weapon_Pistol.Special2"
 		"burst"			"Weapon_Pistol.Burst"

--- a/game/neo/scripts/weapon_mx_silenced.txt
+++ b/game/neo/scripts/weapon_mx_silenced.txt
@@ -76,7 +76,7 @@ WeaponData
 		"reload_npc"		"Weapon_mx.NPC_Reload"
 		"empty"			"Weapon_mx.Empty"
 		"single_shot"		"weapon_mxs.fire"
-		"single_shot_npc"	"Weapon_mxs.NPC_Single"
+		//"single_shot_npc"	"Weapon_mxs.NPC_Single"
 		"special1"		"Weapon_Pistol.Special1"
 		"special2"		"Weapon_Pistol.Special2"
 		"burst"			"Weapon_Pistol.Burst"

--- a/game/neo/scripts/weapon_physcannon.txt
+++ b/game/neo/scripts/weapon_physcannon.txt
@@ -23,21 +23,21 @@ WeaponData
 	SoundData
 	{
 		// launch held object
-		"single_shot"		"Weapon_PhysCannon.Launch"
+		//"single_shot"		"Weapon_PhysCannon.Launch"
 		// Ignore?
-		"reload"			"Weapon_PhysCannon.Charge"
+		//"reload"			"Weapon_PhysCannon.Charge"
 		// dry fire - no target
-		"empty"				"Weapon_PhysCannon.DryFire"
+		//"empty"				"Weapon_PhysCannon.DryFire"
 		// pick up object
-		"special1"			"Weapon_PhysCannon.Pickup"
+		//"special1"			"Weapon_PhysCannon.Pickup"
 		// open claws, target object
-		"special2"			"Weapon_PhysCannon.OpenClaws"
+		//"special2"			"Weapon_PhysCannon.OpenClaws"
 		// close claws, target out of range/invalid
-		"melee_hit"			"Weapon_PhysCannon.CloseClaws"
+		//"melee_hit"			"Weapon_PhysCannon.CloseClaws"
 		// drop object
-		"melee_miss"		"Weapon_PhysCannon.Drop"
+		//"melee_miss"		"Weapon_PhysCannon.Drop"
 		// too heavy
-		"special3"		"Weapon_PhysCannon.TooHeavy"
+		//"special3"		"Weapon_PhysCannon.TooHeavy"
 	}
 
 	// Weapon Sprite data is loaded by the Client DLL.

--- a/game/neo/scripts/weapon_remotedet.txt
+++ b/game/neo/scripts/weapon_remotedet.txt
@@ -65,9 +65,9 @@ WeaponData
 		"empty"			"Weapon_remotedet.Empty"
 		"single_shot"		"Weapon_remotedet.Single"
 		"single_shot_npc"	"Weapon_remotedet.NPC_Single"
-		"special1"		"Weapon_remotedet.Special1"
-		"special2"		"Weapon_remotedet.Special2"
-		"burst"			"Weapon_remotedet.Burst"
+		//"special1"		"Weapon_remotedet.Special1"
+		//"special2"		"Weapon_remotedet.Special2"
+		//"burst"			"Weapon_remotedet.Burst"
 	}
 
 	// Weapon Sprite data is loaded by the Client DLL.

--- a/game/neo/scripts/weapon_rpg.txt
+++ b/game/neo/scripts/weapon_rpg.txt
@@ -26,13 +26,13 @@ WeaponData
 	// Sounds for the weapon. There is a max of 16 sounds per category (i.e. max 16 "single_shot" sounds)
 	SoundData
 	{
-		"single_shot"		"Weapon_RPG.Single"
-		"single_shot_npc"	"Weapon_RPG.NPC_Single"
+		//"single_shot"		"Weapon_RPG.Single"
+		//"single_shot_npc"	"Weapon_RPG.NPC_Single"
 		//Laser on
-		"special1"			"Weapon_RPG.LaserOn"
+		//"special1"			"Weapon_RPG.LaserOn"
 		//Laser off
-		"special2"			"Weapon_RPG.LaserOff"
-		"empty"				"Weapon_SMG1.Empty"
+		//"special2"			"Weapon_RPG.LaserOff"
+		//"empty"				"Weapon_SMG1.Empty"
 	}
 
 	// Weapon Sprite data is loaded by the Client DLL.

--- a/game/neo/scripts/weapon_smac.txt
+++ b/game/neo/scripts/weapon_smac.txt
@@ -76,8 +76,8 @@ WeaponData
 		"empty"			"Weapon_Pistol.Empty"
 		"single_shot"		"Weapon_MP5Navy.Single"
 		"single_shot_npc"	"Weapon_MP5Navy.Single"
-		"special1"		"Weapon_smac.Special1"
-		"special2"		"Weapon_smac.Special2"
+		//"special1"		"Weapon_smac.Special1"
+		//"special2"		"Weapon_smac.Special2"
 		"burst"			"Weapon_Pistol.Burst"
 		"melee_miss"		"Weapon_Generic.melee_swing"
 	}

--- a/game/neo/scripts/weapon_smg1.txt
+++ b/game/neo/scripts/weapon_smg1.txt
@@ -28,7 +28,7 @@ WeaponData
 	{
 		"reload"			"Weapon_SMG1.Reload"
 		"reload_npc"		"Weapon_SMG1.NPC_Reload"
-		"empty"				"Weapon_SMG1.Empty"
+		//"empty"				"Weapon_SMG1.Empty"
 		"single_shot"		"Weapon_SMG1.Single"
 		"single_shot_npc"	"Weapon_SMG1.NPC_Single"
 		"special1"			"Weapon_SMG1.Special1"

--- a/game/neo/scripts/weapon_supa7.txt
+++ b/game/neo/scripts/weapon_supa7.txt
@@ -77,7 +77,7 @@ WeaponData
 	// Sounds for the weapon. There is a max of 16 sounds per category (i.e. max 16 "single_shot" sounds)
 	SoundData
 	{
-		"reload"			"weapon_murata.reload"
+		//"reload"			"weapon_murata.reload"
 		"reload_npc"		"weapon_murata.npc_reload"
 		"empty"				"weapon_murata.empty"
 		"single_shot"	    "weapon_murata.Single"

--- a/game/neo/scripts/weapon_tachi.txt
+++ b/game/neo/scripts/weapon_tachi.txt
@@ -67,8 +67,8 @@ WeaponData
 		"single_shot"	"Weapon_Tachi.Single"
 		"single_shot_npc"	"Weapon_Tachi.NPC_Single"
 		"special1"		"Weapon_Tachi.Special1"
-		"special2"		"Weapon_Tachi.Special2"
-		"burst"			"Weapon_Tachi.Burst"
+		//"special2"		"Weapon_Tachi.Special2"
+		//"burst"			"Weapon_Tachi.Burst"
 	}
 
 	// Weapon Sprite data is loaded by the Client DLL.

--- a/src/game/client/CMakeLists.txt
+++ b/src/game/client/CMakeLists.txt
@@ -1742,7 +1742,7 @@ target_sources_grouped(
     #${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_ar2.h
     #${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_crossbow.cpp
     #${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_crowbar.cpp
-    ${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_frag.cpp
+    #${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_frag.cpp
     ${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_hl2mpbase.cpp
     ${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_hl2mpbase.h
     ${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_hl2mpbase_machinegun.cpp

--- a/src/game/client/fx_impact.cpp
+++ b/src/game/client/fx_impact.cpp
@@ -332,10 +332,12 @@ void PerformCustomEffects( const Vector &vecOrigin, trace_t &tr, const Vector &s
 	{
 		FX_DustImpact( vecOrigin, &tr, iScale );
 	}
+#ifndef NEO
 	else if ( iMaterial == CHAR_TEX_ANTLION )
 	{
 		FX_AntlionImpact( vecOrigin, &tr );
 	}
+#endif // NEO
 	else if ( ( iMaterial == CHAR_TEX_METAL ) || ( iMaterial == CHAR_TEX_VENT ) )
 	{
 		Vector	reflect;

--- a/src/game/server/CMakeLists.txt
+++ b/src/game/server/CMakeLists.txt
@@ -1501,7 +1501,7 @@ target_sources_grouped(
     #${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_ar2.h
     #${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_crossbow.cpp
     #${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_crowbar.cpp
-    ${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_frag.cpp
+    #${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_frag.cpp
     ${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_hl2mpbase.cpp
     ${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_hl2mpbase.h
     ${CMAKE_SOURCE_DIR}/game/shared/hl2mp/weapon_hl2mpbase_machinegun.cpp

--- a/src/game/server/hl2/grenade_frag.cpp
+++ b/src/game/server/hl2/grenade_frag.cpp
@@ -280,7 +280,9 @@ void CGrenadeFrag::Precache( void )
 {
 	PrecacheModel( GRENADE_MODEL );
 
+#ifndef NEO
 	PrecacheScriptSound( "Grenade.Blip" );
+#endif // NEO
 
 	PrecacheModel( "sprites/redglow1.vmt" );
 	PrecacheModel( "sprites/bluelaser1.vmt" );

--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -48,9 +48,9 @@ ConVar hl2mp_spawn_frag_fallback_radius( "hl2mp_spawn_frag_fallback_radius", "48
 
 #define HL2MP_COMMAND_MAX_RATE 0.3
 
+#ifndef NEO
 void DropPrimedFragGrenade( CHL2MP_Player *pPlayer, CBaseCombatWeapon *pGrenade );
 
-#ifndef NEO
 LINK_ENTITY_TO_CLASS( player, CHL2MP_Player );
 #endif
 
@@ -250,11 +250,13 @@ void CHL2MP_Player::Precache( void )
 	for ( i = 0; i < nHeads; ++i )
 		 PrecacheModel( g_ppszRandomCombineModels[i] );
 
+#ifndef NEO
 	PrecacheFootStepSounds();
 
 	PrecacheScriptSound( "NPC_MetroPolice.Die" );
 	PrecacheScriptSound( "NPC_CombineS.Die" );
 	PrecacheScriptSound( "NPC_Citizen.die" );
+#endif // NEO
 }
 
 void CHL2MP_Player::GiveAllItems( void )
@@ -1323,6 +1325,7 @@ void CHL2MP_Player::FlashlightTurnOff( void )
 
 void CHL2MP_Player::Weapon_Drop( CBaseCombatWeapon *pWeapon, const Vector *pvecTarget, const Vector *pVelocity )
 {
+#ifndef NEO
 	//Drop a grenade if it's primed.
 	if ( GetActiveWeapon() )
 	{
@@ -1337,6 +1340,7 @@ void CHL2MP_Player::Weapon_Drop( CBaseCombatWeapon *pWeapon, const Vector *pvecT
 			}
 		}
 	}
+#endif // NEO
 
 	BaseClass::Weapon_Drop( pWeapon, pvecTarget, pVelocity );
 }

--- a/src/game/server/neo/neo_client.cpp
+++ b/src/game/server/neo/neo_client.cpp
@@ -173,7 +173,6 @@ void Precache_HL2MP( void )
 	CBaseEntity::PrecacheScriptSound( "HUDQuickInfo.LowAmmo" );
 	CBaseEntity::PrecacheScriptSound( "HUDQuickInfo.LowHealth" );
 
-	CBaseEntity::PrecacheScriptSound( "FX_AntlionImpact.ShellImpact" );
 	CBaseEntity::PrecacheScriptSound( "Missile.ShotDown" );
 	CBaseEntity::PrecacheScriptSound( "Bullets.DefaultNearmiss" );
 	CBaseEntity::PrecacheScriptSound( "Bullets.GunshipNearmiss" );

--- a/src/game/server/neo/neo_client.cpp
+++ b/src/game/server/neo/neo_client.cpp
@@ -252,7 +252,7 @@ void Precache_NEO_Sounds( void )
 	CBaseEntity::PrecacheScriptSound("weapon_m41l.single");
 	CBaseEntity::PrecacheScriptSound("weapon_m41l.npc_single");
 	CBaseEntity::PrecacheScriptSound("weapon_m41s.single");
-	CBaseEntity::PrecacheScriptSound("weapon_m41s.npc_single");
+	//CBaseEntity::PrecacheScriptSound("weapon_m41s.npc_single");
 
 	CBaseEntity::PrecacheScriptSound("weapon_srs.reload");
 	CBaseEntity::PrecacheScriptSound("weapon_srs.npc_reload");

--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -964,7 +964,9 @@ void CWeaponPhysCannon::Precache( void )
 	PrecacheModel( PHYSCANNON_BEAM_SPRITE );
 	PrecacheModel( PHYSCANNON_BEAM_SPRITE_NOZ );
 
+#ifndef NEO
 	PrecacheScriptSound( "Weapon_PhysCannon.HoldSound" );
+#endif // NEO
 
 	BaseClass::Precache();
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Summary of changes made to solve PrecacheScriptSound errors:

PrecacheScriptSound 'weapon_crowbar.melee_hitworld' failed, no such sound script entry
remove Weapon_Crowbar.Melee_HitWorld from melee_hit_world (unused in rebuild and most likely in og)
override surfaceproperties_hl2.txt removing surface group "crowbar" (not used in any material in rebuild or og or source sdk 2013 mp)

PrecacheScriptSound 'NPC_CombineS.ElectrocuteScream' failed, no such sound script entry
override scripts/talker/response_rules.txt with a blank text file
Could also be solved by not building AI_ResponseSystem.h (I don't think we have any plans for talking ai) but the
file is referenced in many other places

PrecacheScriptSound 'npc_citizen.die' failed, no such sound script entry
solved by NPC_CombineS.ElectrocuteScream

PrecacheScriptSound 'FX_AntlionImpact.ShellImpact' failed, no such sound script entry
remove CBaseEntity::PrecacheScriptSound( "FX_AntlionImpact.ShellImpact" ); from neo_client.cpp
remove call to FX_AntlionImpact in fx_impact.cpp

PrecacheScriptSound 'Bullets.DefaultNearmiss' failed, no such sound script entry
add Bullets.DefaultNearmiss from source sdk base 2013 mp scripts/game_sounds_weapons.txt to game_sounds_weapons.txt
(we're currently purposefully precaching these three in neo_client.cpp, a bit of work to remove all references to 
FX_TracerSound, could instead remove references to these three from FX_TracerSound and not precache?)

PrecacheScriptSound 'Bullets.GunshipNearmiss' failed, no such sound script entry
add Bullets.GunshipNearmiss from source sdk base 2013 mp scripts/game_sounds_weapons.txt to game_sounds_weapons.txt
(see above)

PrecacheScriptSound 'Bullets.StriderNearmiss' failed, no such sound script entry
add Bullets.StriderNearmiss from source sdk base 2013 mp scripts/game_sounds_weapons.txt to game_sounds_weapons.txt
(see above)

PrecacheScriptSound 'weapon_m41s.npc_single' failed, no such sound script entry
comment out CBaseEntity::PrecacheScriptSound("weapon_m41s.npc_single"); 
m41s uses weapon_m41s.single for npcs firing the gun

PrecacheScriptSound 'AlyxEmp.Charge' failed, no such sound script entry
Used in several places when teleporting or materializing weapons, so added AlyxEMP.Charge from base game_sounds_weapons.txt
(not that we never do those things, so could remove from all these places too)

///////
PrecacheScriptSound 'Weapon_SMG1.Empty' failed, no such sound script entry
PrecacheScriptSound 'Weapon_RPG.Single' failed, no such sound script entry
PrecacheScriptSound 'Weapon_RPG.NPC_Single' failed, no such sound script entry
PrecacheScriptSound 'Weapon_RPG.LaserOn' failed, no such sound script entry
PrecacheScriptSound 'Weapon_RPG.LaserOff' failed, no such sound script entry
PrecacheScriptSound 'Weapon_PhysCannon.HoldSound' failed, no such sound script entry
This one is precached separately right before the other sounds are precached from the weapon script, just ifndef NEO out in weapon_physcannon.cpp

PrecacheScriptSound 'Weapon_PhysCannon.DryFire' failed, no such sound script entry
PrecacheScriptSound 'Weapon_PhysCannon.Launch' failed, no such sound script entry
PrecacheScriptSound 'Weapon_PhysCannon.Charge' failed, no such sound script entry
PrecacheScriptSound 'Weapon_PhysCannon.Drop' failed, no such sound script entry
PrecacheScriptSound 'Weapon_PhysCannon.CloseClaws' failed, no such sound script entry
PrecacheScriptSound 'Weapon_PhysCannon.Pickup' failed, no such sound script entry
PrecacheScriptSound 'Weapon_PhysCannon.OpenClaws' failed, no such sound script entry
PrecacheScriptSound 'Weapon_PhysCannon.TooHeavy' failed, no such sound script entry
////////
For all of the above we build these weapons to resolve externals in places like hl2mp_player etc, these sounds should never play so just changed the weapon scripts for these to not use any of these sounds

PrecacheScriptSound 'WeaponFrag.Roll' failed, no such sound script entry
grabbing from base game_sounds_weapons, used in smoke grenade

PrecacheScriptSound 'Grenade.Blip' failed, no such sound script entry
not building grenade_Frag ends in >140 unresolved externals across like 20 files. BlipSound should never be executed so just ifndef NEO out PrecacheScriptSound("Grenade.Blip") in grenade_frag.cpp

PrecacheScriptSound 'WeaponFrag.Throw' failed, no such sound script entry
stopped building weapon_frag, ifndef neo out references to DropPrimedFragGrenade in hl2mp_player

////////
PrecacheScriptSound 'Weapon_Tachi.Burst' failed, no such sound script entry
PrecacheScriptSound 'Weapon_Tachi.Special1' failed, no such sound script entry
change fire mode sound, nothing is played in original, we're trying to play this sound in rebuild, just using tachi_empty.wav as a placeholder

PrecacheScriptSound 'Weapon_Tachi.Special2' failed, no such sound script entry
PrecacheScriptSound 'weapon_murata.reload' failed, no such sound script entry
PrecacheScriptSound 'Weapon_smac.Special1' failed, no such sound script entry
PrecacheScriptSound 'Weapon_smac.Special2' failed, no such sound script entry
PrecacheScriptSound 'Weapon_mxs.NPC_Single' failed, no such sound script entry
PrecacheScriptSound 'Weapon_mx.NPC_Single' failed, no such sound script entry
PrecacheScriptSound 'Ghost.Special1' failed, no such sound script entry
PrecacheScriptSound 'Ghost.Special2' failed, no such sound script entry
PrecacheScriptSound 'Ghost.Special3' failed, no such sound script entry
PrecacheScriptSound 'Weapon_remotedet.Burst' failed, no such sound script entry
PrecacheScriptSound 'Weapon_remotedet.Special1' failed, no such sound script entry
PrecacheScriptSound 'Weapon_remotedet.Special2' failed, no such sound script entry
PrecacheScriptSound 'Weapon_aa13.Insertshell' failed, no such sound script entry
PrecacheScriptSound 'Weapon_aa13.Pump' failed, no such sound script entry
///////
for all of the above again just commenting out the sounds in the weapon script files unless otherwise stated

///////
PrecacheScriptSound 'NPC_Citizen.RunFootstepLeft' failed, no such sound script entry
PrecacheScriptSound 'NPC_Citizen.RunFootstepRight' failed, no such sound script entry
PrecacheScriptSound 'NPC_CombineS.RunFootstepLeft' failed, no such sound script entry
PrecacheScriptSound 'NPC_CombineS.RunFootstepRight' failed, no such sound script entry
PrecacheScriptSound 'NPC_MetroPolice.RunFootstepLeft' failed, no such sound script entry
PrecacheScriptSound 'NPC_MetroPolice.RunFootstepRight' failed, no such sound script entry
PrecacheScriptSound 'NPC_MetroPolice.Die' failed, no such sound script entry
PrecacheScriptSound 'NPC_CombineS.Die' failed, no such sound script entry
PrecacheScriptSound 'NPC_Citizen.die' failed, no such sound script entry
///////
for all of these just ifndef neo out PrecacheFootStepSounds and PrecacheScriptSound in hl2mp_player.cpp

PrecacheScriptSound 'FX_RicochetSound.Ricochet' failed, no such sound script entry
add FX_RicochetSound.Ricochet from source sdk base 2013 mp scripts/game_sounds_weapons.txt to game_sounds_weapons.txt
(precached in effects.cpp, used in FX_RicochetSound in fx.cpp)
