### PR TITLE
Change mp_mapcycle_empty_timeout_seconds default

### DIFF
--- a/src/game/shared/multiplay_gamerules.cpp
+++ b/src/game/shared/multiplay_gamerules.cpp
@@ -101,7 +101,11 @@ ConVar tv_delaymapchange_protect( "tv_delaymapchange_protect", "1", FCVAR_NONE, 
 ConVar mp_restartgame( "mp_restartgame", "0", FCVAR_GAMEDLL, "If non-zero, game will restart in the specified number of seconds" );
 ConVar mp_restartgame_immediate( "mp_restartgame_immediate", "0", FCVAR_GAMEDLL, "If non-zero, game will restart immediately" );
 
+#ifdef NEO
+ConVar mp_mapcycle_empty_timeout_seconds("mp_mapcycle_empty_timeout_seconds", "1800", FCVAR_REPLICATED, "If nonzero, server will cycle to the next map if it has been empty on the current map for N seconds");
+#else
 ConVar mp_mapcycle_empty_timeout_seconds( "mp_mapcycle_empty_timeout_seconds", "0", FCVAR_REPLICATED, "If nonzero, server will cycle to the next map if it has been empty on the current map for N seconds");
+#endif
 
 void cc_SkipNextMapInCycle()
 {


### PR DESCRIPTION
## Description

Set `mp_mapcycle_empty_timeout_seconds` default from 0 to 1800 seconds (30 minutes)

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1120 

