### PR TITLE
Fix UI bind bugs

### DIFF
--- a/src/game/client/mp3player.cpp
+++ b/src/game/client/mp3player.cpp
@@ -1126,6 +1126,11 @@ ConCommand neo_mp3("neo_mp3", &neo_mp3_callback, "Toggle the mp3 player", FCVAR_
 
 void CMP3Player::OnKeyCodePressed(vgui::KeyCode code)
 {
+	if (code == BUTTON_CODE_NONE || code == BUTTON_CODE_INVALID)
+	{
+		return;
+	}
+
 	const auto toggleMP3Bind = gameuifuncs->GetButtonCodeForBind("neo_mp3");
 	if (toggleMP3Bind != code || !g_pPlayer)
 	{

--- a/src/game/client/mp3player.cpp
+++ b/src/game/client/mp3player.cpp
@@ -1126,6 +1126,8 @@ ConCommand neo_mp3("neo_mp3", &neo_mp3_callback, "Toggle the mp3 player", FCVAR_
 
 void CMP3Player::OnKeyCodePressed(vgui::KeyCode code)
 {
+	// This can happen if the user presses a key which has no corresponding mapping,
+	// for example multimedia keys like "Volume Up" will trigger this.
 	if (code == BUTTON_CODE_NONE || code == BUTTON_CODE_INVALID)
 	{
 		return;

--- a/src/game/client/neo/ui/neo_root.cpp
+++ b/src/game/client/neo/ui/neo_root.cpp
@@ -491,17 +491,14 @@ void CNeoRoot::OnRelayedKeyCodeTyped(vgui::KeyCode code)
 		return;
 	}
 
-	constexpr auto refreshBind = [](ButtonCode_t& mutRefButton, const char* bind)->void{
-		mutRefButton = gameuifuncs->GetButtonCodeForBind(bind);
-	};
 	// Refresh every time, because else if the user unbinds or rebinds the key, it will still incorrectly be mapped there.
 	// NEO FIXME (Rain): We do not currently support binding multiple buttons for the same command;
 	// if the user does: bind a foo; bind b foo; then only the latest bind will work.
-	refreshBind(m_ns.keys.bcConsole, "neo_toggleconsole");
-	refreshBind(m_ns.keys.bcMP3Player, "neo_mp3");
-	refreshBind(m_ns.keys.bcTeamMenu, "teammenu");
-	refreshBind(m_ns.keys.bcClassMenu, "classmenu");
-	refreshBind(m_ns.keys.bcLoadoutMenu, "loadoutmenu");
+	m_ns.keys.bcConsole = gameuifuncs->GetButtonCodeForBind("neo_toggleconsole");
+	m_ns.keys.bcMP3Player = gameuifuncs->GetButtonCodeForBind("neo_mp3");
+	m_ns.keys.bcTeamMenu = gameuifuncs->GetButtonCodeForBind("teammenu");
+	m_ns.keys.bcClassMenu = gameuifuncs->GetButtonCodeForBind("classmenu");
+	m_ns.keys.bcLoadoutMenu = gameuifuncs->GetButtonCodeForBind("loadoutmenu");
 
 	if (code == m_ns.keys.bcConsole && code != KEY_BACKQUOTE)
 	{

--- a/src/game/client/neo/ui/neo_root.cpp
+++ b/src/game/client/neo/ui/neo_root.cpp
@@ -483,6 +483,14 @@ void CNeoRoot::FireGameEvent(IGameEvent *event)
 
 void CNeoRoot::OnRelayedKeyCodeTyped(vgui::KeyCode code)
 {
+	// This can happen eg. when the client uses multimedia keys to adjust OS volume.
+	// If we don't return here, then any un-bound UI element which also has the bind "none"
+	// would incorrectly trigger for this unrelated input.
+	if (code <= KEY_NONE)
+	{
+		return;
+	}
+
 	if (m_ns.keys.bcConsole <= KEY_NONE)
 	{
 		m_ns.keys.bcConsole = gameuifuncs->GetButtonCodeForBind("neo_toggleconsole");

--- a/src/game/client/neo/ui/neo_root.cpp
+++ b/src/game/client/neo/ui/neo_root.cpp
@@ -491,14 +491,17 @@ void CNeoRoot::OnRelayedKeyCodeTyped(vgui::KeyCode code)
 		return;
 	}
 
-	if (m_ns.keys.bcConsole <= KEY_NONE)
-	{
-		m_ns.keys.bcConsole = gameuifuncs->GetButtonCodeForBind("neo_toggleconsole");
-		m_ns.keys.bcMP3Player = gameuifuncs->GetButtonCodeForBind("neo_mp3");
-		m_ns.keys.bcTeamMenu = gameuifuncs->GetButtonCodeForBind("teammenu");
-		m_ns.keys.bcClassMenu = gameuifuncs->GetButtonCodeForBind("classmenu");
-		m_ns.keys.bcLoadoutMenu = gameuifuncs->GetButtonCodeForBind("loadoutmenu");
-	}
+	constexpr auto refreshBind = [](ButtonCode_t& mutRefButton, const char* bind)->void{
+		mutRefButton = gameuifuncs->GetButtonCodeForBind(bind);
+	};
+	// Refresh every time, because else if the user unbinds or rebinds the key, it will still incorrectly be mapped there.
+	// NEO FIXME (Rain): We do not currently support binding multiple buttons for the same command;
+	// if the user does: bind a foo; bind b foo; then only the latest bind will work.
+	refreshBind(m_ns.keys.bcConsole, "neo_toggleconsole");
+	refreshBind(m_ns.keys.bcMP3Player, "neo_mp3");
+	refreshBind(m_ns.keys.bcTeamMenu, "teammenu");
+	refreshBind(m_ns.keys.bcClassMenu, "classmenu");
+	refreshBind(m_ns.keys.bcLoadoutMenu, "loadoutmenu");
 
 	if (code == m_ns.keys.bcConsole && code != KEY_BACKQUOTE)
 	{


### PR DESCRIPTION
## Description
Fix #1235, #1236

We still have the problem #1237  here that the user can't assign multiple keybinds for the same command, because the latest bind will always take precedence. But that's outside the scope of this PR.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes: #1235 
- fixes: #1236 
- related: #1237 
- possibly(?) related: #1166 

