### PR TITLE
Fix leech sounds playing when they shouldnt

### DIFF
--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -543,6 +543,8 @@ void CNEO_Player::Spawn(void)
 
 	SetTransmitState(FL_EDICT_PVSCHECK);
 
+	StopWaterDeathSounds();
+
 	SetPlayerTeamModel();
 	if (teamNumber == TEAM_JINRAI || teamNumber == TEAM_NSF)
 	{
@@ -2024,6 +2026,8 @@ void CNEO_Player::Event_Killed( const CTakeDamageInfo &info )
 	{
 		CreateRagdollEntity();
 	}
+
+	StopWaterDeathSounds();
 
 	// Calculate force for weapon drop
 	Vector forceVector = CalcDamageForceVector(info);


### PR DESCRIPTION
## Description
Because the sounds are emitted from the player, the player is preserved and the trigger is not so it never tells the player to stop
They're also really loud and annoying so I made them stop when the player dies also

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1272 


