### PR TITLE
Add neo_restart_this support

### DIFF
--- a/src/game/shared/multiplay_gamerules.cpp
+++ b/src/game/shared/multiplay_gamerules.cpp
@@ -106,7 +106,7 @@ ConVar mp_restartgame( "mp_restartgame", "0", FCVAR_GAMEDLL, "If non-zero, game 
 #ifdef NEO
 ConVar neo_restart_this("neo_restart_this", "0", FCVAR_GAMEDLL, "If non-zero, game will restart immediately",
 	[](IConVar* var, const char* pOldValue, float flOldValue)->void {
-		if (static_cast<ConVar*>(var)->GetBool())
+		if (ConVarRef(var).GetBool())
 		{
 			if (NEORules()) NEORules()->RestartGame();
 		}

--- a/src/game/shared/multiplay_gamerules.cpp
+++ b/src/game/shared/multiplay_gamerules.cpp
@@ -42,6 +42,10 @@
 	#include "NextBotManager.h"
 #endif
 
+#ifdef NEO
+	#include "neo_gamerules.h"
+#endif
+
 #ifdef TF_DLL
 	#include <unordered_set>
 	#include "hl2orange.spa.h"
@@ -99,6 +103,16 @@ ConVar tv_delaymapchange( "tv_delaymapchange", "0", FCVAR_NONE, "Delays map chan
 ConVar tv_delaymapchange_protect( "tv_delaymapchange_protect", "1", FCVAR_NONE, "Protect against doing a manual map change if HLTV is broadcasting and has not caught up with a major game event such as round_end" );
 
 ConVar mp_restartgame( "mp_restartgame", "0", FCVAR_GAMEDLL, "If non-zero, game will restart in the specified number of seconds" );
+#ifdef NEO
+ConVar neo_restart_this("neo_restart_this", "0", FCVAR_GAMEDLL, "If non-zero, game will restart immediately",
+	[](IConVar* var, const char* pOldValue, float flOldValue)->void {
+		if (static_cast<ConVar*>(var)->GetBool())
+		{
+			if (NEORules()) NEORules()->RestartGame();
+		}
+		var->SetValue("0");
+	});
+#endif
 ConVar mp_restartgame_immediate( "mp_restartgame_immediate", "0", FCVAR_GAMEDLL, "If non-zero, game will restart immediately" );
 
 ConVar mp_mapcycle_empty_timeout_seconds( "mp_mapcycle_empty_timeout_seconds", "0", FCVAR_REPLICATED, "If nonzero, server will cycle to the next map if it has been empty on the current map for N seconds");


### PR DESCRIPTION
## Description
Add the `neo_restart_this` cvar for parity.

This cvar differs from `mp_restartgame` in that the latter will give a countdown, whereas `neo_restart_this` is instant.

As a side note, the cvar `mp_restartgame_immediate` seen below is `CTeamplayRoundBasedRules` related, which is not part of our gamerules inheritance chain, and its logic is not quite right, so that's why I'm rolling my own callback for the cvar.

## Toolchain
- Windows MSVC VS2022

## Linked Issues


