### PR TITLE
Spray handling improvements - Freezetime, disabled spray, cleanups

### DIFF
--- a/src/game/client/c_te_playerdecal.cpp
+++ b/src/game/client/c_te_playerdecal.cpp
@@ -22,10 +22,15 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
+#ifdef NEO
+// So that server/player.cpp can utilize cl_spraydisable to disable impulse 201
+static ConVar cl_spraydisable( "cl_spraydisable", "0", FCVAR_USERINFO | FCVAR_ARCHIVE, "Disable player sprays." );
+#else
 #ifdef TF_CLIENT_DLL
 static ConVar cl_spraydisable( "cl_spraydisable", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Disable player sprays." );
 #else
 static ConVar cl_spraydisable( "cl_spraydisable", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Disable player sprays." );
+#endif
 #endif
 
 #ifdef NEO

--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -187,11 +187,13 @@ bool g_bOBSDetected = false;
 #include <tchar.h>
 #include <psapi.h>
 #include <tlhelp32.h>
+#include <direct.h>
 #undef CreateEvent
 #endif
 
 #ifdef LINUX
 #include "neo_fixup_glshaders.h"
+#include <unistd.h>
 #endif
 
 #endif
@@ -1303,6 +1305,90 @@ static void NeoClantag_ChangeCallback(IConVar *cvar, [[maybe_unused]] const char
 }
 #endif
 
+#ifdef NEO
+#define SZ_USERCUSTOM_DIR "download/user_custom"
+// NEO NOTE (nullsystem): Delete custom downloaded sprays from other players on
+// startup and shutdown.
+// NEO JANK (nullsystem): It's done on both startup and shutdown mostly to
+// mitigate SDK filesystem API bug so it likely remove all the expected files
+// on shutdown.
+static void NeoDeleteDownloadedSprays()
+{
+	// NEO NOTE (nullsystem): Only deal with the .dat hexdec named files directly,
+	// no other directories (IFilesystem can't delete directories) or files deleted.
+	FileFindHandle_t findHdlFL;
+	for (const char *pszFNameFLDir = filesystem->FindFirst(SZ_USERCUSTOM_DIR "/*", &findHdlFL);
+		 pszFNameFLDir && findHdlFL != FILESYSTEM_INVALID_FIND_HANDLE;
+		 pszFNameFLDir = filesystem->FindNext(findHdlFL))
+	{
+		// Sanity check, expects directory of two character hexadecimal
+		const bool bIsValidFLDir = filesystem->FindIsDirectory(findHdlFL)
+				&& (V_strlen(pszFNameFLDir) == 2)
+				&& V_isxdigit(pszFNameFLDir[0])
+				&& V_isxdigit(pszFNameFLDir[1]);
+		if (!bIsValidFLDir)
+		{
+			continue;
+		}
+
+		char szSLRelPath[MAX_PATH];
+		V_sprintf_safe(szSLRelPath, SZ_USERCUSTOM_DIR "/%s", pszFNameFLDir);
+
+		char szSLSearch[MAX_PATH];
+		V_sprintf_safe(szSLSearch, "%s/*.dat", szSLRelPath);
+
+		FileFindHandle_t findHdlSL;
+		for (const char *pszFNameSLDat = filesystem->FindFirst(szSLSearch, &findHdlSL);
+			 pszFNameSLDat && findHdlSL != FILESYSTEM_INVALID_FIND_HANDLE;
+			 pszFNameSLDat = filesystem->FindNext(findHdlSL))
+		{
+			// Filename sanity check: Make sure filename is of this format: 00000000.dat - ffffffff.dat
+			static constexpr int BASE_FNAMESIZE = 8;
+			const int iFNameSLDatSize = V_strlen(pszFNameSLDat);
+			const bool bIsExpectedFNameSize = (iFNameSLDatSize == (BASE_FNAMESIZE + sizeof(".dat") - 1));
+			const bool bIsFile = !filesystem->FindIsDirectory(findHdlSL);
+			if (!bIsExpectedFNameSize || !bIsFile)
+			{
+				continue;
+			}
+
+			bool bFNameIsHexDigit = true;
+			for (int i = 0; bFNameIsHexDigit && i < BASE_FNAMESIZE; ++i)
+			{
+				bFNameIsHexDigit = V_isxdigit(pszFNameSLDat[i]);
+			}
+			if (!bFNameIsHexDigit)
+			{
+				continue;
+			}
+
+			char szFullFPathSLDat[MAX_PATH];
+			V_sprintf_safe(szFullFPathSLDat, SZ_USERCUSTOM_DIR "/%s/%s", pszFNameFLDir, pszFNameSLDat);
+
+			// NEO JANK (nullsystem): filesystem API seems buggy having earlier file(s) in alphanum order
+			// unable to recognize those files and remove them. When RemoveFile was called wasn't the issue
+			// and changing to calling it after Find... usages didn't solve it.
+			// So instead, doing this cleanup on both startup and shutdown could somewhat mitigate it.
+			filesystem->RemoveFile(szFullFPathSLDat);
+		}
+		filesystem->FindClose(findHdlSL);
+
+		// Remove this assumingly empty directory with rmdir
+		// It only removes empty directory so generally safe call
+		// and don't need to double check.
+		char szFullPath[MAX_PATH];
+		filesystem->RelativePathToFullPath_safe(szSLRelPath, "MOD", szFullPath);
+#if defined(WIN32)
+		// Both slash deliminator is valid in Windows, don't need to convert
+		_rmdir(szFullPath);
+#elif defined(LINUX)
+		rmdir(szFullPath);
+#endif
+	}
+	filesystem->FindClose(findHdlFL);
+}
+#endif
+
 //-----------------------------------------------------------------------------
 // Purpose: Called after client & server DLL are loaded and all systems initialized
 //-----------------------------------------------------------------------------
@@ -1409,6 +1495,8 @@ void CHLClient::PostInit()
 	{
 		V_memset(gStreamerModeNames[i], '.', 5);
 	}
+
+	NeoDeleteDownloadedSprays();
 #endif // NEO
 	
         if ( !r_lightmap_bicubic_set.GetBool() && materials )
@@ -1427,6 +1515,10 @@ void CHLClient::PostInit()
 //-----------------------------------------------------------------------------
 void CHLClient::Shutdown( void )
 {
+#ifdef NEO
+	NeoDeleteDownloadedSprays();
+#endif
+
     if (g_pAchievementsAndStatsInterface)
     {
         g_pAchievementsAndStatsInterface->ReleasePanel();


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Allow impulse 201 (spray) in freezetime
* Prevent impulse 201 if the client disabled spray
* Delete custom downloaded sprays on both startup and shutdown
    * Both startup and shutdown mostly to workaround filesystem API bug trying to recognize some of the files
* Test on `*.dat` sprays deletion on Windows (rainyan tested)

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Gentoo/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1205

