### PR TITLE
NeoUI - Clipboard + selection + free-cursor for TextEdit

### DIFF
--- a/src/game/client/neo/ui/neo_root.cpp
+++ b/src/game/client/neo/ui/neo_root.cpp
@@ -483,10 +483,6 @@ void CNeoRoot::OnRelayedKeyCodeTyped(vgui::KeyCode code)
 		NeoToggleconsole();
 		return;
 	}
-	else if (code == m_ns.keys.bcMP3Player)
-	{
-		engine->ClientCmd_Unrestricted("neo_mp3");
-	}
 	g_uiCtx.eCode = code;
 	OnMainLoop(NeoUI::MODE_KEYPRESSED);
 }
@@ -590,6 +586,11 @@ void CNeoRoot::MainLoopRoot(const MainLoopParam param)
 	NeoUI::BeginContext(&g_uiCtx, param.eMode, nullptr, "CtxRoot");
 	NeoUI::BeginSection(true);
 	{
+		if (param.eMode == NeoUI::MODE_KEYPRESSED && g_uiCtx.eCode == m_ns.keys.bcMP3Player)
+		{
+			engine->ClientCmd_Unrestricted("neo_mp3");
+		}
+
 		g_uiCtx.eButtonTextStyle = NeoUI::TEXTSTYLE_CENTER;
 		const int iFlagToMatch = IsInGame() ? FLAG_SHOWINGAME : FLAG_SHOWINMAIN;
 		bool mouseOverButton = false;
@@ -705,7 +706,8 @@ void CNeoRoot::MainLoopRoot(const MainLoopParam param)
 			m_avImage->Paint();
 
 			wchar_t wszDisplayName[NEO_MAX_DISPLAYNAME];
-			GetClNeoDisplayName(wszDisplayName, neo_name.GetString(), neo_clantag.GetString(), cl_onlysteamnick.GetBool());
+			GetClNeoDisplayName(wszDisplayName, neo_name.GetString(), neo_clantag.GetString(),
+					(cl_onlysteamnick.GetBool()) ? CL_NEODISPLAYNAME_FLAG_ONLYSTEAMNICK : CL_NEODISPLAYNAME_FLAG_NONE);
 
 			const char *szNeoName = neo_name.GetString();
 			const bool bUseNeoName = (szNeoName && szNeoName[0] != '\0' && !cl_onlysteamnick.GetBool());
@@ -928,9 +930,12 @@ void CNeoRoot::MainLoopSettings(const MainLoopParam param)
 				{
 					NeoSettingsRestore(&m_ns);
 				}
-				if (NeoUI::Button(L"Accept").bPressed)
+				if (m_ns.bIsValid)
 				{
-					NeoSettingsSave(&m_ns);
+					if (NeoUI::Button(L"Accept").bPressed)
+					{
+						NeoSettingsSave(&m_ns);
+					}
 				}
 			}
 			NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
@@ -980,7 +985,8 @@ void CNeoRoot::MainLoopNewGame(const MainLoopParam param)
 			NeoUI::TextEdit(L"Hostname", m_newGame.wszHostname, SZWSZ_LEN(m_newGame.wszHostname));
 			NeoUI::SliderInt(L"Max players", &m_newGame.iMaxPlayers, 1, MAX_PLAYERS-1); // -1 to accommodate SourceTV
 			NeoUI::SliderInt(L"Bot Quota", &m_newGame.iBotQuota, 0, MAX_PLAYERS-1);
-			NeoUI::TextEdit(L"Password", m_newGame.wszPassword, SZWSZ_LEN(m_newGame.wszPassword));
+			NeoUI::TextEdit(L"Password", m_newGame.wszPassword, SZWSZ_LEN(m_newGame.wszPassword),
+					cl_neo_streamermode.GetBool() ? NeoUI::TEXTEDITFLAG_PASSWORD : NeoUI::TEXTEDITFLAG_NONE);
 			NeoUI::RingBoxBool(L"Friendly fire", &m_newGame.bFriendlyFire);
 			NeoUI::RingBoxBool(L"Use Steam networking", &m_newGame.bUseSteamNetworking);
 		}
