### PR TITLE
Don't render glow effect twice, move until after HDR pass so glow colours remain consistent

### DIFF
--- a/src/game/client/viewrender.cpp
+++ b/src/game/client/viewrender.cpp
@@ -2188,8 +2188,9 @@ void CViewRender::RenderView( const CViewSetup &viewRender, int nClearFlags, int
 				pRenderContext.SafeRelease();
 			}
 		}
-
+#ifndef NEO
 		GetClientModeNormal()->DoPostScreenSpaceEffects( &viewRender );
+#endif // NEO
 
 		// Now actually draw the viewmodel
 		DrawViewModels( viewRender, whatToDraw & RENDERVIEW_DRAWVIEWMODEL );
@@ -2249,8 +2250,6 @@ void CViewRender::RenderView( const CViewSetup &viewRender, int nClearFlags, int
 
 		PerformScreenSpaceEffects( 0, 0, viewRender.width, viewRender.height );
 
-		GetClientModeNormal()->DoPostScreenSpaceEffects( &viewRender );
-
 		if ( g_pMaterialSystemHardwareConfig->GetHDRType() == HDR_TYPE_INTEGER )
 		{
 			pRenderContext.GetFrom( materials );
@@ -2258,6 +2257,9 @@ void CViewRender::RenderView( const CViewSetup &viewRender, int nClearFlags, int
 			pRenderContext.SafeRelease();
 		}
 
+#ifdef NEO // Add glow effect after HDR stuff is done, so the colour of the effect doesn't vary
+		GetClientModeNormal()->DoPostScreenSpaceEffects(&viewRender);
+#endif // NEO
 		CleanupMain3DView( viewRender );
 
 		if ( m_rbTakeFreezeFrame[viewRender.m_eStereoEye ] )


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

With HDR enabled, the colour of the glow effect when using xray in spectate changes depending on the exposure of the camera. This PR moves when post screen space effects are done (currently the xray glow is the only thing done in dopostscreenspaceeffects), and removes a duplicate call to DoPostScreenSpaceEffects.
