### PR TITLE
Fix crash after opening map selection screen then doing some specific actions

### DIFF
--- a/src/game/client/neo/ui/neo_root.cpp
+++ b/src/game/client/neo/ui/neo_root.cpp
@@ -498,16 +498,19 @@ void CNeoRoot::OnMainLoop(const NeoUI::Mode eMode)
 	int wide, tall;
 	GetSize(wide, tall);
 	float secondsSpentOnLoadingScreen = (gpGlobals->realtime - g_pNeoRoot->m_flTimeLoadingScreenTransition);
+	bool changedAlpha = false;
 	if (secondsSpentOnLoadingScreen < NEO_MENU_SECONDS_DELAY)
 	{
-		// version number will not print here, could draw before return or could just ignore since we will be removing the version number anyway
-		return;
+		// early return here can crash the game #1277
+		surface()->DrawSetAlphaMultiplier(0);
+		changedAlpha = true;
 	}
 	secondsSpentOnLoadingScreen -= NEO_MENU_SECONDS_DELAY;
-	if (secondsSpentOnLoadingScreen < NEO_MENU_SECONDS_TILL_FULLY_OPAQUE)
+	if (!changedAlpha && secondsSpentOnLoadingScreen < NEO_MENU_SECONDS_TILL_FULLY_OPAQUE)
 	{
 		// Quadratic ease in
 		surface()->DrawSetAlphaMultiplier((secondsSpentOnLoadingScreen * secondsSpentOnLoadingScreen) / (NEO_MENU_SECONDS_TILL_FULLY_OPAQUE * NEO_MENU_SECONDS_TILL_FULLY_OPAQUE));
+		changedAlpha = true;
 	}
 
 	const RootState ePrevState = m_state;
@@ -550,7 +553,10 @@ void CNeoRoot::OnMainLoop(const NeoUI::Mode eMode)
 		}
 	}
 
-	surface()->DrawSetAlphaMultiplier(1);
+	if (changedAlpha)
+	{
+		surface()->DrawSetAlphaMultiplier(1);
+	}
 
 	if (eMode == NeoUI::MODE_PAINT)
 	{


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Removes an early return from neoroot::OnMainLoop that causes a crash down the line if the map selection screen was open

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1277