### PR TITLE
Play rollover only on mousemoved, reset m_iHoverBtn correctly

### DIFF
--- a/src/game/client/neo/ui/neo_root.cpp
+++ b/src/game/client/neo/ui/neo_root.cpp
@@ -584,6 +584,7 @@ void CNeoRoot::MainLoopRoot(const MainLoopParam param)
 	{
 		g_uiCtx.eButtonTextStyle = NeoUI::TEXTSTYLE_CENTER;
 		const int iFlagToMatch = IsInGame() ? FLAG_SHOWINGAME : FLAG_SHOWINMAIN;
+		bool mouseOverButton = false;
 		for (int i = 0; i < BTNS_TOTAL; ++i)
 		{
 			const auto btnInfo = BTNS_INFO[i];
@@ -619,13 +620,20 @@ void CNeoRoot::MainLoopRoot(const MainLoopParam param)
 						}
 					}
 				}
-				if (retBtn.bMouseHover && i != m_iHoverBtn)
+				if (retBtn.bMouseHover)
 				{
-					// Sound rollover feedback
-					surface()->PlaySound("ui/buttonrollover.wav");
-					m_iHoverBtn = i;
+					mouseOverButton = true;
+					if (i != m_iHoverBtn && param.eMode == NeoUI::MODE_MOUSEMOVED)
+					{ // Sound rollover feedback
+						surface()->PlaySound("ui/buttonrollover.wav");
+						m_iHoverBtn = i;
+					}
 				}
 			}
+		}
+		if (!mouseOverButton && m_iHoverBtn < BTNS_TOTAL && param.eMode == NeoUI::MODE_MOUSEMOVED)
+		{
+			m_iHoverBtn = -1;
 		}
 	}
 	NeoUI::EndSection();
@@ -820,11 +828,17 @@ void CNeoRoot::MainLoopRoot(const MainLoopParam param)
 		engine->ClientCmd("neo_mp3");
 
 	}
-	if (musicPlayerBtn.bMouseHover && SMBTN_MP3 != m_iHoverBtn)
+	if (param.eMode == NeoUI::MODE_MOUSEMOVED)
 	{
-		// Sound rollover feedback
-		surface()->PlaySound("ui/buttonrollover.wav");
-		m_iHoverBtn = SMBTN_MP3;
+		if (musicPlayerBtn.bMouseHover && SMBTN_MP3 != m_iHoverBtn)
+		{ // Sound rollover feedback
+			surface()->PlaySound("ui/buttonrollover.wav");
+			m_iHoverBtn = SMBTN_MP3;
+		}
+		else if (!musicPlayerBtn.bMouseHover && SMBTN_MP3 == m_iHoverBtn)
+		{
+			m_iHoverBtn = -1;
+		}
 	}
 	
 	NeoUI::EndSection();


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Makes the sound rollover feedback sound nicer when moving between two buttons that touch, and makes the sound play when moving the mouse on and off the same button repeatedly

- fixes #1242
- fixes #1243