### PR TITLE
Fix random objects being hot in thermals sometimes

### DIFF
--- a/src/game/client/c_baseanimating.cpp
+++ b/src/game/client/c_baseanimating.cpp
@@ -3294,6 +3294,7 @@ int C_BaseAnimating::DrawModel( int flags )
 			}
 		}
 		bool isMoving = false;
+		bool isHot = false;
 		if (inMotionVision && vel.LengthSqr() > 0.25 && !IsViewModel() && !(extraFlags & STUDIO_IGNORE_NEO_EFFECTS)) // MOVING_SPEED_MINIMUM ^2
 		{
 			isMoving = true;
@@ -3312,6 +3313,7 @@ int C_BaseAnimating::DrawModel( int flags )
 			IMaterial* pass = materials->FindMaterial("dev/thermal_base_animating_model", TEXTURE_GROUP_MODEL);
 			Assert(!IsErrorMaterial(pass));
 			modelrender->ForcedMaterialOverride(pass);
+			isHot = true;
 		}
 
 #endif // NEO
@@ -3357,7 +3359,7 @@ int C_BaseAnimating::DrawModel( int flags )
 			}
 		}
 #ifdef NEO
-		if (isMoving)
+		if (isMoving || isHot)
 		{
 			modelrender->ForcedMaterialOverride(nullptr);
 		}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

a materialoverride in c_baseanimating::DrawModel to draw gibs that wasn't cleared after caused an issue where other baseanimating objects had their material overriden too

-fixes #1279
