### PR TITLE
Revert NeoUI mouse handling change, -tools loads up legacy main menu instead

### DIFF
--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -1990,7 +1990,10 @@ void CHLClient::LevelInitPostEntity( )
 	internalCenterPrint->Clear();
 
 #ifdef NEO
-	g_pNeoLoading->m_wszLoadingMap[0] = L'\0';
+	if (g_pNeoLoading)
+	{
+		g_pNeoLoading->m_wszLoadingMap[0] = L'\0';
+	}
 #endif
 }
 

--- a/src/game/client/clientmode_shared.cpp
+++ b/src/game/client/clientmode_shared.cpp
@@ -425,12 +425,16 @@ void ClientModeShared::Init()
 	HOOK_MESSAGE( Rumble );
 
 #ifdef NEO
-	if (CreateInterfaceFn gameUIFactory = g_gameUI.GetFactory())
+	const bool bCliArgTools = CommandLine()->CheckParm("-tools");
+	if (!bCliArgTools)
 	{
-		if (IGameUI *pGameUI = reinterpret_cast<IGameUI *>(gameUIFactory(GAMEUI_INTERFACE_VERSION, nullptr)))
+		if (CreateInterfaceFn gameUIFactory = g_gameUI.GetFactory())
 		{
-			g_pNeoLoading = new CNeoLoading;
-			pGameUI->SetLoadingBackgroundDialog(g_pNeoLoading->GetVPanel());
+			if (IGameUI *pGameUI = reinterpret_cast<IGameUI *>(gameUIFactory(GAMEUI_INTERFACE_VERSION, nullptr)))
+			{
+				g_pNeoLoading = new CNeoLoading;
+				pGameUI->SetLoadingBackgroundDialog(g_pNeoLoading->GetVPanel());
+			}
 		}
 	}
 #endif
@@ -970,7 +974,10 @@ void ClientModeShared::LevelInit( const char *newmap )
 	enginesound->SetPlayerDSP( filter, 0, true );
 
 #ifdef NEO
-	g_pVGuiLocalize->ConvertANSIToUnicode(newmap, g_pNeoLoading->m_wszLoadingMap, sizeof(g_pNeoLoading->m_wszLoadingMap));
+	if (g_pNeoLoading)
+	{
+		g_pVGuiLocalize->ConvertANSIToUnicode(newmap, g_pNeoLoading->m_wszLoadingMap, sizeof(g_pNeoLoading->m_wszLoadingMap));
+	}
 #endif
 }
 
@@ -997,7 +1004,10 @@ void ClientModeShared::LevelShutdown( void )
 	enginesound->SetPlayerDSP( filter, 0, true );
 
 #ifdef NEO
-	g_pNeoLoading->m_wszLoadingMap[0] = L'\0';
+	if (g_pNeoLoading)
+	{
+		g_pNeoLoading->m_wszLoadingMap[0] = L'\0';
+	}
 #endif
 }
 

--- a/src/game/client/neo/ui/neo_root.cpp
+++ b/src/game/client/neo/ui/neo_root.cpp
@@ -119,7 +119,7 @@ CNeoRootInput::CNeoRootInput(CNeoRoot *rootPanel)
 {
 	MakePopup(true);
 	SetKeyBoardInputEnabled(true);
-	SetMouseInputEnabled(true);
+	SetMouseInputEnabled(false);
 	SetVisible(true);
 	SetEnabled(true);
 	PerformLayout();
@@ -127,10 +127,8 @@ CNeoRootInput::CNeoRootInput(CNeoRoot *rootPanel)
 
 void CNeoRootInput::PerformLayout()
 {
-	int iScrWide, iScrTall;
-	vgui::surface()->GetScreenSize(iScrWide, iScrTall);
 	SetPos(0, 0);
-	SetSize(iScrWide, iScrTall);
+	SetSize(1, 1);
 	SetBgColor(COLOR_TRANSPARENT);
 	SetFgColor(COLOR_TRANSPARENT);
 }
@@ -143,31 +141,6 @@ void CNeoRootInput::OnKeyCodeTyped(vgui::KeyCode code)
 void CNeoRootInput::OnKeyTyped(wchar_t unichar)
 {
 	m_pNeoRoot->OnRelayedKeyTyped(unichar);
-}
-
-void CNeoRootInput::OnMousePressed(vgui::MouseCode code)
-{
-	m_pNeoRoot->OnRelayedMousePressed(code);
-}
-
-void CNeoRootInput::OnMouseReleased(vgui::MouseCode code)
-{
-	m_pNeoRoot->OnRelayedMouseReleased(code);
-}
-
-void CNeoRootInput::OnMouseDoublePressed(vgui::MouseCode code)
-{
-	m_pNeoRoot->OnRelayedMouseDoublePressed(code);
-}
-
-void CNeoRootInput::OnMouseWheeled(int delta)
-{
-	m_pNeoRoot->OnRelayedMouseWheeled(delta);
-}
-
-void CNeoRootInput::OnCursorMoved(int x, int y)
-{
-	m_pNeoRoot->OnRelayedCursorMoved(x, y);
 }
 
 void CNeoRootInput::OnThink()
@@ -405,31 +378,31 @@ void CNeoRoot::Paint()
 	OnMainLoop(NeoUI::MODE_PAINT);
 }
 
