### PR TITLE
Don't draw smoke fog overlay when xraying

### DIFF
--- a/src/game/client/smoke_fog_overlay.cpp
+++ b/src/game/client/smoke_fog_overlay.cpp
@@ -151,7 +151,6 @@ void UpdateThermalOverride()
 	}
 	else if (localPlayer->IsObserver() && glow_outline_effect_enable.GetBool() && (localPlayer->GetTeamNumber() == TEAM_SPECTATOR || mp_forcecamera.GetInt() == OBS_ALLOW_ALL))
 	{
-		g_SmokeFogOverlayThermalOverride = true;
 		g_SmokeFogOverlayAlpha = 0;
 	}
 	g_SmokeFogOverlayThermalOverride = false;

--- a/src/game/client/smoke_fog_overlay.cpp
+++ b/src/game/client/smoke_fog_overlay.cpp
@@ -121,6 +121,8 @@ void DrawSmokeFogOverlay()
 	pMesh->Draw();
 }
 
+extern ConVar glow_outline_effect_enable;
+extern ConVar mp_forcecamera;
 void UpdateThermalOverride()
 {
 	auto localPlayer = C_NEO_Player::GetLocalNEOPlayer();
@@ -130,6 +132,7 @@ void UpdateThermalOverride()
 		if (localPlayer->GetClass() == NEO_CLASS_SUPPORT && localPlayer->IsInVision())
 		{
 			g_SmokeFogOverlayThermalOverride = true;
+			g_SmokeFogOverlayAlpha = 0;
 			return;
 		}
 	}
@@ -141,9 +144,15 @@ void UpdateThermalOverride()
 			if (targetPlayer->GetClass() == NEO_CLASS_SUPPORT && targetPlayer->IsInVision())
 			{
 				g_SmokeFogOverlayThermalOverride = true;
+				g_SmokeFogOverlayAlpha = 0;
 				return;
 			}
 		}
+	}
+	else if (localPlayer->IsObserver() && glow_outline_effect_enable.GetBool() && (localPlayer->GetTeamNumber() == TEAM_SPECTATOR || mp_forcecamera.GetInt() == OBS_ALLOW_ALL))
+	{
+		g_SmokeFogOverlayThermalOverride = true;
+		g_SmokeFogOverlayAlpha = 0;
 	}
 	g_SmokeFogOverlayThermalOverride = false;
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

The value of g_SmokeFogOverlayAlpha is calculated somewhere in the engine and prevents the xray overlay from working, g_SmokeFogOverlayThermalOverride isn't enough to fix it since we don't have access to that code so have to set the value of g_SmokeFogOverlayAlpha to 0 to get it working again.

To test this start a match with bots, spawn as a support, throw a smoke, kill yourself, go into free roam spectate mode and fly into the smoke, enable xray, and look towards the bots.

Will still draw the smoke fog overlay in the case where we are on a team and mp_forcecamera is set to anything other than OBS_ALLOW_ALL
