### PR TITLE
NeoNextBots shoot at visible parts of other clients

### DIFF
--- a/src/game/server/NextBot/NextBotVisionInterface.cpp
+++ b/src/game/server/NextBot/NextBotVisionInterface.cpp
@@ -775,8 +775,10 @@ bool IVision::IsLineOfSightClearToEntity( const CBaseEntity *subject, Vector *vi
 	{
 		*visibleSpot = result.endpos;
 	}
+#ifdef NEO
 
 	idealTargetPoint[subject->entindex()] = result.endpos;
+#endif // NEO
 
 	return ( result.fraction >= 1.0f && !result.startsolid );
 

--- a/src/game/server/NextBot/NextBotVisionInterface.cpp
+++ b/src/game/server/NextBot/NextBotVisionInterface.cpp
@@ -565,7 +565,11 @@ void IVision::Update( void )
 
 
 //------------------------------------------------------------------------------------------
+#ifdef NEO
+bool IVision::IsAbleToSee( CBaseEntity *subject, FieldOfViewCheckType checkFOV, Vector *visibleSpot )
+#else
 bool IVision::IsAbleToSee( CBaseEntity *subject, FieldOfViewCheckType checkFOV, Vector *visibleSpot ) const
+#endif // NEO
 {
 	VPROF_BUDGET( "IVision::IsAbleToSee", "NextBotExpensive" );
 
@@ -708,7 +712,11 @@ bool IVision::IsLineOfSightClear( const Vector &pos ) const
 
 
 //------------------------------------------------------------------------------------------
+#ifdef NEO
+bool IVision::IsLineOfSightClearToEntity( const CBaseEntity *subject, Vector *visibleSpot )
+#else
 bool IVision::IsLineOfSightClearToEntity( const CBaseEntity *subject, Vector *visibleSpot ) const
+#endif // NEO
 {
 #ifdef TERROR
 	// TODO: Integration querycache & its dependencies
@@ -767,6 +775,8 @@ bool IVision::IsLineOfSightClearToEntity( const CBaseEntity *subject, Vector *vi
 	{
 		*visibleSpot = result.endpos;
 	}
+
+	idealTargetPoint[subject->entindex()] = result.endpos;
 
 	return ( result.fraction >= 1.0f && !result.startsolid );
 

--- a/src/game/server/NextBot/NextBotVisionInterface.h
+++ b/src/game/server/NextBot/NextBotVisionInterface.h
@@ -8,6 +8,9 @@
 
 #include "NextBotComponentInterface.h"
 #include "NextBotKnownEntity.h"
+#ifdef NEO
+#include <map>
+#endif // NEO
 
 class IBody;
 class INextBotEntityFilter;
@@ -81,7 +84,11 @@ public:
 	 * If 'visibleSpot' is non-NULL, the highest priority spot on the subject that is visible is returned.
 	 */ 
 	enum FieldOfViewCheckType { USE_FOV, DISREGARD_FOV };
+#ifdef NEO
+	virtual bool IsAbleToSee( CBaseEntity *subject, FieldOfViewCheckType checkFOV, Vector *visibleSpot = NULL );
+#else
 	virtual bool IsAbleToSee( CBaseEntity *subject, FieldOfViewCheckType checkFOV, Vector *visibleSpot = NULL ) const;
+#endif // NEO
 	virtual bool IsAbleToSee( const Vector &pos, FieldOfViewCheckType checkFOV ) const;
 
 	virtual bool IsIgnored( CBaseEntity *subject ) const;		// return true to completely ignore this entity (may not be in sight when this is called)
@@ -102,7 +109,12 @@ public:
 	 * Returns true if the ray between the position and the subject is unobstructed.
 	 * A visible spot on the subject is returned in 'visibleSpot'.
 	 */
+#ifdef NEO // May as well update idealTargetPoint here to not do extra tracelines
+	virtual bool IsLineOfSightClearToEntity( const CBaseEntity *subject, Vector *visibleSpot = NULL );
+	std::map<int, Vector> idealTargetPoint;
+#else
 	virtual bool IsLineOfSightClearToEntity( const CBaseEntity *subject, Vector *visibleSpot = NULL ) const;
+#endif // NEO
 
 	/// @todo: Implement LookAt system
 	virtual bool IsLookingAt( const Vector &pos, float cosTolerance = 0.95f ) const;					// are we looking at the given position

--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -232,6 +232,11 @@ Vector CNEOBotMainAction::SelectTargetPoint( const INextBot *meBot, const CBaseC
 			}
 		}
 
+		if (me->GetVisionInterface()->idealTargetPoint.contains(subject->entindex()))
+		{
+			return me->GetVisionInterface()->idealTargetPoint[subject->entindex()];
+		}
+
 		// aim for the center of the object (ie: sentry gun)
 		return subject->WorldSpaceCenter();
 	}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Previously the bots would always shoot center mass, but IsLineOfSightClearToEntity checks center mass, eye pos and origin. This pr adds a map to NextBotVisionInterface that stores the ideal position for the bot to aim at when shooting at entities.