-void CNeoRoot::OnRelayedMousePressed(vgui::MouseCode code)
+void CNeoRoot::OnMousePressed(vgui::MouseCode code)
 {
 	g_uiCtx.eCode = code;
 	OnMainLoop(NeoUI::MODE_MOUSEPRESSED);
 }
 
-void CNeoRoot::OnRelayedMouseReleased(vgui::MouseCode code)
+void CNeoRoot::OnMouseReleased(vgui::MouseCode code)
 {
 	g_uiCtx.eCode = code;
 	OnMainLoop(NeoUI::MODE_MOUSERELEASED);
 }
 
-void CNeoRoot::OnRelayedMouseDoublePressed(vgui::MouseCode code)
+void CNeoRoot::OnMouseDoublePressed(vgui::MouseCode code)
 {
 	g_uiCtx.eCode = code;
 	OnMainLoop(NeoUI::MODE_MOUSEDOUBLEPRESSED);
 }
 
-void CNeoRoot::OnRelayedMouseWheeled(int delta)
+void CNeoRoot::OnMouseWheeled(int delta)
 {
 	g_uiCtx.eCode = (delta > 0) ? MOUSE_WHEEL_UP : MOUSE_WHEEL_DOWN;
 	OnMainLoop(NeoUI::MODE_MOUSEWHEELED);
 }
 
-void CNeoRoot::OnRelayedCursorMoved(int x, int y)
+void CNeoRoot::OnCursorMoved(int x, int y)
 {
 	g_uiCtx.iMouseAbsX = x;
 	g_uiCtx.iMouseAbsY = y;

--- a/src/game/client/neo/ui/neo_root.h
+++ b/src/game/client/neo/ui/neo_root.h
@@ -44,11 +44,6 @@ public:
 	void PerformLayout() final;
 	void OnKeyCodeTyped(vgui::KeyCode code) final;
 	void OnKeyTyped(wchar_t unichar) final;
-	void OnMousePressed(vgui::MouseCode code) final;
-	void OnMouseReleased(vgui::MouseCode code) final;
-	void OnMouseDoublePressed(vgui::MouseCode code) final;
-	void OnMouseWheeled(int delta) final;
-	void OnCursorMoved(int x, int y) final;
 	void OnThink();
 	CNeoRoot *m_pNeoRoot = nullptr;
 };
@@ -151,11 +146,11 @@ public:
 	void OnRelayedKeyTyped(wchar_t unichar);
 	void ApplySchemeSettings(vgui::IScheme *pScheme) final;
 	void Paint() final;
-	void OnRelayedMousePressed(vgui::MouseCode code);
-	void OnRelayedMouseReleased(vgui::MouseCode code);
-	void OnRelayedMouseDoublePressed(vgui::MouseCode code);
-	void OnRelayedMouseWheeled(int delta);
-	void OnRelayedCursorMoved(int x, int y);
+	void OnMousePressed(vgui::MouseCode code) final;
+	void OnMouseReleased(vgui::MouseCode code) final;
+	void OnMouseDoublePressed(vgui::MouseCode code) final;
+	void OnMouseWheeled(int delta) final;
+	void OnCursorMoved(int x, int y) final;
 	void OnTick() final;
 	void FireGameEvent(IGameEvent *event) final;
 

--- a/src/game/client/vgui_int.cpp
+++ b/src/game/client/vgui_int.cpp
@@ -208,8 +208,12 @@ void VGui_CreateGlobalPanels( void )
 #endif
 
 #ifdef NEO
-	OverrideUI->Create(0U);
-	OverrideGameUI();
+	const bool bCliArgTools = CommandLine()->CheckParm("-tools");
+	if (!bCliArgTools)
+	{
+		OverrideUI->Create(0U);
+		OverrideGameUI();
+	}
 #endif
 
 	// Part of game


### PR DESCRIPTION
This reverts commit aa58c4a25c76798a82c3b0816a8187af558f8152. Because there's issues with mouse focus screwing with the other dialogs, just reverting this should fix that one and instead the `-tools` option will load up the legacy main menu instead.