### PR TITLE
Fix #1165

### DIFF
--- a/src/game/client/hl2mp/c_hl2mp_player.cpp
+++ b/src/game/client/hl2mp/c_hl2mp_player.cpp
@@ -551,12 +551,22 @@ bool C_HL2MP_Player::SuitPower_RemoveDevice( const CSuitPowerDevice &device )
 	if( !IsSuitEquipped() )
 		return false;
 
+#ifdef NEO
+	// Recons can spam sprint whenever and it doesn't matter.
+	// Fixes https://github.com/NeotokyoRebuild/neo/issues/1165
+	// where this could drain AUX for recons stuck in geometry whilst attempting to sprint.
+	const bool isRecon = static_cast<CNEO_Player*>(this)->GetClass() == NEO_CLASS_RECON;
+	const float antiExploitDrainRate = isRecon ? 0 : device.GetDeviceDrainRate() * 0.1f;
+#else
+	const float antiExploitDrainRate = device.GetDeviceDrainRate() * 0.1f;
+#endif
+
 	// Take a little bit of suit power when you disable a device. If the device is shutting off
 	// because the battery is drained, no harm done, the battery charge cannot go below 0. 
 	// This code in combination with the delay before the suit can start recharging are a defense
 	// against exploits where the player could rapidly tap sprint and never run out of power.
 	MsgPredTest2( "[Client %d] [A REMOVE] m_HL2Local.m_flSuitPower: %f\n", gpGlobals->tickcount, m_HL2Local.m_flSuitPower );
-	SuitPower_Drain( device.GetDeviceDrainRate() * 0.1f );
+	SuitPower_Drain( antiExploitDrainRate );
 	MsgPredTest2( "[Client %d] [B REMOVE] m_HL2Local.m_flSuitPower: %f\n", gpGlobals->tickcount, m_HL2Local.m_flSuitPower );
 
 	m_HL2Local.m_bitsActiveDevices &= ~device.GetDeviceID();


### PR DESCRIPTION
## Description
Fix the bug with recon sprint costing AUX.

It seems the AUX draining stems from an anti-exploit logic in the engine base code regarding sprinting. Since recons have infinite sprint, we can just skip that part for them to avoid the problem.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- Fixes #1165 


