### PR TITLE
Fix incorrect container paths in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ Make sure the "x64 Native Tools Command Prompt for VS2022" is used instead of th
 Your system must include the following packages:
 `gcc g++ cmake ninja-build docker-ce docker-ce-cli containerd.io apt-transport-https ca-certificates curl gnupg gnupg-utils cmake build-essential`
 
-**Note:** Depending on your operating system, the package names may vary, please consult google or your package manager for correct package names. The listed are for debian `apt`. (Includes Ubuntu, Linux Mint, etc)
+> [!NOTE]
+> Depending on your distro, the package names may vary; please consult Google or your package manager for correct package names. The listed are for Debian `apt`. (Includes Ubuntu, Linux Mint, etc).
+> 
+> If using Docker, also note that following the [official install guide](https://docs.docker.com/desktop/setup/install/linux/) steps will likely configure sources for all transitive dependencies like
+> `containerd.io`, so if they were not previously available by your package manager sources, it's worth checking again after installing Docker, before proceeding to add/install them manually. This is
+> the case at least for APT.
 
 Download and use the OCI image for Docker/Podman/Toolbx:
 

--- a/README.md
+++ b/README.md
@@ -65,20 +65,20 @@ Download and use the OCI image for Docker/Podman/Toolbx:
 ###### Running the container
 Docker:
 ```
-# docker run -v /PATH_TO_REPO/neo/src:/root/neo/src --rm -it --entrypoint /bin/bash registry.gitlab.steamos.cloud/steamrt/sniper/sdk
+# docker run -v /PATH_TO_REPO/:/root/neo/ --rm -it --entrypoint /bin/bash registry.gitlab.steamos.cloud/steamrt/sniper/sdk
 $ cd /root/neo/src/
 ```
 
 Podman: 
 ```
-$ podman run -v /PATH_TO_REPO/neo/src:/root/neo/src --rm -it --entrypoint /bin/bash registry.gitlab.steamos.cloud/steamrt/sniper/sdk
+$ podman run -v /PATH_TO_REPO/:/root/neo/ --rm -it --entrypoint /bin/bash registry.gitlab.steamos.cloud/steamrt/sniper/sdk
 $ cd /root/neo/src/
 ```
 
 Toolbx: 
 ```
 $ toolbox enter sniper
-$ cd /PATH_TO_REPO/neo/src
+$ cd /PATH_TO_REPO/src
 ```
 
 Depending on the terminal, you may need to install an additional terminfo in the container just to make it usable.


### PR DESCRIPTION
## Description
Fix an erroneous path in the README documentation for building using the Sniper container.

By installing Docker and all the dependencies using a clean Pop!_OS 22.04 LTS Linux distro, and then following the README build instructions for Docker, the CMake setup fails at the `cmake --preset linux-debug` command.

I'm assuming this is because our docs instruct to mount the container into `neo/src`. But doing so, the relative (unmounted) `neo/game` content will only contain whatever data got pulled from `neoAssets` repo by the CMakeLists, and not the game assets still found in the main repo's `neo/game` dir.

I've modified the instructions to instead mount to the base repo folder, such that from `neo/src`, a relative `../game` in the CMake file will reach the code repo `neo/game` files, even inside the container. I only tested this with Docker, but I assume the same logic would apply for the other container tools listed (Podman, Toolbx), so I edited their paths the same way in the docs.

(An alternative solution might be to move all (build-pertinent) data like `GameMenu.res.in` to `neoAssets`? So that we didn't need to mount the fluff in the repo root dir inside the build container just for the sake of the `src/../game` relative path traversal.)

I also removed the explicit `/neo` suffix from the `PATH_TO_REPO` placeholder value in the docs, because it already is a part the repo path (and repos can be renamed when forking, so the `/neo` suffix may be inaccurate for users who renamed their repo fork to something else.

The CMake error looks like this (unrelevant lines omitted):
```bash
dev@pop-os:~/code/neo/src$ sudo docker run -v .:/root/neo/src --rm -it --entrypoint /bin/bash registry.gitlab.steamos.cloud/steamrt/sniper/sdk

(steamrt sniper 3.0.20250519.130773)root@7a5601b7ac38:/> cd /root/neo/src
(steamrt sniper 3.0.20250519.130773)root@7a5601b7ac38:~/neo/src> cmake --preset linux-debug

CMake Error: File /root/neo/game/neo/resource/GameMenu.res.in does not exist.
CMake Error at cmake/build_info.cmake:27 (configure_file):
  configure_file Problem configuring file
```

The offending lines being: https://github.com/NeotokyoRebuild/neo/blob/8c50153ade38979542af9f0e2dfdb90935672809/src/cmake/build_info.cmake#L27-L28

Probably because:
```bash
(steamrt sniper 3.0.20250519.130773)root@7a5601b7ac38:~/neo/src> ls ../game/neo/resource/
KillfeedIcons.sfd  KillfeedIcons.ttf
```
Note the absense of `GameMenu.res.in` in the `ls` printout. Whereas the KillfeedIcons have indeed been correctly pulled from `neoAssets/neo/resource`, into the otherwise nonexistant folder.

---

Here's a more detailed fail output:
```bash
dev@pop-os:~/code$ pwd
/home/dev/code

dev@pop-os:~/code$ git clone https://github.com/NeotokyoRebuild/neo
Cloning into 'neo'...
remote: Enumerating objects: 23988, done.
remote: Counting objects: 100% (30/30), done.
remote: Compressing objects: 100% (27/27), done.
remote: Total 23988 (delta 7), reused 8 (delta 3), pack-reused 23958 (from 1)
Receiving objects: 100% (23988/23988), 190.71 MiB | 13.37 MiB/s, done.
Resolving deltas: 100% (13755/13755), done.

dev@pop-os:~/code$ cd neo/src
dev@pop-os:~/code/neo/src$ sudo docker run -v .:/root/neo/src --rm -it --entrypoint /bin/bash registry.gitlab.steamos.cloud/steamrt/sniper/sdk

(steamrt sniper 3.0.20250519.130773)root@7a5601b7ac38:/> cd /root/neo/src
(steamrt sniper 3.0.20250519.130773)root@7a5601b7ac38:~/neo/src> cmake --preset linux-debug
Preset CMake variables:

  CMAKE_BUILD_TYPE="Debug"
  CMAKE_CXX_COMPILER="g++"
  CMAKE_C_COMPILER="gcc"

-- The C compiler identification is GNU 10.3.0
-- The CXX compiler identification is GNU 10.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CMAKE_VERSION: 3.25.1
-- TIMESTAMP: 2025-07-06T21:41:23Z
-- 64-bit build
-- Found Git: /usr/bin/git (found version "2.30.2") 

CMake Error: File /root/neo/game/neo/resource/GameMenu.res.in does not exist.
CMake Error at cmake/build_info.cmake:27 (configure_file):
  configure_file Problem configuring file
Call Stack (most recent call first):
  CMakeLists.txt:19 (include)

# (unrelevant neoAssets successful download info lines omitted here)

-- Configuring incomplete, errors occurred!
See also "/root/neo/src/build/linux-debug/CMakeFiles/CMakeOutput.log".
```

## Toolchain
- Linux GCC 10 Sniper 3.0
