### PR TITLE
Fix main menu maxplayers slider value

### DIFF
--- a/src/game/client/neo/ui/neo_root.cpp
+++ b/src/game/client/neo/ui/neo_root.cpp
@@ -969,7 +969,7 @@ void CNeoRoot::MainLoopNewGame(const MainLoopParam param)
 				m_state = STATE_MAPLIST;
 			}
 			NeoUI::TextEdit(L"Hostname", m_newGame.wszHostname, SZWSZ_LEN(m_newGame.wszHostname));
-			NeoUI::SliderInt(L"Max players", &m_newGame.iMaxPlayers, 1, 32);
+			NeoUI::SliderInt(L"Max players", &m_newGame.iMaxPlayers, 1, MAX_PLAYERS-1); // -1 to accommodate SourceTV
 			NeoUI::TextEdit(L"Password", m_newGame.wszPassword, SZWSZ_LEN(m_newGame.wszPassword));
 			NeoUI::RingBoxBool(L"Friendly fire", &m_newGame.bFriendlyFire);
 			NeoUI::RingBoxBool(L"Use Steam networking", &m_newGame.bUseSteamNetworking);


### PR DESCRIPTION
## Description
Since the x64 update 2fdf6fb2, the engine's `MAX_PLAYERS` limit (for x64) has increased from 33 to 101. Update the main menu's server creation panel slider value to use this definition, instead of hardcoding 32 as the upper bound.

We're using `MAX_PLAYERS-1` because as per
https://github.com/NeotokyoRebuild/neo/blob/8f0fee0b0e4760af3851afb856815de9db2a9250/src/game/shared/shareddefs.h#L285-L287 the maximum gamerules allowed players should be <MAX_PLAYERS to make room for the SourceTV/replay bot on the last allocated slot.

## Toolchain
- Windows MSVC VS2022

## Linked Issues