@@ -1809,19 +1815,28 @@ void CNeoRoot::MainLoopPopup(const MainLoopParam param)
 			break;
 			case STATE_CONFIRMSETTINGS:
 			{
-				NeoUI::Label(L"Settings changed: Do you want to apply the settings?");
+				NeoUI::Label((m_ns.bIsValid) ?
+						L"Settings changed: Do you want to apply the settings?" :
+						L"Error: Invalid settings, cannot save.");
 				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 				NeoUI::SetPerRowLayout(3);
 				{
 					g_uiCtx.iLayoutX = (g_uiCtx.iMarginX / 2);
-					if (NeoUI::Button(L"Save (Enter)").bPressed || NeoUI::Bind(KEY_ENTER))
+					if (m_ns.bIsValid)
 					{
-						NeoSettingsSave(&m_ns);
-						m_state = STATE_ROOT;
+						if (NeoUI::Button(L"Save (Enter)").bPressed || NeoUI::Bind(KEY_ENTER))
+						{
+							NeoSettingsSave(&m_ns);
+							m_state = STATE_ROOT;
+						}
 					}
 					if (NeoUI::Button(L"Discard").bPressed)
 					{
 						m_state = STATE_ROOT;
+					}
+					if (!m_ns.bIsValid)
+					{
+						NeoUI::Pad();
 					}
 					if (NeoUI::Button(L"Cancel (ESC)").bPressed || NeoUI::Bind(KEY_ESCAPE))
 					{
@@ -1854,9 +1869,7 @@ void CNeoRoot::MainLoopPopup(const MainLoopParam param)
 				NeoUI::SwapFont(NeoUI::FONT_NTNORMAL);
 				{
 					NeoUI::SetPerRowLayout(2, NeoUI::ROWLAYOUT_TWOSPLIT);
-					g_uiCtx.bTextEditIsPassword = true;
-					NeoUI::TextEdit(L"Password:", m_wszServerPassword, SZWSZ_LEN(m_wszServerPassword));
-					g_uiCtx.bTextEditIsPassword = false;
+					NeoUI::TextEdit(L"Password:", m_wszServerPassword, SZWSZ_LEN(m_wszServerPassword), NeoUI::TEXTEDITFLAG_PASSWORD);
 				}
 				NeoUI::SetPerRowLayout(3);
 				{

--- a/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/src/game/client/neo/ui/neo_root_settings.cpp
@@ -672,8 +672,8 @@ static_assert(ARRAYSIZE(DLFILTER_STRMAP) == ARRAYSIZE(DLFILTER_LABELS));
 void NeoSettings_General(NeoSettings *ns)
 {
 	NeoSettings::General *pGeneral = &ns->general;
-	NeoUI::TextEdit(L"Name", pGeneral->wszNeoName, MAX_PLAYER_NAME_LENGTH);
-	NeoUI::TextEdit(L"Clan tag", pGeneral->wszNeoClantag, NEO_MAX_CLANTAG_LENGTH);
+	NeoUI::TextEdit(L"Name", pGeneral->wszNeoName, MAX_PLAYER_NAME_LENGTH - 1);
+	NeoUI::TextEdit(L"Clan tag", pGeneral->wszNeoClantag, NEO_MAX_CLANTAG_LENGTH - 1);
 	NeoUI::RingBoxBool(L"Show only steam name", &pGeneral->bOnlySteamNick);
 	NeoUI::RingBoxBool(L"Friendly marker spectator only clantags", &pGeneral->bMarkerSpecOnlyClantag);
 

--- a/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/src/game/client/neo/ui/neo_root_settings.cpp
@@ -245,6 +245,7 @@ void NeoSettingsDeinit(NeoSettings *ns)
 void NeoSettingsRestore(NeoSettings *ns, const NeoSettings::Keys::Flags flagsKeys)
 {
 	ns->bModified = false;
+	ns->bIsValid = true;
 	NeoSettings::CVR *cvr = &ns->cvr;
 	{
 		NeoSettings::General *pGeneral = &ns->general;
@@ -671,14 +672,27 @@ static_assert(ARRAYSIZE(DLFILTER_STRMAP) == ARRAYSIZE(DLFILTER_LABELS));
 void NeoSettings_General(NeoSettings *ns)
 {
 	NeoSettings::General *pGeneral = &ns->general;
-	NeoUI::TextEdit(L"Name", pGeneral->wszNeoName, SZWSZ_LEN(pGeneral->wszNeoName));
-	NeoUI::TextEdit(L"Clan tag", pGeneral->wszNeoClantag, SZWSZ_LEN(pGeneral->wszNeoClantag));
+	NeoUI::TextEdit(L"Name", pGeneral->wszNeoName, MAX_PLAYER_NAME_LENGTH);
+	NeoUI::TextEdit(L"Clan tag", pGeneral->wszNeoClantag, NEO_MAX_CLANTAG_LENGTH);
 	NeoUI::RingBoxBool(L"Show only steam name", &pGeneral->bOnlySteamNick);
 	NeoUI::RingBoxBool(L"Friendly marker spectator only clantags", &pGeneral->bMarkerSpecOnlyClantag);
 
 	wchar_t wszTotalClanAndName[NEO_MAX_DISPLAYNAME];
-	GetClNeoDisplayName(wszTotalClanAndName, pGeneral->wszNeoName, pGeneral->wszNeoClantag, pGeneral->bOnlySteamNick);
-	NeoUI::Label(L"Display name", wszTotalClanAndName);
+	ns->bIsValid = GetClNeoDisplayName(wszTotalClanAndName,
+			pGeneral->wszNeoName, pGeneral->wszNeoClantag,
+			((pGeneral->bOnlySteamNick) ?
+			 	CL_NEODISPLAYNAME_FLAG_CHECK | CL_NEODISPLAYNAME_FLAG_ONLYSTEAMNICK :
+				CL_NEODISPLAYNAME_FLAG_CHECK));
+	if (ns->bIsValid)
+	{
+		NeoUI::Label(L"Display name", wszTotalClanAndName);
+	}
+	else
+	{
+		NeoUI::BeginOverrideFgColor(COLOR_RED);
+		NeoUI::Label(L"Display name (invalid)", wszTotalClanAndName);
+		NeoUI::EndOverrideFgColor();
+	}
 
 	NeoUI::SliderInt(L"FOV", &pGeneral->iFov, 75, 110);
 	NeoUI::SliderInt(L"Viewmodel FOV Offset", &pGeneral->iViewmodelFov, -20, 40);

--- a/src/game/client/neo/ui/neo_root_settings.h
+++ b/src/game/client/neo/ui/neo_root_settings.h
@@ -38,8 +38,8 @@ struct NeoSettings
 {
 	struct General
 	{
-		wchar_t wszNeoName[MAX_PLAYER_NAME_LENGTH + 1];
-		wchar_t wszNeoClantag[NEO_MAX_CLANTAG_LENGTH + 1];
+		wchar_t wszNeoName[MAX_PLAYER_NAME_LENGTH];
+		wchar_t wszNeoClantag[NEO_MAX_CLANTAG_LENGTH];
 		bool bOnlySteamNick;
 		bool bMarkerSpecOnlyClantag;
 		int iFov;

--- a/src/game/client/neo/ui/neo_root_settings.h
+++ b/src/game/client/neo/ui/neo_root_settings.h
@@ -169,6 +169,7 @@ struct NeoSettings
 	int iCurTab = 0;
 	bool bBack = false;
 	bool bModified = false;
+	bool bIsValid = false;
 	int iNextBinding = -1;
 
 	struct CVR

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -544,7 +544,7 @@ void CNEOScoreBoard::UpdatePlayerInfo()
 			UpdatePlayerAvatar( i, playerData );
 
 			const char *oldName = playerData->GetString("name","");
-			char newName[MAX_PLAYER_NAME_LENGTH + 1 + NEO_MAX_CLANTAG_LENGTH + 1];
+			char newName[NEO_MAX_DISPLAYNAME];
 
 			UTIL_MakeSafeName( oldName, newName, ARRAYSIZE(newName) );
 
@@ -724,7 +724,7 @@ void CNEOScoreBoard::GetPlayerScoreInfo(int playerIndex, KeyValues *kv)
 	const char *pClantag = g_PR->GetClanTag(playerIndex);
 	if (pClantag && pClantag[0] && (!cl_neo_streamermode.GetBool() || g_PR->IsLocalPlayer(playerIndex)))
 	{
-		char szClanTagWName[MAX_PLAYER_NAME_LENGTH + 1 + NEO_MAX_CLANTAG_LENGTH + 1];
+		char szClanTagWName[NEO_MAX_DISPLAYNAME];
 		V_sprintf_safe(szClanTagWName, "[%s] %s", pClantag, g_PR->GetPlayerName(playerIndex));
 		kv->SetString("name", szClanTagWName);
 	}

--- a/src/game/client/neo/ui/neo_ui.cpp
+++ b/src/game/client/neo/ui/neo_ui.cpp
@@ -2,12 +2,16 @@
 
 #include <vgui/ILocalize.h>
 #include <vgui/IInput.h>
+#include <vgui/ISystem.h>
 #include <vgui_controls/Controls.h>
 #include <filesystem.h>
 #include <stb_image.h>
 #include <materialsystem/imaterial.h>
 
 #include "neo_misc.h"
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
 
 static const wchar_t *ENABLED_LABELS[] = {
 	L"Disabled",
@@ -22,6 +26,11 @@ static Context *c = &g_emptyCtx;
 const int ROWLAYOUT_TWOSPLIT[] = { 40, -1 };
 static constexpr int WDGINFO_ALLOC_STEPS = 64;
 
+#define DEBUG_NEOUI 0 // NEO NOTE (nullsystem): !!! Always flip to 0 on master + PR !!!
+#ifndef DEBUG
+static_assert(DEBUG_NEOUI == 0);
+#endif
+
 void SwapFont(const EFont eFont, const bool bForce)
 {
 	if (c->eMode != MODE_PAINT || (!bForce && (c->eFont == eFont))) return;
@@ -33,6 +42,17 @@ void SwapColorNormal(const Color &color)
 {
 	c->normalBgColor = color;
 	vgui::surface()->DrawSetColor(c->normalBgColor);
+}
+
+void BeginOverrideFgColor(const Color &fgColor)
+{
+	c->cOverrideFgColor = fgColor;
+	c->bIsOverrideFgColor = true;
+}
+
+void EndOverrideFgColor()
+{
+	c->bIsOverrideFgColor = false;
 }
 
 void MultiWidgetHighlighter(const int iTotalWidgets)
@@ -160,7 +180,6 @@ void BeginContext(NeoUI::Context *pNextCtx, const NeoUI::Mode eMode, const wchar
 	c->bValueEdited = false;
 	c->eButtonTextStyle = TEXTSTYLE_CENTER;
 	c->eLabelTextStyle = TEXTSTYLE_LEFT;
-	c->bTextEditIsPassword = false;
 	c->selectBgColor = COLOR_NEOPANELSELECTBG;
 	c->normalBgColor = COLOR_NEOPANELACCENTBG;
 	// Different pointer, change context
@@ -228,6 +247,101 @@ void BeginContext(NeoUI::Context *pNextCtx, const NeoUI::Mode eMode, const wchar
 
 void EndContext()
 {
+	if (c->iRightClick >= 0 && c->iRightClickSection >= 0 && c->pwszRightClickList && c->ipwszRightClickListSize > 0)
+	{
+		bool bDeInitRightClick = false;
+		switch (c->eMode)
+		{
+		case MODE_PAINT:
+		{
+			static Color menuColor = COLOR_NEOPANELFRAMEBG;
+			const Dim &dim = c->dimRightClick;
+			vgui::surface()->DrawSetColor(menuColor);
+			vgui::surface()->DrawFilledRect(
+					dim.x,
+					dim.y,
+					dim.x + dim.wide,
+					dim.y + dim.tall);
+			for (int i = 0, iNextY = dim.y;
+					i < c->ipwszRightClickListSize;
+					++i, iNextY += c->layout.iRowTall)
+			{
+				if (c->iRightClickHotItem == i)
+				{
+					vgui::surface()->DrawSetColor(c->selectBgColor);
+					vgui::surface()->DrawFilledRect(
+							dim.x,
+							iNextY,
+							dim.x + dim.wide,
+							iNextY + c->layout.iRowTall);
+				}
+				const wchar *pwszItemLabel = c->pwszRightClickList[i];
+				vgui::surface()->DrawSetTextPos(dim.x + c->iMarginX,
+						iNextY + c->iMarginY);
+				vgui::surface()->DrawPrintText(pwszItemLabel, V_wcslen(pwszItemLabel));
+			}
+			vgui::surface()->DrawSetColor(c->normalBgColor);
+		} break;
+		case MODE_KEYPRESSED:
+		case MODE_KEYTYPED:
+		{
+			bDeInitRightClick = true;
+		} break;
+		case MODE_MOUSEPRESSED:
+		{
+			bDeInitRightClick = true;
+			// Wide/tall set to 0 indicates it's a newly initialized right-click menu
+			if (c->dimRightClick.wide == 0 || c->dimRightClick.tall == 0)
+			{
+				const auto *pFontI = &c->fonts[c->eFont];
+				int iMinTextSize = 0;
+				for (int i = 0; i < c->ipwszRightClickListSize; ++i)
+				{
+					const wchar *pwszItemLabel = c->pwszRightClickList[i];
+					iMinTextSize = Max(iMinTextSize, V_wcslen(pwszItemLabel));
+				}
+				// Empty text size should never really happen, but just in-case, just don't
+				// init the menu
+				Assert(iMinTextSize > 0);
+				if (iMinTextSize > 0)
+				{
+					const int iChWidth = vgui::surface()->GetCharacterWidth(pFontI->hdl, 'A');
+					c->dimRightClick.wide = (c->iMarginX * 2) + (iMinTextSize * iChWidth);
+					c->dimRightClick.tall = c->ipwszRightClickListSize * c->layout.iRowTall;
+					bDeInitRightClick = false;
+				}
+			}
+		} break;
+		case MODE_MOUSEMOVED:
+		{
+			const Dim &dim = c->dimRightClick;
+			if (dim.wide > 0 && dim.tall > 0 &&
+					IN_BETWEEN_EQ(dim.x, c->iMouseAbsX, dim.x + dim.wide) &&
+					IN_BETWEEN_EQ(dim.y, c->iMouseAbsY, dim.y + dim.tall))
+			{
+				const int iRelMenuPosY = c->iMouseAbsY - dim.y;
+				c->iRightClickHotItem = (iRelMenuPosY / static_cast<float>(dim.tall)) * c->ipwszRightClickListSize;
+			}
+			else
+			{
+				c->iRightClickHotItem = -1;
+			}
+		} break;
+		default:
+			break;
+		}
+
+		if (bDeInitRightClick)
+		{
+			// Already set wide/tall indicates right-click menu already initalized before
+			// and can now de-initialize/close
+			c->iRightClick = -1;
+			c->iRightClickSection = -1;
+			c->pwszRightClickList = nullptr;
+			c->ipwszRightClickListSize = 0;
+		}
+	}
+
 	if (c->eMode == MODE_MOUSEPRESSED && !c->iHasMouseInPanel)
 	{
 		c->iActive = FOCUSOFF_NUM;
@@ -481,29 +595,7 @@ void SetPerCellVertLayout(const int iRowTotal, const int *iRowProportions)
 	c->iVertLayoutY = 0;
 }
 
-static GetMouseinFocusedRet InternalGetMouseinFocused()
-{
-	const bool bMouseIn = IN_BETWEEN_EQ(c->rWidgetArea.x0, c->iMouseAbsX, c->rWidgetArea.x1)
-			&& IN_BETWEEN_EQ(c->rWidgetArea.y0, c->iMouseAbsY, c->rWidgetArea.y1);
-	if (bMouseIn)
-	{
-		c->iHot = c->iWidget;
-		c->iHotSection = c->iSection;
-	}
-	const bool bHot = c->iHot == c->iWidget && c->iHotSection == c->iSection;
-	const bool bActive = c->iWidget == c->iActive && c->iSection == c->iActiveSection;
-	if (bActive || bHot)
-	{
-		vgui::surface()->DrawSetColor(c->selectBgColor);
-		if (bActive) vgui::surface()->DrawSetTextColor(COLOR_NEOPANELTEXTBRIGHT);
-	}
-	return GetMouseinFocusedRet{
-		.bActive = bActive,
-		.bHot = bHot,
-	};
-}
-
-void BeginWidget(const WidgetFlag eWidgetFlag)
+GetMouseinFocusedRet BeginWidget(const WidgetFlag eWidgetFlag)
 {
 	if (c->iWidget >= c->iWdgInfosMax)
 	{
@@ -614,13 +706,46 @@ void BeginWidget(const WidgetFlag eWidgetFlag)
 			++c->iIdxRowParts;
 		}
 	}
+
+	if (c->bIsOverrideFgColor)
+	{
+		vgui::surface()->DrawSetTextColor(c->cOverrideFgColor);
+	}
+
+	// Check mouse hot/active states if WIDGETFLAG_MOUSE flag set
+	if (eWidgetFlag & WIDGETFLAG_MOUSE)
+	{
+		const bool bMouseIn = IN_BETWEEN_EQ(c->rWidgetArea.x0, c->iMouseAbsX, c->rWidgetArea.x1)
+				&& IN_BETWEEN_EQ(c->rWidgetArea.y0, c->iMouseAbsY, c->rWidgetArea.y1);
+		if (bMouseIn)
+		{
+			c->iHot = c->iWidget;
+			c->iHotSection = c->iSection;
+		}
+		const bool bHot = c->iHot == c->iWidget && c->iHotSection == c->iSection;
+		const bool bActive = c->iWidget == c->iActive && c->iSection == c->iActiveSection;
+		if (bActive || bHot)
+		{
+			vgui::surface()->DrawSetColor(c->selectBgColor);
+			if (bActive && !c->bIsOverrideFgColor)
+			{
+				vgui::surface()->DrawSetTextColor(COLOR_NEOPANELTEXTBRIGHT);
+			}
+		}
+		return GetMouseinFocusedRet{
+			.bActive = bActive,
+			.bHot = bHot,
+		};
+	}
+	
+	return GetMouseinFocusedRet{};
 }
 
 void EndWidget(const GetMouseinFocusedRet wdgState)
 {
 	++c->iWidget;
 	// NEO TODO (nullsystem): Will refactor when dealing with styling/color refactor
-	if (wdgState.bActive || wdgState.bHot)
+	if (wdgState.bActive || wdgState.bHot || c->bIsOverrideFgColor)
 	{
 		vgui::surface()->DrawSetColor(c->normalBgColor);
 		vgui::surface()->DrawSetTextColor(COLOR_NEOPANELTEXTNORMAL);
@@ -770,9 +895,8 @@ void Label(const wchar_t *wszLabel, const wchar_t *wszText)
 
 NeoUI::RetButton Button(const wchar_t *wszText)
 {
-	BeginWidget();
+	const auto wdgState = BeginWidget(WIDGETFLAG_MOUSE);
 	RetButton ret = {};
-	const auto wdgState = InternalGetMouseinFocused();
 	ret.bMouseHover = wdgState.bHot;
 
 	if (IN_BETWEEN_AR(0, c->irWidgetLayoutY, c->dPanel.tall))
@@ -984,9 +1108,8 @@ bool Texture(const char *szTexturePath, const int x, const int y, const int widt
 
 NeoUI::RetButton ButtonTexture(const char *szTexturePath)
 {
-	BeginWidget();
+	const auto wdgState = BeginWidget(WIDGETFLAG_MOUSE);
 	RetButton ret = {};
-	const auto wdgState = InternalGetMouseinFocused();
 	ret.bMouseHover = wdgState.bHot;
 
 	if (IN_BETWEEN_AR(0, c->irWidgetLayoutY, c->dPanel.tall))
@@ -1067,8 +1190,7 @@ void RingBox(const wchar_t *wszLeftLabel, const wchar_t **wszLabelsList, const i
 
 void RingBox(const wchar_t **wszLabelsList, const int iLabelsSize, int *iIndex)
 {
-	BeginWidget();
-	const auto wdgState = InternalGetMouseinFocused();
+	const auto wdgState = BeginWidget(WIDGETFLAG_MOUSE);
 
 	if (IN_BETWEEN_AR(0, c->irWidgetLayoutY, c->dPanel.tall))
 	{
@@ -1158,8 +1280,7 @@ void RingBox(const wchar_t **wszLabelsList, const int iLabelsSize, int *iIndex)
 void Tabs(const wchar_t **wszLabelsList, const int iLabelsSize, int *iIndex)
 {
 	// This is basically a ringbox but different UI
-	BeginWidget(WIDGETFLAG_SKIPACTIVE);
-	const auto wdgState = InternalGetMouseinFocused();
+	const auto wdgState = BeginWidget(WIDGETFLAG_SKIPACTIVE | WIDGETFLAG_MOUSE);
 
 	SwapFont(FONT_NTHORIZSIDES);
 	const int iTabWide = (c->dPanel.wide / iLabelsSize);
@@ -1282,8 +1403,7 @@ void Slider(const wchar_t *wszLeftLabel, float *flValue, const float flMin, cons
 {
 	MultiWidgetHighlighter(2);
 	Label(wszLeftLabel);
-	BeginWidget();
-	const auto wdgState = InternalGetMouseinFocused();
+	const auto wdgState = BeginWidget(WIDGETFLAG_MOUSE);
 
 	if (IN_BETWEEN_AR(0, c->irWidgetLayoutY, c->dPanel.tall))
 	{
@@ -1516,17 +1636,81 @@ void SliderU8(const wchar_t *wszLeftLabel, uint8 *ucValue, const uint8 iMin, con
 	}
 }
 
-void TextEdit(const wchar_t *wszLeftLabel, wchar_t *wszText, const int iMaxBytes)
+static int TextEditChIdxFromMouse(const int iWszTextSize)
+{
+	const int iMouseOnXWidth = c->iMouseAbsX - (c->rWidgetArea.x0 + c->iMarginX);
+	int iChIdx = -1;
+	for (int i = 0; i < iWszTextSize; ++i)
+	{
+		if (c->irTextWidths[i] > iMouseOnXWidth)
+		{
+			// Check if left or right of middle of character
+			int iMidPoint = 0;
+			if (i == 0)
+			{
+				const int iChWidth = c->irTextWidths[i];
+				iMidPoint = iChWidth / 2;
+			}
+			else
+			{
+				const int iChWidth = c->irTextWidths[i] - c->irTextWidths[i - 1];
+				iMidPoint = c->irTextWidths[i - 1] + (iChWidth / 2);
+			}
+			iChIdx = (iMouseOnXWidth >= iMidPoint) ? i + 1 : i;
+			break;
+		}
+	}
+	if (iChIdx == -1)
+	{
+		if (iMouseOnXWidth >= c->irTextWidths[iWszTextSize - 1])
+		{
+			iChIdx = iWszTextSize;
+		}
+		else
+		{
+			iChIdx = 0;
+		}
+	}
+	return iChIdx;
+}
+
+// NEO NOTE (nullsystem): Build up irTextWidths, hot spot so do only when necessary
+//
+// wszVisText could be a password for visuals so a separate iWszTextSize
+// which is always set by V_wcslen(wszText) instead
+static void BuildUpIrTextWidths(const wchar_t *wszVisText, const int iWszTextSize)
+{
+	Assert(iWszTextSize < MAX_TEXTINPUT_U8BYTES_LIMIT);
+
+	wchar_t wszMutVisText[MAX_TEXTINPUT_U8BYTES_LIMIT];
+	V_wcscpy_safe(wszMutVisText, wszVisText);
+
+	const auto *pFontI = &c->fonts[c->eFont];
+
+	V_memset(c->irTextWidths, 0, sizeof(c->irTextWidths));
+	for (int i = 0; i < iWszTextSize; ++i)
+	{
+		const wchar_t wchTemp = wszMutVisText[i + 1];
+		wszMutVisText[i + 1] = '\0';
+		int iFontWide, iFontTall;
+		vgui::surface()->GetTextSize(pFontI->hdl, wszMutVisText, iFontWide, iFontTall);
+		c->irTextWidths[i] = iFontWide;
+		wszMutVisText[i + 1] = wchTemp;
+	}
+}
+
+void TextEdit(const wchar_t *wszLeftLabel, wchar_t *wszText, const int iMaxWszTextSize, const ETextEditFlags flags)
 {
 	MultiWidgetHighlighter(2);
 	Label(wszLeftLabel);
-	TextEdit(wszText, iMaxBytes);
+	TextEdit(wszText, iMaxWszTextSize, flags);
 }
 
-void TextEdit(wchar_t *wszText, const int iMaxBytes)
+void TextEdit(wchar_t *wszText, const int iMaxWszTextSize, const ETextEditFlags flags)
 {
-	BeginWidget();
-	static wchar_t staticWszPasswordChars[256] = {};
+	const auto wdgState = BeginWidget(WIDGETFLAG_MOUSE);
+
+	static wchar_t staticWszPasswordChars[MAX_TEXTINPUT_U8BYTES_LIMIT] = {};
 	if (staticWszPasswordChars[0] == L'\0')
 	{
 		for (int i = 0; i < (ARRAYSIZE(staticWszPasswordChars) - 1); ++i)
@@ -1535,97 +1719,428 @@ void TextEdit(wchar_t *wszText, const int iMaxBytes)
 		}
 	}
 
-	const auto wdgState = InternalGetMouseinFocused();
-
 	if (IN_BETWEEN_AR(0, c->irWidgetLayoutY, c->dPanel.tall))
 	{
+		int iCopyAction = -1;
+
+		const bool bHasTextSel = wdgState.bActive;
+		const bool bCurRightStart = (c->iTextSelCur >= c->iTextSelStart);
+
+		// NEO NOTE (nullsystem): Only use iWszTextSize when not changing it
+		// EX: paint, cursor/selection only change actions, or just before
+		// changing it. Otherwise use V_wcslen directly after changing wszText
+		// contents.
+		const int iWszTextSize = V_wcslen(wszText);
+
+		const int iTextSelMin = bCurRightStart ? c->iTextSelStart : c->iTextSelCur;
+		const int iTextSelMax = bCurRightStart ? c->iTextSelCur : c->iTextSelStart;
+
+		const bool bIsSelection = bHasTextSel && iTextSelMin < iTextSelMax;
+		const bool bIsCursor = bHasTextSel && iTextSelMin == iTextSelMax;
+		const bool bFromEnd = bHasTextSel && (iTextSelMin == iTextSelMax && iWszTextSize <= iTextSelMin);
+
+		const bool bIsPassword = flags & TEXTEDITFLAG_PASSWORD;
+		if (bIsPassword)
+		{
+			staticWszPasswordChars[iWszTextSize + 1] = L'\0';
+		}
+
+		bool bRebuildIrTextWidths = false;
+
 		switch (c->eMode)
 		{
 		case MODE_PAINT:
 		{
+			const bool bEditBlinkShow = (static_cast<int>(gpGlobals->curtime * 1.5f) % 2 == 0);
+			const auto *pFontI = &c->fonts[c->eFont];
 			if (wdgState.bHot)
 			{
 				vgui::surface()->DrawFilledRect(c->rWidgetArea.x0, c->rWidgetArea.y0,
 												c->rWidgetArea.x1, c->rWidgetArea.y1);
 			}
-			const auto *pFontI = &c->fonts[c->eFont];
-			vgui::surface()->DrawSetTextPos(c->rWidgetArea.x0 + c->iMarginX,
+#if defined(DEBUG) && DEBUG_NEOUI // Right-aligned text to show debug info
+			vgui::surface()->DrawSetTextColor(Color(32, 32, 180, 255));
+			wchar_t wszDbgText[MAX_TEXTINPUT_U8BYTES_LIMIT];
+			V_swprintf_safe(wszDbgText, L"%d %d %d %d",
+					iTextSelMin, iTextSelMax, c->iTextSelStart, c->iTextSelCur);
+			int iFontWide, iFontTall;
+			vgui::surface()->GetTextSize(pFontI->hdl, wszDbgText, iFontWide, iFontTall);
+			vgui::surface()->DrawSetTextPos(c->rWidgetArea.x1 - c->iMarginX - iFontWide,
 											c->rWidgetArea.y0 + pFontI->iYOffset);
-			const int iWszTextSize = V_wcslen(wszText);
-			if (c->bTextEditIsPassword)
+			vgui::surface()->DrawPrintText(wszDbgText, V_wcslen(wszDbgText));
+			vgui::surface()->DrawSetTextColor(COLOR_NEOPANELTEXTNORMAL);
+#endif // defined(DEBUG) && DEBUG_NEOUI
+			if (bHasTextSel && (bIsSelection || bEditBlinkShow))
 			{
-				vgui::surface()->DrawPrintText(staticWszPasswordChars, iWszTextSize);
-			}
-			else
-			{
-				vgui::surface()->DrawPrintText(wszText, iWszTextSize);
-			}
-			if (wdgState.bActive)
-			{
-				const bool bEditBlinkShow = (static_cast<int>(gpGlobals->curtime * 1.5f) % 2 == 0);
-				if (bEditBlinkShow)
+				int iXStart;
+				if (iTextSelMin <= 0)
 				{
-					int iFontWide, iFontTall;
-					if (c->bTextEditIsPassword)
+					iXStart = 0;
+				}
+				else if (iTextSelMin >= iWszTextSize)
+				{
+					iXStart = c->irTextWidths[iWszTextSize - 1];
+				}
+				else
+				{
+					iXStart = c->irTextWidths[iTextSelMin - 1];
+				}
+
+				// If bIsCursor, render cursor-like, otherwise selection
+				int iXEnd;
+				if (bIsCursor)
+				{
+					iXEnd = iXStart + (c->iMarginX / 2);
+				}
+				else
+				{
+					if (iTextSelMax <= 0)
 					{
-						staticWszPasswordChars[iWszTextSize] = L'\0';
-						vgui::surface()->GetTextSize(pFontI->hdl, staticWszPasswordChars, iFontWide, iFontTall);
-						staticWszPasswordChars[iWszTextSize] = L'*';
+						iXEnd = 0;
+					}
+					else if (iTextSelMax >= iWszTextSize)
+					{
+						iXEnd = c->irTextWidths[iWszTextSize - 1];
 					}
 					else
 					{
-						vgui::surface()->GetTextSize(pFontI->hdl, wszText, iFontWide, iFontTall);
+						iXEnd = c->irTextWidths[iTextSelMax - 1];
 					}
-					const int iMarkX = c->iMarginX + iFontWide;
-					vgui::surface()->DrawSetColor(COLOR_NEOPANELTEXTBRIGHT);
-					vgui::surface()->DrawFilledRect(c->rWidgetArea.x0 + iMarkX,
-													c->rWidgetArea.y0 + pFontI->iYOffset,
-													c->rWidgetArea.x0 + iMarkX + c->iMarginX,
-													c->rWidgetArea.y0 + pFontI->iYOffset + iFontTall);
+				}
+
+				if (iXStart != iXEnd)
+				{
+					vgui::surface()->DrawSetColor(
+							bIsCursor ?
+								COLOR_NEOPANELTEXTBRIGHT :
+								Color(180, 32, 32, 255));
+					vgui::surface()->DrawFilledRect(
+							c->rWidgetArea.x0 + c->iMarginX + iXStart,
+							c->rWidgetArea.y0 + ((bIsCursor) ? pFontI->iYOffset : 0),
+							c->rWidgetArea.x0 + c->iMarginX + iXEnd,
+							(bIsCursor) ? c->rWidgetArea.y0 + pFontI->iYOffset + vgui::surface()->GetFontTall(pFontI->hdl) : c->rWidgetArea.y1);
+					vgui::surface()->DrawSetColor(c->normalBgColor);
 				}
 			}
+			vgui::surface()->DrawSetTextPos(c->rWidgetArea.x0 + c->iMarginX,
+											c->rWidgetArea.y0 + pFontI->iYOffset);
+			const wchar_t *pwszPrintText = (bIsPassword) ? staticWszPasswordChars : wszText;
+			vgui::surface()->DrawPrintText(pwszPrintText, iWszTextSize);
 		}
 		break;
 		case MODE_MOUSEPRESSED:
 		{
-			if (wdgState.bHot)
+			if (c->eCode == MOUSE_LEFT &&
+					c->iRightClick == c->iWidget &&
+					c->iRightClickSection == c->iSection)
+			{
+				iCopyAction = c->iRightClickHotItem;
+			}
+
+			if (!IN_BETWEEN_AR(0, iCopyAction, c->ipwszRightClickListSize) && wdgState.bHot)
 			{
 				c->iActive = c->iWidget;
 				c->iActiveSection = c->iSection;
+
+				switch (c->eCode)
+				{
+				case MOUSE_LEFT:
+				{
+					BuildUpIrTextWidths(bIsPassword ? staticWszPasswordChars : wszText, iWszTextSize);
+					const int iStartPos = TextEditChIdxFromMouse(iWszTextSize);
+
+					// Selection start point
+					c->iTextSelStart = iStartPos;
+					c->iTextSelCur = iStartPos;
+					c->iTextSelDrag = c->iWidget;
+					c->iTextSelDragSection = c->iSection;
+				} break;
+				case MOUSE_RIGHT:
+				{
+					// Open right-click menu
+					static const wchar *PWSZ_TEXTEDIT_RIGHTCLICK[COPYMENU__TOTAL] = {
+						L"Cut", L"Copy", L"Paste",
+					};
+					c->dimRightClick.x = c->iMouseAbsX;
+					c->dimRightClick.y = c->iMouseAbsY;
+					c->dimRightClick.wide = 0;
+					c->dimRightClick.tall = 0;
+					c->iRightClick = c->iWidget;
+					c->iRightClickSection = c->iSection;
+					c->pwszRightClickList = PWSZ_TEXTEDIT_RIGHTCLICK;
+					c->ipwszRightClickListSize = ARRAYSIZE(PWSZ_TEXTEDIT_RIGHTCLICK);
+				} break;
+				default:
+					break;
+				}
+			}
+		}
+		break;
+		case MODE_MOUSERELEASED:
+		{
+			c->iTextSelDrag = -1;
+			c->iTextSelDragSection = -1;
+		}
+		break;
+		case MODE_MOUSEMOVED:
+		{
+			if (c->iTextSelDrag == c->iWidget && c->iTextSelDragSection == c->iSection)
+			{
+				c->iTextSelCur = TextEditChIdxFromMouse(iWszTextSize);
 			}
 		}
 		break;
 		case MODE_KEYPRESSED:
 		{
-			if (wdgState.bActive && c->eCode == KEY_BACKSPACE)
+			const bool bIsCtrlDown = (vgui::input()->IsKeyDown(KEY_LCONTROL) || vgui::input()->IsKeyDown(KEY_RCONTROL));
+			if (bIsCtrlDown && bHasTextSel)
 			{
-				const int iTextSize = V_wcslen(wszText);
-				if (iTextSize > 0)
+				switch (c->eCode)
 				{
-					wszText[iTextSize - 1] = L'\0';
-					c->bValueEdited = true;
+				break; case KEY_X: if (bIsSelection) iCopyAction = COPYMENU_CUT;
+				break; case KEY_C: if (bIsSelection) iCopyAction = COPYMENU_COPY;
+				break; case KEY_V: iCopyAction = COPYMENU_PASTE;
+				break; default: break;
+				}
+			}
+			if (!IN_BETWEEN_AR(0, iCopyAction, c->ipwszRightClickListSize) && wdgState.bActive)
+			{
+				const bool bIsShiftDown = (vgui::input()->IsKeyDown(KEY_LSHIFT) || vgui::input()->IsKeyDown(KEY_RSHIFT));
+				switch (c->eCode)
+				{
+				case KEY_HOME:
+				case KEY_END:
+				{
+					c->iTextSelCur = (c->eCode == KEY_HOME) ? 0 : iWszTextSize;
+					if (!bIsShiftDown)
+					{
+						c->iTextSelStart = c->iTextSelCur;
+					}
+				} break;
+				case KEY_LEFT:
+				case KEY_RIGHT:
+				{
+					if (bIsCtrlDown)
+					{
+						// NEO NOTE (nullsystem): This matches vgui behavior
+						// which is always start of word even on CTRL+right
+						// and only space used for delimiter
+						int iNextCur = (c->eCode == KEY_LEFT) ? 0 : iWszTextSize;
+						const int iIncr = ((c->eCode == KEY_LEFT) ? -1 : +1);
+
+						for (int i = c->iTextSelCur + iIncr;
+								IN_BETWEEN_AR(1, i, iWszTextSize);
+								i += iIncr)
+						{
+							if (wszText[i - 1] == L' ' && wszText[i] != L' ')
+							{
+								iNextCur = i;
+								break;
+							}
+						}
+						c->iTextSelCur = iNextCur;
+					}
+					else
+					{
+						c->iTextSelCur = clamp(c->iTextSelCur + ((c->eCode == KEY_LEFT) ? -1 : +1), 0, iWszTextSize);
+					}
+
+					if (!bIsShiftDown)
+					{
+						c->iTextSelStart = c->iTextSelCur;
+					}
+				} break;
+				case KEY_BACKSPACE:
+				case KEY_DELETE:
+				{
+					if (iWszTextSize > 0)
+					{
+						bool bIsValueEdited = true;
+						const bool bIsLeftDelete = (c->eCode == KEY_BACKSPACE);
+						// Write to temporary first otherwise wszText -> wszText can corrupt
+						static wchar_t wszStaticTmpText[MAX_TEXTINPUT_U8BYTES_LIMIT];
+
+						if (bFromEnd && bIsLeftDelete)
+						{
+							// Cursor - At the end
+							wszText[iWszTextSize - 1] = L'\0';
+							--c->iTextSelStart;
+						}
+						else if (bIsCursor)
+						{
+							if (iTextSelMin > 0 && bIsLeftDelete)
+							{
+								// Cursor - delete character before cursor, non-zero, cursor shift left
+								V_swprintf_safe(wszStaticTmpText, L"%.*ls%ls", iTextSelMin - 1, wszText, wszText + iTextSelMin);
+								V_wcsncpy(wszText, wszStaticTmpText, sizeof(wchar_t) * iMaxWszTextSize);
+								--c->iTextSelStart;
+							}
+							else if (iTextSelMin < iWszTextSize && !bIsLeftDelete)
+							{
+								// Cursor - delete character after cursor, non-end
+								V_swprintf_safe(wszStaticTmpText, L"%.*ls%ls", iTextSelMin, wszText, wszText + iTextSelMin + 1);
+								V_wcsncpy(wszText, wszStaticTmpText, sizeof(wchar_t) * iMaxWszTextSize);
+							}
+						}
+						else if (bIsSelection)
+						{
+							// Selection - delete selected texts
+							wszText[iTextSelMin] = L'\0';
+							V_swprintf_safe(wszStaticTmpText, L"%ls%ls", wszText, wszText + iTextSelMax);
+							V_wcsncpy(wszText, wszStaticTmpText, sizeof(wchar_t) * iMaxWszTextSize);
+							c->iTextSelStart = iTextSelMin;
+						}
+						else
+						{
+							bIsValueEdited = false;
+						}
+
+						if (bIsValueEdited)
+						{
+							bRebuildIrTextWidths = true;
+							c->iTextSelCur = c->iTextSelStart;
+						}
+					}
+				} break;
+				default:
+					break;
 				}
 			}
 		}
 		break;
 		case MODE_KEYTYPED:
 		{
-			if (wdgState.bActive && iswprint(c->unichar))
+			if (wdgState.bActive && iswprint(c->unichar) && iWszTextSize < iMaxWszTextSize)
 			{
-				static char szTmpANSICheck[MAX_TEXTINPUT_U8BYTES_LIMIT];
-				const int iTextInU8Bytes = g_pVGuiLocalize->ConvertUnicodeToANSI(wszText, szTmpANSICheck, sizeof(szTmpANSICheck));
-				if (iTextInU8Bytes < iMaxBytes)
+				if (bFromEnd)
 				{
-					int iTextSize = V_wcslen(wszText);
-					wszText[iTextSize++] = c->unichar;
-					wszText[iTextSize] = L'\0';
-					c->bValueEdited = true;
+					wszText[iWszTextSize] = c->unichar;
+					wszText[iWszTextSize + 1] = L'\0';
 				}
+				else if (bIsCursor)
+				{
+					for (int i = (iWszTextSize - 1); i >= iTextSelMin; --i)
+					{
+						wszText[i + 1] = wszText[i];
+					}
+					wszText[iTextSelMin] = c->unichar;
+					wszText[iWszTextSize + 1] = L'\0';
+				}
+				else if (bIsSelection)
+				{
+					// Has multi selection - delete selected texts then insert text
+					static wchar_t wszStaticTmpText[MAX_TEXTINPUT_U8BYTES_LIMIT] = {};
+					V_swprintf_safe(wszStaticTmpText, L"%.*ls%lc%ls", iTextSelMin, wszText, c->unichar, wszText + iTextSelMax);
+					V_wcsncpy(wszText, wszStaticTmpText, sizeof(wchar_t) * iMaxWszTextSize);
+				}
+				bRebuildIrTextWidths = true;
+				// Any character typed devolves back to cursor on iTextSelMin
+				c->iTextSelStart = Min(iTextSelMin + 1, V_wcslen(wszText));
+				c->iTextSelCur = c->iTextSelStart;
 			}
 		}
 		break;
 		default:
 			break;
+		}
+
+		switch (iCopyAction)
+		{
+		case COPYMENU_CUT:
+		case COPYMENU_COPY:
+		{
+			if (iTextSelMin < iTextSelMax)
+			{
+				const wchar_t wchTmp = wszText[iTextSelMax];
+				wszText[iTextSelMax] = L'\0';
+
+				wchar_t wszCopyBuf[MAX_TEXTINPUT_U8BYTES_LIMIT];
+				V_wcscpy_safe(wszCopyBuf, wszText + iTextSelMin);
+
+				wszText[iTextSelMax] = wchTmp;
+
+				char szCopyBuf[MAX_TEXTINPUT_U8BYTES_LIMIT] = {};
+				g_pVGuiLocalize->ConvertUnicodeToANSI(wszCopyBuf, szCopyBuf, sizeof(szCopyBuf));
+
+				vgui::system()->SetClipboardText(szCopyBuf, V_strlen(szCopyBuf));
+
+				const bool bIsCut = iCopyAction == COPYMENU_CUT;
+				if (bIsCut)
+				{
+					wszText[iTextSelMin] = L'\0';
+					V_snwprintf(wszText, iMaxWszTextSize, L"%ls%ls", wszText, wszText + iTextSelMax);
+					bRebuildIrTextWidths = true;
+					c->iTextSelStart = iTextSelMin;
+					c->iTextSelCur = iTextSelMin;
+				}
+#if defined(DEBUG) && DEBUG_NEOUI
+				Msg("COPYMENU_%s: %s\n", (bIsCut) ? "CUT" : "COPY", szCopyBuf);
+#endif // defined(DEBUG) && DEBUG_NEOUI
+			}
+		} break;	
+		case COPYMENU_PASTE:
+		{
+			if (vgui::system()->GetClipboardTextCount() > 0)
+			{
+				wchar_t wszClipboard[MAX_TEXTINPUT_U8BYTES_LIMIT] = {};
+				const int iClipboardWSZBytes = vgui::system()->GetClipboardText(0, wszClipboard, ARRAYSIZE(wszClipboard));
+				if (iClipboardWSZBytes > 0)
+				{
+					// Write to temporary first otherwise wszText -> wszText can corrupt
+					static wchar_t wszStaticTmpText[MAX_TEXTINPUT_U8BYTES_LIMIT];
+					if (bFromEnd)
+					{
+						V_wcsncat(wszText, wszClipboard, iMaxWszTextSize);
+						c->iTextSelCur = V_wcslen(wszText);
+					}
+					else if (bIsCursor)
+					{
+						// Single selection - append clipboard on cursor
+						if (iTextSelMin > 0)
+						{
+							V_swprintf_safe(wszStaticTmpText, L"%.*ls%ls%ls", iTextSelMin, wszText, wszClipboard, wszText + iTextSelMin);
+						}
+						else
+						{
+							V_swprintf_safe(wszStaticTmpText, L"%ls%ls", wszClipboard, wszText);
+						}
+						V_wcsncpy(wszText, wszStaticTmpText, sizeof(wchar_t) * iMaxWszTextSize);
+						c->iTextSelCur = Min(c->iTextSelCur + V_wcslen(wszClipboard), V_wcslen(wszText));
+					}
+					else if (bIsSelection)
+					{
+						// Multi selection - clipboard replaces selection
+						V_swprintf_safe(wszStaticTmpText, L"%.*ls%ls%ls", iTextSelMin, wszText, wszClipboard, wszText + iTextSelMax);
+						V_wcsncpy(wszText, wszStaticTmpText, sizeof(wchar_t) * iMaxWszTextSize);
+						c->iTextSelCur = Min(iTextSelMin + V_wcslen(wszClipboard), V_wcslen(wszText));
+					}
+					// All devolves to cursor
+					c->iTextSelStart = c->iTextSelCur;
+					bRebuildIrTextWidths = true;
+#if defined(DEBUG) && DEBUG_NEOUI
+					char szClipboard[MAX_TEXTINPUT_U8BYTES_LIMIT] = {};
+					g_pVGuiLocalize->ConvertUnicodeToANSI(wszClipboard, szClipboard, sizeof(szClipboard));
+					char szText[MAX_TEXTINPUT_U8BYTES_LIMIT] = {};
+					g_pVGuiLocalize->ConvertUnicodeToANSI(wszText, szText, sizeof(szText));
+					Msg("COPYMENU_PASTE: %s -> %s\n", szClipboard, szText);
+#endif // defined(DEBUG) && DEBUG_NEOUI
+				}
+			}
+		} break;
+		default:
+			break;
+		}
+
+		if (bIsPassword)
+		{
+			// iWszTextSize instead of V_wcslen because it's altered
+			// before the changes happens.
+			staticWszPasswordChars[iWszTextSize + 1] = L'*';
+		}
+		if (bRebuildIrTextWidths)
+		{
+			BuildUpIrTextWidths(bIsPassword ? staticWszPasswordChars : wszText, V_wcslen(wszText));
+			c->bValueEdited = true;
 		}
 	}
 

--- a/src/game/client/neo/ui/neo_ui.cpp
+++ b/src/game/client/neo/ui/neo_ui.cpp
@@ -428,6 +428,7 @@ void BeginSection(const bool bDefaultFocus)
 	}
 
 	NeoUI::SetPerRowLayout(1, nullptr, c->layout.iDefRowTall);
+	NeoUI::SetPerCellVertLayout(0);
 }
 
 void EndSection()
@@ -2090,7 +2091,7 @@ void TextEdit(wchar_t *wszText, const int iMaxWszTextSize, const ETextEditFlags 
 					static wchar_t wszStaticTmpText[MAX_TEXTINPUT_U8BYTES_LIMIT];
 					if (bFromEnd)
 					{
-						V_wcsncat(wszText, wszClipboard, iMaxWszTextSize);
+						V_wcsncat(wszText, wszClipboard, iMaxWszTextSize + 1);
 						c->iTextSelCur = V_wcslen(wszText);
 					}
 					else if (bIsCursor)

--- a/src/game/client/neo/ui/neo_ui.h
+++ b/src/game/client/neo/ui/neo_ui.h
@@ -125,6 +125,21 @@ enum EFont
 	FONT__TOTAL,
 };
 
+enum ECopyMenu
+{
+	COPYMENU_CUT,
+	COPYMENU_COPY,
+	COPYMENU_PASTE,
+
+	COPYMENU__TOTAL,
+};
+
+enum ETextEditFlags
+{
+	TEXTEDITFLAG_NONE = 0,
+	TEXTEDITFLAG_PASSWORD = 1 << 0,
+};
+
 struct SliderInfo
 {
 	wchar_t wszText[33];
@@ -148,6 +163,9 @@ struct Context
 	Color bgColor;
 	Color selectBgColor;
 	Color normalBgColor;
+
+	Color cOverrideFgColor;
+	bool bIsOverrideFgColor = false;
 
 	// Mouse handling
 	int iMouseAbsX;
@@ -199,7 +217,6 @@ struct Context
 
 	TextStyle eButtonTextStyle;
 	TextStyle eLabelTextStyle;
-	bool bTextEditIsPassword;
 
 	FontInfo fonts[FONT__TOTAL] = {};
 	EFont eFont = FONT_NTNORMAL;
@@ -222,6 +239,21 @@ struct Context
 	const char *pSzCurCtxName;
 	CUtlHashtable<const wchar_t *, SliderInfo> htSliders;
 	CUtlHashtable<CUtlConstString, int> htTexMap;
+
+	// Right click menu
+	int iRightClick = -1;
+	int iRightClickSection = -1;
+	int iRightClickHotItem = -1;
+	int ipwszRightClickListSize = 0;
+	const wchar **pwszRightClickList = nullptr;
+	Dim dimRightClick = {};
+
+	// TextEdit text selection
+	int iTextSelStart = -1;
+	int iTextSelCur = -1;
+	int iTextSelDrag = -1;
+	int iTextSelDragSection = -1;
+	int irTextWidths[MAX_TEXTINPUT_U8BYTES_LIMIT] = {};
 };
 
 struct GetMouseinFocusedRet
@@ -259,11 +291,13 @@ struct LabelExOpt
 #define COLOR_NEOPANELBAR Color(20, 20, 20, 255)
 #define COLOR_NEOPANELMICTEST Color(30, 90, 30, 255)
 
-enum WidgetFlag
+enum WidgetFlag_
 {
 	WIDGETFLAG_NONE = 0,
 	WIDGETFLAG_SKIPACTIVE = 1 << 0,
+	WIDGETFLAG_MOUSE = 1 << 1,
 };
+typedef int WidgetFlag;
 
 void FreeContext(NeoUI::Context *pCtx);
 
@@ -271,7 +305,7 @@ void BeginContext(NeoUI::Context *pNextCtx, const NeoUI::Mode eMode, const wchar
 void EndContext();
 void BeginSection(const bool bDefaultFocus = false);
 void EndSection();
-void BeginWidget(const WidgetFlag eWidgetFlag = WIDGETFLAG_NONE);
+GetMouseinFocusedRet BeginWidget(const WidgetFlag eWidgetFlag = WIDGETFLAG_NONE);
 void EndWidget(const GetMouseinFocusedRet wdgState);
 
 void SetPerRowLayout(const int iColTotal, const int *iColProportions = nullptr, const int iRowHeight = -1);
@@ -281,6 +315,9 @@ void SetPerCellVertLayout(const int iRowTotal, const int *iRowProportions = null
 void SwapFont(const EFont eFont, const bool bForce = false);
 void SwapColorNormal(const Color &color);
 void MultiWidgetHighlighter(const int iTotalWidgets);
+
+void BeginOverrideFgColor(const Color &fgColor);
+void EndOverrideFgColor();
 
 // Widgets
 /*1W*/ void Pad();
@@ -305,9 +342,8 @@ void MultiWidgetHighlighter(const int iTotalWidgets);
 					  const wchar_t *wszSpecialText = nullptr);
 /*2W*/ void SliderU8(const wchar_t *wszLeftLabel, uint8 *ucValue, const uint8 iMin, const uint8 iMax, const uint8 iStep = 1,
 					 const wchar_t *wszSpecialText = nullptr);
-// NEO NOTE (nullsystem): iMaxBytes as in when the wchar_t fits into back into a UTF-8 char
-/*1W*/ void TextEdit(wchar_t *wszText, const int iMaxBytes);
-/*2W*/ void TextEdit(const wchar_t *wszLeftLabel, wchar_t *wszText, const int iMaxBytes);
+/*1W*/ void TextEdit(wchar_t *wszText, const int iMaxWszTextSize, const ETextEditFlags flags = TEXTEDITFLAG_NONE);
+/*2W*/ void TextEdit(const wchar_t *wszLeftLabel, wchar_t *wszText, const int iMaxWszTextSize, const ETextEditFlags flags = TEXTEDITFLAG_NONE);
 /*SW*/ void ImageTexture(const char *szTexturePath, const wchar_t *wszErrorMsg = L"", const char *szTextureGroup = "");
 
 // NeoUI::Texture is non-widget, but utilizes NeoUI's image/texture handling

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -949,7 +949,7 @@ void CNEORules::Think(void)
 		m_bThinkCheckClantags = false;
 		int iHasClantags[TEAM__TOTAL] = {};
 		bool bClantagSet[TEAM__TOTAL] = {};
-		char szTeamClantags[TEAM__TOTAL][NEO_MAX_CLANTAG_LENGTH + 1] = {};
+		char szTeamClantags[TEAM__TOTAL][NEO_MAX_CLANTAG_LENGTH] = {};
 		for (int i = 1; i <= gpGlobals->maxClients; ++i)
 		{
 			auto pNeoPlayer = static_cast<CNEO_Player*>(UTIL_PlayerByIndex(i));

--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -208,8 +208,8 @@ void DMClSortedPlayers(PlayerXPInfo (*pPlayersOrder)[MAX_PLAYERS + 1], int *piTo
 #endif
 
 bool GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
-						 const wchar_t wszNeoName[MAX_PLAYER_NAME_LENGTH + 1],
-						 const wchar_t wszNeoClantag[NEO_MAX_CLANTAG_LENGTH + 1],
+						 const wchar_t (&wszNeoName)[MAX_PLAYER_NAME_LENGTH],
+						 const wchar_t (&wszNeoClantag)[NEO_MAX_CLANTAG_LENGTH],
 						 const EClNeoDisplayNameFlag flags)
 {
 	const bool bShowSteamNick = (flags & CL_NEODISPLAYNAME_FLAG_ONLYSTEAMNICK) || wszNeoName[0] == '\0';
@@ -236,16 +236,16 @@ bool GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
 	if (flags & CL_NEODISPLAYNAME_FLAG_CHECK)
 	{
 		// Double it so we can check for overflow
-		char szNeoName[2 * (MAX_PLAYER_NAME_LENGTH + 1)];
+		char szNeoName[2 * MAX_PLAYER_NAME_LENGTH];
 		const int iSzNeoNameSize = g_pVGuiLocalize->ConvertUnicodeToANSI(wszNeoName, szNeoName, sizeof(szNeoName));
-		if (iSzNeoNameSize > (MAX_PLAYER_NAME_LENGTH + 1))
+		if (iSzNeoNameSize > MAX_PLAYER_NAME_LENGTH)
 		{
 			return false;
 		}
 
-		char szNeoClantag[2 * (NEO_MAX_CLANTAG_LENGTH + 1)];
+		char szNeoClantag[2 * NEO_MAX_CLANTAG_LENGTH];
 		const int iSzNeoClantagSize = g_pVGuiLocalize->ConvertUnicodeToANSI(wszNeoClantag, szNeoClantag, sizeof(szNeoClantag));
-		if (iSzNeoClantagSize > (NEO_MAX_CLANTAG_LENGTH + 1))
+		if (iSzNeoClantagSize > NEO_MAX_CLANTAG_LENGTH)
 		{
 			return false;
 		}
@@ -259,8 +259,8 @@ bool GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
 						 const char *pSzNeoClantag,
 						 const EClNeoDisplayNameFlag flags)
 {
-	wchar_t wszNeoName[MAX_PLAYER_NAME_LENGTH + 1];
-	wchar_t wszNeoClantag[NEO_MAX_CLANTAG_LENGTH + 1];
+	wchar_t wszNeoName[MAX_PLAYER_NAME_LENGTH];
+	wchar_t wszNeoClantag[NEO_MAX_CLANTAG_LENGTH];
 	g_pVGuiLocalize->ConvertANSIToUnicode(pSzNeoName, wszNeoName, sizeof(wszNeoName));
 	g_pVGuiLocalize->ConvertANSIToUnicode(pSzNeoClantag, wszNeoClantag, sizeof(wszNeoClantag));
 	return GetClNeoDisplayName(pWszDisplayName, wszNeoName, wszNeoClantag, flags);

--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -207,12 +207,12 @@ void DMClSortedPlayers(PlayerXPInfo (*pPlayersOrder)[MAX_PLAYERS + 1], int *piTo
 }
 #endif
 
-void GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
+bool GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
 						 const wchar_t wszNeoName[MAX_PLAYER_NAME_LENGTH + 1],
 						 const wchar_t wszNeoClantag[NEO_MAX_CLANTAG_LENGTH + 1],
-						 const bool bOnlySteamNick)
+						 const EClNeoDisplayNameFlag flags)
 {
-	const bool bShowSteamNick = bOnlySteamNick || wszNeoName[0] == '\0';
+	const bool bShowSteamNick = (flags & CL_NEODISPLAYNAME_FLAG_ONLYSTEAMNICK) || wszNeoName[0] == '\0';
 	wchar_t wszDisplayName[MAX_PLAYER_NAME_LENGTH + 1] = {};
 	if (bShowSteamNick)
 	{
@@ -232,17 +232,37 @@ void GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
 	{
 		V_wcscpy_safe(pWszDisplayName, wszDisplayName);
 	}
+
+	if (flags & CL_NEODISPLAYNAME_FLAG_CHECK)
+	{
+		// Double it so we can check for overflow
+		char szNeoName[2 * (MAX_PLAYER_NAME_LENGTH + 1)];
+		const int iSzNeoNameSize = g_pVGuiLocalize->ConvertUnicodeToANSI(wszNeoName, szNeoName, sizeof(szNeoName));
+		if (iSzNeoNameSize > (MAX_PLAYER_NAME_LENGTH + 1))
+		{
+			return false;
+		}
+
+		char szNeoClantag[2 * (NEO_MAX_CLANTAG_LENGTH + 1)];
+		const int iSzNeoClantagSize = g_pVGuiLocalize->ConvertUnicodeToANSI(wszNeoClantag, szNeoClantag, sizeof(szNeoClantag));
+		if (iSzNeoClantagSize > (NEO_MAX_CLANTAG_LENGTH + 1))
+		{
+			return false;
+		}
+	}
+
+	return true;
 }
 
-void GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
+bool GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
 						 const char *pSzNeoName,
 						 const char *pSzNeoClantag,
-						 const bool bOnlySteamNick)
+						 const EClNeoDisplayNameFlag flags)
 {
 	wchar_t wszNeoName[MAX_PLAYER_NAME_LENGTH + 1];
 	wchar_t wszNeoClantag[NEO_MAX_CLANTAG_LENGTH + 1];
 	g_pVGuiLocalize->ConvertANSIToUnicode(pSzNeoName, wszNeoName, sizeof(wszNeoName));
 	g_pVGuiLocalize->ConvertANSIToUnicode(pSzNeoClantag, wszNeoClantag, sizeof(wszNeoClantag));
-	GetClNeoDisplayName(pWszDisplayName, wszNeoName, wszNeoClantag, bOnlySteamNick);
+	return GetClNeoDisplayName(pWszDisplayName, wszNeoName, wszNeoClantag, flags);
 }
 

--- a/src/game/shared/neo/neo_player_shared.h
+++ b/src/game/shared/neo/neo_player_shared.h
@@ -367,17 +367,25 @@ void DMClSortedPlayers(PlayerXPInfo (*pPlayersOrder)[MAX_PLAYERS + 1], int *piTo
 
 inline char gStreamerModeNames[MAX_PLAYERS + 1][MAX_PLAYER_NAME_LENGTH + 1];
 
+enum EClNeoDisplayNameFlag_
+{
+	CL_NEODISPLAYNAME_FLAG_NONE = 0,
+	CL_NEODISPLAYNAME_FLAG_ONLYSTEAMNICK = 1 << 0,
+	CL_NEODISPLAYNAME_FLAG_CHECK = 1 << 1,
+};
+typedef int EClNeoDisplayNameFlag;
+
 static constexpr int NEO_MAX_CLANTAG_LENGTH = 12;
 static constexpr int NEO_MAX_DISPLAYNAME = MAX_PLAYER_NAME_LENGTH + 1 + NEO_MAX_CLANTAG_LENGTH + 1;
-void GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
+bool GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
 						 const wchar_t wszNeoName[MAX_PLAYER_NAME_LENGTH + 1],
 						 const wchar_t wszNeoClantag[NEO_MAX_CLANTAG_LENGTH + 1],
-						 const bool bOnlySteamNick);
+						 const EClNeoDisplayNameFlag flags = CL_NEODISPLAYNAME_FLAG_NONE);
 
-void GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
+bool GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
 						 const char *pSzNeoName,
 						 const char *pSzNeoClantag,
-						 const bool bOnlySteamNick);
+						 const EClNeoDisplayNameFlag flags = CL_NEODISPLAYNAME_FLAG_NONE);
 
 // NEO NOTE (nullsystem): Max string length is 
 // something like: "2;2;-16711936;1;6;1.000;25;25;5;25;1;50;50;"

--- a/src/game/shared/neo/neo_player_shared.h
+++ b/src/game/shared/neo/neo_player_shared.h
@@ -375,11 +375,11 @@ enum EClNeoDisplayNameFlag_
 };
 typedef int EClNeoDisplayNameFlag;
 
-static constexpr int NEO_MAX_CLANTAG_LENGTH = 12;
-static constexpr int NEO_MAX_DISPLAYNAME = MAX_PLAYER_NAME_LENGTH + 1 + NEO_MAX_CLANTAG_LENGTH + 1;
+static constexpr int NEO_MAX_CLANTAG_LENGTH = 11 + 1; // Includes null character
+static constexpr int NEO_MAX_DISPLAYNAME = MAX_PLAYER_NAME_LENGTH + 1 + NEO_MAX_CLANTAG_LENGTH + 2;
 bool GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],
-						 const wchar_t wszNeoName[MAX_PLAYER_NAME_LENGTH + 1],
-						 const wchar_t wszNeoClantag[NEO_MAX_CLANTAG_LENGTH + 1],
+						 const wchar_t (&wszNeoName)[MAX_PLAYER_NAME_LENGTH],
+						 const wchar_t (&wszNeoClantag)[NEO_MAX_CLANTAG_LENGTH],
 						 const EClNeoDisplayNameFlag flags = CL_NEODISPLAYNAME_FLAG_NONE);
 
 bool GetClNeoDisplayName(wchar_t (&pWszDisplayName)[NEO_MAX_DISPLAYNAME],


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Add right-click menu for NeoUI, only used by TextEdit for clipboard functionality
* Clipboard actions envoked both by keybind and right-click menu
* Add selection support for TextEdit
* Cursor set on any position other than final + paste in-between texts
* Text selection with shift modifier + HOME/END/LEFT/RIGHT
* Prev/next word with ctrl modifier + LEFT/RIGHT (vgui ctrl modifier behavior)
* Password TextEdit toggle now a flag in function rather than context bool variable
* TODO later?: Multi-lined text editor, read-only mode, slider's text editor. Those can be done later as this PR is already long.
* Refactored NeoUI mouse handling, added ability to override foreground/text color
* Mark create server password field as password if streamer mode is on

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Gentoo/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1255

