### PR TITLE
Fix client crash

### DIFF
--- a/src/game/client/neo/ui/neo_hud_ammo.cpp
+++ b/src/game/client/neo/ui/neo_hud_ammo.cpp
@@ -236,7 +236,7 @@ void CNEOHud_Ammo::DrawAmmo() const
 	constexpr auto maxBullets = 100; // PZ Mag Size
 
 	char bullets[maxBullets + 1];
-	magSizeMax = min(magSizeMax, sizeof(bullets));
+	magSizeMax = min(magSizeMax, sizeof(bullets)-1);
 	int i;
 	for(i = 0; i < magSizeMax; i++)
 	{

--- a/src/game/client/neo/ui/neo_hud_ammo.cpp
+++ b/src/game/client/neo/ui/neo_hud_ammo.cpp
@@ -248,7 +248,8 @@ void CNEOHud_Ammo::DrawAmmo() const
 		
 	if(bulletsOverflowing)
 	{
-		bullets[magSizeMax - 1] = '+';
+		if (magSizeMax > 0)
+			bullets[magSizeMax - 1] = '+';
 
 		if(maxClip == magSizeCurrent)
 		{


### PR DESCRIPTION
## Description
Fix buffer overrun bugs in the ammo UI causing a crash to desktop.

Sadly I don't have steps to reproduce the crash, but this is based on a crash memory dump from my own match.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
