### PR TITLE
Bots - Shoot through glass + penetrateables

### DIFF
--- a/src/game/client/CMakeLists.txt
+++ b/src/game/client/CMakeLists.txt
@@ -1623,6 +1623,8 @@ target_sources_grouped(
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_ghost_cap_point.h
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_juggernaut.cpp
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_juggernaut.h
+    ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_penetration_resistance.cpp
+    ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_penetration_resistance.h
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_player_shared.cpp
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_player_shared.h
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_player_spawnpoint.cpp

--- a/src/game/server/CMakeLists.txt
+++ b/src/game/server/CMakeLists.txt
@@ -1349,6 +1349,8 @@ target_sources_grouped(
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_ghost_cap_point.h
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_juggernaut.cpp
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_juggernaut.h
+    ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_penetration_resistance.cpp
+    ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_penetration_resistance.h
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_player_shared.cpp
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_player_shared.h
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_player_spawnpoint.cpp

--- a/src/game/server/neo/bot/behavior/neo_bot_attack.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_attack.cpp
@@ -32,7 +32,6 @@ ActionResult< CNEOBot >	CNEOBotAttack::OnStart( CNEOBot *me, Action< CNEOBot > *
 ActionResult< CNEOBot >	CNEOBotAttack::Update( CNEOBot *me, float interval )
 {
 	const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat();
-	me->EquipBestWeaponForThreat( threat );
 
 	if ( threat == NULL || threat->IsObsolete() || !me->GetIntentionInterface()->ShouldAttack( me, threat ) )
 	{
@@ -65,7 +64,7 @@ ActionResult< CNEOBot >	CNEOBotAttack::Update( CNEOBot *me, float interval )
 	if ( bAggressive ||
 	     !threat->IsVisibleRecently() || 
 		 me->IsRangeGreaterThan( threat->GetEntity()->GetAbsOrigin(), me->GetDesiredAttackRange() ) || 
-		 !me->IsLineOfFireClear( threat->GetEntity()->EyePosition() ) )
+		 !me->IsLineOfFireClear( threat->GetEntity()->EyePosition(), CNEOBot::LINE_OF_FIRE_FLAGS_DEFAULT ) )
 	{
 		// SUPA7 reload can be interrupted so proactively reload
 		if (myWeapon && (myWeapon->GetNeoWepBits() & NEO_WEP_SUPA7) && (myWeapon->Clip1() < myWeapon->GetMaxClip1()))

--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -321,7 +321,7 @@ bool CNEOBotMainAction::IsImmediateThreat( const CBaseCombatCharacter *subject, 
 		return false;
 
 	// if they can't hurt me, they aren't an immediate threat
-	if ( !me->IsLineOfFireClear( threat->GetEntity() ) )
+	if ( !me->IsLineOfFireClear( threat->GetEntity(), CNEOBot::LINE_OF_FIRE_FLAGS_DEFAULT ) )
 		return false;
 
 	Vector to = me->GetAbsOrigin() - threat->GetLastKnownPosition();
@@ -587,13 +587,64 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 	if ( threat == NULL || !threat->GetEntity() || !threat->IsVisibleRecently() )
 		return;
 
-	// don't shoot through windows/etc
-	if ( !me->IsLineOfFireClear( threat->GetEntity()->EyePosition() ) )
+	CNEOBot::LineOfFireFlags lofFlags = CNEOBot::LINE_OF_FIRE_FLAGS_DEFAULT;
+	auto *neoThreat = ToNEOPlayer(threat->GetEntity());
+	const bool bThreatIsGhoster = neoThreat && neoThreat->IsCarryingGhost();
+	if (bThreatIsGhoster)
 	{
-		if ( !me->IsLineOfFireClear( threat->GetEntity()->WorldSpaceCenter() ) )
+		lofFlags |= CNEOBot::LINE_OF_FIRE_FLAGS_PENETRATION;
+	}
+
+	// don't shoot through non-shootables, check if shootable by any non-shotguns weapons
+	Vector vShootablePos = threat->GetEntity()->EyePosition();
+	if ( !me->IsLineOfFireClear( vShootablePos, lofFlags ) )
+	{
+		vShootablePos = threat->GetEntity()->WorldSpaceCenter();
+		if ( !me->IsLineOfFireClear( vShootablePos, lofFlags ) )
 		{
-			if ( !me->IsLineOfFireClear( threat->GetEntity()->GetAbsOrigin() ) )
+			vShootablePos = threat->GetEntity()->GetAbsOrigin();
+			if ( !me->IsLineOfFireClear( vShootablePos, lofFlags ) )
+			{
 				return;
+			}
+		}
+	}
+
+	// Check again if shotgun from last "any" shootable pos
+	bool bNotPrimary = false;
+	bool bShotgunSituationHandled = false;
+	// If holding non-primary, have shotgun in primary, and sight clear for shotgun, try to switch to shotgun
+	// Otherwise if holding shotgun and sight not clear for shotgun, try to switch to secondary
+	if (myWeapon && (myWeapon->GetNeoWepBits() & (NEO_WEP_MILSO | NEO_WEP_TACHI | NEO_WEP_KYLA | NEO_WEP_KNIFE | NEO_WEP_THROWABLE)))
+	{
+		auto *primaryWeapon = static_cast<CNEOBaseCombatWeapon *>(me->Weapon_GetSlot(0));
+		if (primaryWeapon && (primaryWeapon->GetNeoWepBits() & (NEO_WEP_AA13 | NEO_WEP_SUPA7)))
+		{
+			const bool bClearForShotgun = me->IsLineOfFireClear(vShootablePos, CNEOBot::LINE_OF_FIRE_FLAGS_SHOTGUN);
+			if (bClearForShotgun)
+			{
+				bNotPrimary = false;
+				me->EquipBestWeaponForThreat(threat, bNotPrimary);
+				myWeapon = static_cast<CNEOBaseCombatWeapon *>(me->GetActiveWeapon());
+			}
+			bShotgunSituationHandled = true;
+		}
+	}
+	else if (myWeapon && (myWeapon->GetNeoWepBits() & (NEO_WEP_AA13 | NEO_WEP_SUPA7)))
+	{
+		const bool bClearForShotgun = me->IsLineOfFireClear(vShootablePos, CNEOBot::LINE_OF_FIRE_FLAGS_SHOTGUN);
+		if (!bClearForShotgun)
+		{
+			// Try to switch over to non-shotgun weapon
+			bNotPrimary = true;
+			me->EquipBestWeaponForThreat(threat, bNotPrimary);
+			myWeapon = static_cast<CNEOBaseCombatWeapon *>(me->GetActiveWeapon());
+			// If it's still Supa7, then it should try to dodge the threat instead
+			if (myWeapon && (myWeapon->GetNeoWepBits() & (NEO_WEP_AA13 | NEO_WEP_SUPA7)))
+			{
+				return;
+			}
+			bShotgunSituationHandled = true;
 		}
 	}
 
@@ -609,6 +660,11 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 		return;
 	}
 
+	if (!bShotgunSituationHandled)
+	{
+		me->EquipBestWeaponForThreat(threat, false);
+	}
+
 	float threatRange = ( threat->GetEntity()->GetAbsOrigin() - me->GetAbsOrigin() ).Length();
 
 	// actual head aiming is handled elsewhere, just check if we're on target
@@ -622,6 +678,12 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 
 	if (bOnTarget)
 	{
+		if (bThreatIsGhoster)
+		{
+			me->GetBodyInterface()->AimHeadTowards(vShootablePos, IBody::CRITICAL, 1.0f, nullptr,
+					"Aiming at a visible ghoster threat");
+		}
+
 		if ( me->IsCombatWeapon( myWeapon ) )
 		{
 			if (myWeapon->m_iClip1 <= 0)
@@ -635,7 +697,7 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 				else if (IsImmediateThreat(me->GetEntity(), threat) && !m_isWaitingForFullReload)
 				{
 					// intention is to swap to secondary if available
-					me->EquipBestWeaponForThreat(threat);
+					me->EquipBestWeaponForThreat(threat, bNotPrimary);
 				}
 				else
 				{
@@ -698,7 +760,6 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 				}
 			}
 		}
-	
 	}
 }
 
@@ -748,7 +809,7 @@ void CNEOBotMainAction::Dodge( CNEOBot *me )
 	const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat();
 	if ( threat && threat->IsVisibleRecently() )
 	{
-		bool isShotClear = me->IsLineOfFireClear( threat->GetLastKnownPosition() );
+		bool isShotClear = me->IsLineOfFireClear( threat->GetLastKnownPosition(), CNEOBot::LINE_OF_FIRE_FLAGS_DEFAULT );
 
 		// don't dodge if they can't hit us
 		if ( !isShotClear )

--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -589,8 +589,10 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 
 	CNEOBot::LineOfFireFlags lofFlags = CNEOBot::LINE_OF_FIRE_FLAGS_DEFAULT;
 	auto *neoThreat = ToNEOPlayer(threat->GetEntity());
+
+	// Only hard + expert bots will attempt to wallbang at ghoster
 	const bool bThreatIsGhoster = neoThreat && neoThreat->IsCarryingGhost();
-	if (bThreatIsGhoster)
+	if (bThreatIsGhoster && me->GetDifficulty() >= CNEOBot::HARD)
 	{
 		lofFlags |= CNEOBot::LINE_OF_FIRE_FLAGS_PENETRATION;
 	}

--- a/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.cpp
@@ -65,10 +65,17 @@ ActionResult< CNEOBot >	CNEOBotSeekAndDestroy::Update( CNEOBot *me, float interv
 
 	if ( threat )
 	{
-		const float engageRange = 1000.0f;
-		if ( me->IsRangeLessThan( threat->GetLastKnownPosition(), engageRange ) )
+		const auto *neoThreat = ToNEOPlayer(threat->GetEntity());
+		// This will just go to the ghoster RecomputeSeekPath logics instead of
+		// only going after it
+		const bool bDontSuspendForGhoster = (neoThreat && neoThreat->IsCarryingGhost());
+		if (!bDontSuspendForGhoster)
 		{
-			return SuspendFor( new CNEOBotAttack, "Going after an enemy" );
+			const float engageRange = 1000.0f;
+			if ( me->IsRangeLessThan( threat->GetLastKnownPosition(), engageRange ) )
+			{
+				return SuspendFor( new CNEOBotAttack, "Going after an enemy" );
+			}
 		}
 	}
 	else

--- a/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.cpp
@@ -181,8 +181,7 @@ ActionResult< CNEOBot >	CNEOBotTacticalMonitor::Update( CNEOBot *me, float inter
 		}
 	}
 
-	const CKnownEntity* threat = me->GetVisionInterface()->GetPrimaryKnownThreat();
-	me->EquipBestWeaponForThreat( threat );
+	const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat();
 
 	// check if we need to get to cover
 	QueryResultType shouldRetreat = me->GetIntentionInterface()->ShouldRetreat( me );

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -15,6 +15,8 @@
 #include "weapon_neobasecombatweapon.h"
 #include "weapon_knife.h"
 #include "nav_mesh.h"
+#include "neo_penetration_resistance.h"
+#include "neo_shot_manipulator.h"
 
 #include "behavior/neo_bot_behavior.h"
 
@@ -1464,7 +1466,7 @@ bool CNEOBot::EquipRequiredWeapon(void)
 
 //-----------------------------------------------------------------------------------------------------
 // Equip the best weapon we have to attack the given threat
-void CNEOBot::EquipBestWeaponForThreat(const CKnownEntity* threat)
+void CNEOBot::EquipBestWeaponForThreat(const CKnownEntity* threat, const bool bNotPrimary)
 {
 	if (EquipRequiredWeapon())
 		return;
@@ -1477,9 +1479,15 @@ void CNEOBot::EquipBestWeaponForThreat(const CKnownEntity* threat)
 	CNEOBaseCombatWeapon* throwable = static_cast<CNEOBaseCombatWeapon *>(Weapon_GetSlot(3));
 
 	// --------------------------------------------------------------------------------
-	// Don't consider weapons that we have no ammo for.
-	if (primaryWeapon && (!primaryWeapon->m_iPrimaryAmmoType || primaryWeapon->Clip1() + primaryWeapon->m_iPrimaryAmmoCount <= 0)) // We do not care about slugs
+	// Don't consider weapons that we have no ammo for (or filter out primary like shotgun + glass scenario)
+	// We do not care about slugs
+	if (bNotPrimary ||
+			(primaryWeapon &&
+			 	(!primaryWeapon->m_iPrimaryAmmoType ||
+				 (primaryWeapon->Clip1() + primaryWeapon->m_iPrimaryAmmoCount) <= 0)))
+	{
 		primaryWeapon = NULL;
+	}
 
 	if (secondaryWeapon && (secondaryWeapon->Clip1() + secondaryWeapon->m_iPrimaryAmmoCount <= 0))
 		secondaryWeapon = NULL;
@@ -1693,50 +1701,173 @@ bool CNEOBot::IsQuietWeapon(CNEOBaseCombatWeapon* weapon) const
 	return false;
 }
 
+unsigned int CNEOBot::LineOfFireMask(const LineOfFireFlags flags)
+{
+	// Flag set by outside which should already know if using shotgun or not
+	// Shotgun cannot deal with windows at all
+	if (flags & LINE_OF_FIRE_FLAGS_SHOTGUN)
+	{
+		return MASK_SHOT;
+	}
+	return MASK_SHOT & ~CONTENTS_WINDOW;
+}
+
+// A very basic penetration material check, it doesn't do the full penetration
+// check and just simply base it on the material that it traced in front of the bot
+// and a short distance.
+bool CNEOBot::IsLineOfFirePenetrationClear(const trace_t &tr, const Vector &from, const Vector &to,
+		const ELineOfFirePenetrationMode eMode) const
+{
+	// Min is making sure at least the distance under it is considered
+	// Max is scaling up to penetration value of 100.0f which no weapon have, but
+	// scaling works out in general
+	static constexpr const float FL_METERS_TRY_PENETRATE_MIN = 9.0f;
+	static constexpr const float FL_METERS_TRY_PENETRATE_MAX = 36.0f;
+
+	int material = physprops->GetSurfaceData(tr.surface.surfaceProps)->game.material;
+	if (material != 'J')
+	{
+		// Only bother with fire penetration in short distance
+		auto *neoWeapon = static_cast<CNEOBaseCombatWeapon *>(GetActiveWeapon());
+		if (!neoWeapon)
+		{
+			return false;
+		}
+
+		// Glass mode can just skip the distance check
+		bool bAttemptPenTest = (eMode == LINE_OF_FIRE_PENETRATION_MODE_GLASS);
+		if (!bAttemptPenTest)
+		{
+			const float flMaxTryDist = clamp(
+					(neoWeapon->GetPenetration() / 100.0f) * FL_METERS_TRY_PENETRATE_MAX,
+					FL_METERS_TRY_PENETRATE_MIN, FL_METERS_TRY_PENETRATE_MAX);
+
+			const float flMeters = METERS_PER_INCH * from.DistTo(to);
+			bAttemptPenTest = (flMeters <= flMaxTryDist);
+		}
+		if (bAttemptPenTest)
+		{
+			material -= 'A';
+			if (IN_BETWEEN_AR(0, material, MATERIALS_NUM))
+			{
+				// Just for simplicity, only try to fire against materials that can be penetrated
+				if (PENETRATION_RESISTANCE[material] < 1.0f)
+				{
+					CNEOShotManipulator manipulator(0,
+							const_cast<CNEOBot *>(this)->GetAutoaimVector(AUTOAIM_SCALE_DEFAULT),
+							const_cast<CNEOBot *>(this),
+							neoWeapon);
+
+					Vector vecDir = manipulator.ApplySpread(const_cast<CNEOBot *>(this)->GetAttackSpread(neoWeapon));
+
+					trace_t	penetrationTrace;
+					TestPenetrationTrace(penetrationTrace, tr, vecDir, nullptr);
+
+					// See if we found the surface again
+					const bool bFoundSurface = (penetrationTrace.startsolid || tr.fraction == 0.0f || penetrationTrace.fraction == 1.0f);
+					return !bFoundSurface;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+bool CNEOBot::IsLineOfSightClear(CBaseEntity *entity, LineOfSightCheckType checkType) const
+{
+	if (auto *neoPlayer = ToNEOPlayer(entity); neoPlayer && neoPlayer->IsCarryingGhost())
+	{
+		return true;
+	}
+	return BaseClass::IsLineOfSightClear(entity, checkType);
+}
 
 //-----------------------------------------------------------------------------------------------------
 // Return true if a weapon has no obstructions along the line between the given points
-bool CNEOBot::IsLineOfFireClear(const Vector& from, const Vector& to) const
+bool CNEOBot::IsLineOfFireClear(const Vector& from, const Vector& to, const LineOfFireFlags flags) const
 {
 	trace_t trace;
 	NextBotTraceFilterIgnoreActors botFilter(NULL, COLLISION_GROUP_NONE);
 	CTraceFilterIgnoreFriendlyCombatItems ignoreFriendlyCombatFilter(this, COLLISION_GROUP_NONE, GetTeamNumber());
 	CTraceFilterChain filter(&botFilter, &ignoreFriendlyCombatFilter);
 
-	UTIL_TraceLine(from, to, MASK_SOLID_BRUSHONLY, &filter, &trace);
+	const auto lofMask = LineOfFireMask(flags);
+	UTIL_TraceLine(from, to, lofMask, &filter, &trace);
 
-	return !trace.DidHit();
+	const bool bIsClear = !trace.DidHit();
+
+	if (bIsClear && !(lofMask & CONTENTS_WINDOW) && !(flags & LINE_OF_FIRE_FLAGS_PENETRATION))
+	{
+		// Do a second trace with the window mask added in, if this hits but not the first,
+		// then the window need to go to IsLineOfFirePenetrationClear so we can
+		// differentiate between penetratable vs non-penetratable windows
+		trace_t withWindowTrace;
+		UTIL_TraceLine(from, to, MASK_SHOT, &filter, &withWindowTrace);
+		if (withWindowTrace.DidHit())
+		{
+			return IsLineOfFirePenetrationClear(withWindowTrace, from, to, LINE_OF_FIRE_PENETRATION_MODE_GLASS);
+		}
+	}
+
+	if (!bIsClear && !(flags & LINE_OF_FIRE_FLAGS_SHOTGUN) && (flags & LINE_OF_FIRE_FLAGS_PENETRATION))
+	{
+		return IsLineOfFirePenetrationClear(trace, from, to, LINE_OF_FIRE_PENETRATION_MODE_DEFAULT);
+	}
+
+	return bIsClear;
 }
 
 
 //-----------------------------------------------------------------------------------------------------
 // Return true if a weapon has no obstructions along the line from our eye to the given position
-bool CNEOBot::IsLineOfFireClear(const Vector& where) const
+bool CNEOBot::IsLineOfFireClear(const Vector& where, const LineOfFireFlags flags) const
 {
-	return IsLineOfFireClear(const_cast<CNEOBot*>(this)->EyePosition(), where);
+	return IsLineOfFireClear(const_cast<CNEOBot*>(this)->EyePosition(), where, flags);
 }
 
 
 //-----------------------------------------------------------------------------------------------------
 // Return true if a weapon has no obstructions along the line between the given point and entity
-bool CNEOBot::IsLineOfFireClear(const Vector& from, CBaseEntity* who) const
+bool CNEOBot::IsLineOfFireClear(const Vector& from, CBaseEntity* who, const LineOfFireFlags flags) const
 {
 	trace_t trace;
 	NextBotTraceFilterIgnoreActors botFilter(NULL, COLLISION_GROUP_NONE);
 	CTraceFilterIgnoreFriendlyCombatItems ignoreFriendlyCombatFilter(this, COLLISION_GROUP_NONE, GetTeamNumber());
 	CTraceFilterChain filter(&botFilter, &ignoreFriendlyCombatFilter);
 
-	UTIL_TraceLine(from, who->WorldSpaceCenter(), MASK_SOLID_BRUSHONLY, &filter, &trace);
+	const Vector to = who->WorldSpaceCenter();
+	const auto lofMask = LineOfFireMask(flags);
+	UTIL_TraceLine(from, to, lofMask, &filter, &trace);
 
-	return !trace.DidHit() || trace.m_pEnt == who;
+	const bool bIsClear = !trace.DidHit() || trace.m_pEnt == who;
+
+	if (bIsClear && !(lofMask & CONTENTS_WINDOW) && !(flags & LINE_OF_FIRE_FLAGS_PENETRATION))
+	{
+		// Do a second trace with the window mask added in, if this hits but not the first,
+		// then the window need to go to IsLineOfFirePenetrationClear so we can
+		// differentiate between penetratable vs non-penetratable windows
+		trace_t withWindowTrace;
+		UTIL_TraceLine(from, to, MASK_SHOT, &filter, &withWindowTrace);
+		if (withWindowTrace.DidHit())
+		{
+			return IsLineOfFirePenetrationClear(withWindowTrace, from, to, LINE_OF_FIRE_PENETRATION_MODE_GLASS);
+		}
+	}
+
+	if (!bIsClear && !(flags & LINE_OF_FIRE_FLAGS_SHOTGUN) && (flags & LINE_OF_FIRE_FLAGS_PENETRATION))
+	{
+		return IsLineOfFirePenetrationClear(trace, from, to, LINE_OF_FIRE_PENETRATION_MODE_DEFAULT);
+	}
+
+	return bIsClear;
 }
 
 
 //-----------------------------------------------------------------------------------------------------
 // Return true if a weapon has no obstructions along the line from our eye to the given entity
-bool CNEOBot::IsLineOfFireClear(CBaseEntity* who) const
+bool CNEOBot::IsLineOfFireClear(CBaseEntity* who, const LineOfFireFlags flags) const
 {
-	return IsLineOfFireClear(const_cast<CNEOBot*>(this)->EyePosition(), who);
+	return IsLineOfFireClear(const_cast<CNEOBot*>(this)->EyePosition(), who, flags);
 }
 
 
@@ -1893,11 +2024,14 @@ bool CNEOBot::FindSplashTarget(CBaseEntity* target, float maxSplashRadius, Vecto
 		trace_t trace;
 		NextBotTraceFilterIgnoreActors filter(NULL, COLLISION_GROUP_NONE);
 
-		UTIL_TraceLine(target->WorldSpaceCenter(), probe, MASK_SOLID_BRUSHONLY, &filter, &trace);
+		auto *myWeapon = static_cast<const CNEOBaseCombatWeapon *>(GetActiveWeapon());
+		const bool bIsShotgun = (myWeapon && (myWeapon->GetNeoWepBits() & (NEO_WEP_AA13 | NEO_WEP_SUPA7)));
+		const LineOfFireFlags flags = bIsShotgun ? LINE_OF_FIRE_FLAGS_SHOTGUN : LINE_OF_FIRE_FLAGS_DEFAULT;
+		UTIL_TraceLine(target->WorldSpaceCenter(), probe, LineOfFireMask(flags), &filter, &trace);
 		if (trace.DidHitWorld())
 		{
 			// can we shoot this spot?
-			if (IsLineOfFireClear(trace.endpos))
+			if (IsLineOfFireClear(trace.endpos, flags))
 			{
 				// yes, found a corner-sticky target
 				*splashTarget = trace.endpos;

--- a/src/game/server/neo/bot/neo_bot.h
+++ b/src/game/server/neo/bot/neo_bot.h
@@ -153,7 +153,7 @@ public:
 	float GetDesiredAttackRange(void) const;						// return the ideal range at which we can effectively attack
 
 	bool EquipRequiredWeapon(void);								// if we're required to equip a specific weapon, do it.
-	void EquipBestWeaponForThreat(const CKnownEntity* threat);	// equip the best weapon we have to attack the given threat
+	void EquipBestWeaponForThreat(const CKnownEntity* threat, const bool bNotPrimary = false);	// equip the best weapon we have to attack the given threat
 
 	void PushRequiredWeapon(CNEOBaseCombatWeapon* weapon);				// force us to equip and use this weapon until popped off the required stack
 	void PopRequiredWeapon(void);									// pop top required weapon off of stack and discard
@@ -188,10 +188,29 @@ public:
 	bool IsWeaponRestricted(CNEOBaseCombatWeapon* weapon) const;
 	bool ScriptIsWeaponRestricted(HSCRIPT script) const;
 
-	bool IsLineOfFireClear(const Vector& where) const;			// return true if a weapon has no obstructions along the line from our eye to the given position
-	bool IsLineOfFireClear(CBaseEntity* who) const;				// return true if a weapon has no obstructions along the line from our eye to the given entity
-	bool IsLineOfFireClear(const Vector& from, const Vector& to) const;			// return true if a weapon has no obstructions along the line between the given points
-	bool IsLineOfFireClear(const Vector& from, CBaseEntity* who) const;			// return true if a weapon has no obstructions along the line between the given point and entity
+	enum LineOfFireFlags_
+	{
+		LINE_OF_FIRE_FLAGS_DEFAULT = 0,
+		LINE_OF_FIRE_FLAGS_SHOTGUN = 1 << 0,
+		LINE_OF_FIRE_FLAGS_PENETRATION = 1 << 1,
+	};
+	typedef int LineOfFireFlags;
+
+	enum ELineOfFirePenetrationMode
+	{
+		LINE_OF_FIRE_PENETRATION_MODE_DEFAULT = 0,
+		LINE_OF_FIRE_PENETRATION_MODE_GLASS,
+	};
+	bool IsLineOfFirePenetrationClear(const trace_t &tr, const Vector &from, const Vector &to,
+			const ELineOfFirePenetrationMode eMode) const;
+
+	using BaseClass::IsLineOfSightClear;
+	bool IsLineOfSightClear(CBaseEntity *entity, LineOfSightCheckType checkType = IGNORE_NOTHING) const override;
+
+	bool IsLineOfFireClear(const Vector& where, const LineOfFireFlags flags) const;			// return true if a weapon has no obstructions along the line from our eye to the given position
+	bool IsLineOfFireClear(CBaseEntity* who, const LineOfFireFlags flags) const;				// return true if a weapon has no obstructions along the line from our eye to the given entity
+	bool IsLineOfFireClear(const Vector& from, const Vector& to, const LineOfFireFlags flags) const;			// return true if a weapon has no obstructions along the line between the given points
+	bool IsLineOfFireClear(const Vector& from, CBaseEntity* who, const LineOfFireFlags flags) const;			// return true if a weapon has no obstructions along the line between the given point and entity
 
 	bool IsEntityBetweenTargetAndSelf(CBaseEntity* other, CBaseEntity* target);	// return true if "other" is positioned inbetween us and "target"
 
@@ -399,6 +418,8 @@ public:
 	void AddEventChangeAttributes(const EventChangeAttributes_t* newEvent);
 	const EventChangeAttributes_t* GetEventChangeAttributes(const char* pszEventName) const;
 	void OnEventChangeAttributes(const CNEOBot::EventChangeAttributes_t* pEvent);
+
+	static unsigned int LineOfFireMask(const LineOfFireFlags flags);
 
 	bool IsFiring() const;
 	bool m_bOnTarget = false;

--- a/src/game/server/neo/bot/neo_bot_vision.cpp
+++ b/src/game/server/neo/bot/neo_bot_vision.cpp
@@ -166,7 +166,7 @@ bool CNEOBotVision::IsInFieldOfView( CBaseEntity *subject ) const
 	const int iGhosterPlayer = NEORules()->GetGhosterPlayer();
 	if (iGhosterPlayer > 0)
 	{
-		auto *pNEOPlayer = dynamic_cast<CNEO_Player *>(subject);
+		auto *pNEOPlayer = ToNEOPlayer(subject);
 		if (pNEOPlayer && pNEOPlayer->IsCarryingGhost())
 		{
 			return true;
@@ -175,3 +175,19 @@ bool CNEOBotVision::IsInFieldOfView( CBaseEntity *subject ) const
 
 	return IVision::IsInFieldOfView(subject);
 }
+
+bool CNEOBotVision::IsAbleToSee(CBaseEntity *subject, FieldOfViewCheckType checkFOV, Vector *visibleSpot) const
+{
+	const int iGhosterPlayer = NEORules()->GetGhosterPlayer();
+	if (iGhosterPlayer > 0)
+	{
+		auto *pNEOPlayer = ToNEOPlayer(subject);
+		if (pNEOPlayer && pNEOPlayer->IsCarryingGhost())
+		{
+			return true;
+		}
+	}
+
+	return IVision::IsAbleToSee(subject, checkFOV, visibleSpot);
+}
+

--- a/src/game/server/neo/bot/neo_bot_vision.h
+++ b/src/game/server/neo/bot/neo_bot_vision.h
@@ -25,6 +25,9 @@ public:
 
 	bool IsInFieldOfView( CBaseEntity *subject ) const override;
 
+	bool IsAbleToSee(CBaseEntity *subject, FieldOfViewCheckType checkFOV, Vector *visibleSpot = nullptr) const override;
+	// NEO NOTE (nullsystem): Not overriding non-CBaseEntity version as that doesn't give us enough info properly
+
 private:
 	CUtlVector< CHandle< CBaseCombatCharacter > > m_potentiallyVisibleNPCVector;
 	CountdownTimer m_potentiallyVisibleUpdateTimer;

--- a/src/game/shared/baseentity_shared.cpp
+++ b/src/game/shared/baseentity_shared.cpp
@@ -17,6 +17,7 @@
 #ifdef NEO
 #include "neo_shot_manipulator.h"
 #include "weapon_neobasecombatweapon.h"
+#include "neo_penetration_resistance.h"
 #ifdef CLIENT_DLL
 #include "c_neo_player.h"
 #else
@@ -2158,38 +2159,7 @@ void CBaseEntity::FireBullets( const FireBulletsInfo_t &info )
 }
 
 #ifdef NEO
-#define MAX_PENETRATION_DEPTH 12.f
-
-#define MATERIALS_NUM 26
-static const float penetrationResistance[MATERIALS_NUM] =
-{
-	1.0,						// CHAR_TEX_ANTLION
-	1.0,						// CHAR_TEX_BLOODYFLESH	
-	0.3,						// CHAR_TEX_CONCRETE		
-	0.2,						// CHAR_TEX_DIRT			
-	1.0,						// CHAR_TEX_EGGSHELL		
-	0.6,						// CHAR_TEX_FLESH			
-	0.75,						// CHAR_TEX_GRATE			
-	0.6,						// CHAR_TEX_ALIENFLESH		
-	1.0,						// CHAR_TEX_CLIP			
-	1.0,						// CHAR_TEX_BLOCKBULLETS		
-	1.0,						// CHAR_TEX_UNUSED		
-	0.8,						// CHAR_TEX_PLASTIC		
-	0.5,						// CHAR_TEX_METAL			
-	0.2,						// CHAR_TEX_SAND			
-	0.8,						// CHAR_TEX_FOLIAGE		
-	0.5,						// CHAR_TEX_COMPUTER		
-	1.0,						// CHAR_TEX_UNUSED		
-	1.0,						// CHAR_TEX_UNUSED		
-	1.0,						// CHAR_TEX_SLOSH			
-	0.5,						// CHAR_TEX_TILE			
-	1.0,						// CHAR_TEX_UNUSED		
-	0.75,						// CHAR_TEX_VENT			
-	0.75,						// CHAR_TEX_WOOD			
-	1.0,						// CHAR_TEX_UNUSED		
-	0.9,						// CHAR_TEX_GLASS			
-	1.0,						// CHAR_TEX_WARPSHIELD
-};
+bool ShouldPenetrate(const trace_t &tr);
 
 //-----------------------------------------------------------------------------
 // Handle shot penetration
@@ -2218,7 +2188,7 @@ void CBaseEntity::HandleShotPenetration(const FireBulletsInfo_t& info,
 	material -= 'A';
 	if (material > 0 && material < MATERIALS_NUM)
 	{
-		penResistance = penetrationResistance[material];
+		penResistance = PENETRATION_RESISTANCE[material];
 	}
 
 	if (tr.m_pEnt && tr.m_pEnt->IsPlayer())
@@ -2238,26 +2208,8 @@ void CBaseEntity::HandleShotPenetration(const FireBulletsInfo_t& info,
 	}
 #endif // CLIENT_DLL
 
-	// Find the furthest point along the bullets trajectory
-	Vector	testPos = tr.endpos + (vecDir * MAX_PENETRATION_DEPTH);
-
-	// Instead of tracing backwards from the furthest point the bullet could penetrate given a thick enough object initially penetrated, step into the object originally hit and find the next object behind this object,
-	// if any, and trace backwards from that next object. There must be empty space between the next object and the object originally hit for the next object to be detected. This is a limitation of traceline and is why
-	// placing toolsbulletblock inside of an object doesn't stop bullets penetrating straight through the bigger object.
-	trace_t	nextObjectTrace;
-	UTIL_TraceLine(tr.endpos + (vecDir * 0.1), testPos, MASK_SHOT, pTraceFilter, &nextObjectTrace);
-
-	CEffectData	data;
-
-	data.m_vNormal = tr.plane.normal;
-	data.m_vOrigin = tr.endpos;
-
 	trace_t	penetrationTrace;
-
-	// Re-trace backwards to find the bullet ext
-	// tracelines started inside of props get stuck unlike those started inside of brushes, revert to the original behaviour in those cases
-	Vector penetrationTraceStart = nextObjectTrace.fraction == 0.0f ? tr.endpos + (vecDir * MAX_PENETRATION_DEPTH) : nextObjectTrace.endpos - (vecDir * 0.1);
-	UTIL_TraceLine(penetrationTraceStart, tr.endpos, MASK_SHOT, nullptr, &penetrationTrace);
+	TestPenetrationTrace(penetrationTrace, tr, vecDir, pTraceFilter);
 
 	// See if we found the surface again
 	if (penetrationTrace.startsolid || tr.fraction == 0.0f || penetrationTrace.fraction == 1.0f)
@@ -2278,6 +2230,7 @@ void CBaseEntity::HandleShotPenetration(const FireBulletsInfo_t& info,
 	// Impact the other side (will look like an exit effect)
 	DoImpactEffect(penetrationTrace, GetAmmoDef()->DamageType(info.m_iAmmoType));
 
+	CEffectData	data;
 	data.m_vNormal = penetrationTrace.plane.normal;
 	data.m_vOrigin = penetrationTrace.endpos;
 

--- a/src/game/shared/baseentity_shared.cpp
+++ b/src/game/shared/baseentity_shared.cpp
@@ -2169,7 +2169,7 @@ void CBaseEntity::HandleShotPenetration(const FireBulletsInfo_t& info,
 {
 	float penResistance = 0;
 	int material = physprops->GetSurfaceData(tr.surface.surfaceProps)->game.material;
-	if (material == 'J')
+	if (material == CHAR_TEX_BLOCKBULLETS)
 	{ // we hit blockbullets, do not penetrate
 #ifdef CLIENT_DLL
 		if (cl_neo_bullet_trace.GetBool())

--- a/src/game/shared/decals.h
+++ b/src/game/shared/decals.h
@@ -21,7 +21,11 @@
 #define CHAR_TEX_GRATE			'G'
 #define CHAR_TEX_ALIENFLESH		'H'
 #define CHAR_TEX_CLIP			'I'
+#ifdef NEO
+#define CHAR_TEX_BLOCKBULLETS	'J'
+#else
 //#define CHAR_TEX_UNUSED		'J'
+#endif // NEO
 //#define CHAR_TEX_UNUSED		'K'
 #define CHAR_TEX_PLASTIC		'L'
 #define CHAR_TEX_METAL			'M'

--- a/src/game/shared/neo/neo_penetration_resistance.cpp
+++ b/src/game/shared/neo/neo_penetration_resistance.cpp
@@ -1,0 +1,23 @@
+#include "neo_penetration_resistance.h"
+
+#include "cbase.h"
+#include "gametrace.h"
+
+void TestPenetrationTrace(trace_t &penetrationTrace,
+		const trace_t &tr, const Vector &vecDir, ITraceFilter *pTraceFilter)
+{
+	// Find the furthest point along the bullets trajectory
+	Vector testPos = tr.endpos + (vecDir * MAX_PENETRATION_DEPTH);
+
+	// Instead of tracing backwards from the furthest point the bullet could penetrate given a thick enough object initially penetrated, step into the object originally hit and find the next object behind this object,
+	// if any, and trace backwards from that next object. There must be empty space between the next object and the object originally hit for the next object to be detected. This is a limitation of traceline and is why
+	// placing toolsbulletblock inside of an object doesn't stop bullets penetrating straight through the bigger object.
+	trace_t	nextObjectTrace;
+	UTIL_TraceLine(tr.endpos + (vecDir * 0.1), testPos, MASK_SHOT, pTraceFilter, &nextObjectTrace);
+
+	// Re-trace backwards to find the bullet ext
+	// tracelines started inside of props get stuck unlike those started inside of brushes, revert to the original behaviour in those cases
+	Vector penetrationTraceStart = nextObjectTrace.fraction == 0.0f ? tr.endpos + (vecDir * MAX_PENETRATION_DEPTH) : nextObjectTrace.endpos - (vecDir * 0.1);
+	UTIL_TraceLine(penetrationTraceStart, tr.endpos, MASK_SHOT, nullptr, &penetrationTrace);
+}
+

--- a/src/game/shared/neo/neo_penetration_resistance.h
+++ b/src/game/shared/neo/neo_penetration_resistance.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "mathlib/vector.h"
+
+class ITraceFilter;
+class CGameTrace;
+typedef CGameTrace trace_t;
+
+#define MAX_PENETRATION_DEPTH 12.0f
+#define MATERIALS_NUM 26
+static constexpr const float PENETRATION_RESISTANCE[MATERIALS_NUM] =
+{
+	1.0,						// CHAR_TEX_ANTLION
+	1.0,						// CHAR_TEX_BLOODYFLESH	
+	0.3,						// CHAR_TEX_CONCRETE		
+	0.2,						// CHAR_TEX_DIRT			
+	1.0,						// CHAR_TEX_EGGSHELL		
+	0.6,						// CHAR_TEX_FLESH			
+	0.75,						// CHAR_TEX_GRATE			
+	0.6,						// CHAR_TEX_ALIENFLESH		
+	1.0,						// CHAR_TEX_CLIP			
+	1.0,						// CHAR_TEX_BLOCKBULLETS		
+	1.0,						// CHAR_TEX_UNUSED		
+	0.8,						// CHAR_TEX_PLASTIC		
+	0.5,						// CHAR_TEX_METAL			
+	0.2,						// CHAR_TEX_SAND			
+	0.8,						// CHAR_TEX_FOLIAGE		
+	0.5,						// CHAR_TEX_COMPUTER		
+	1.0,						// CHAR_TEX_UNUSED		
+	1.0,						// CHAR_TEX_UNUSED		
+	1.0,						// CHAR_TEX_SLOSH			
+	0.5,						// CHAR_TEX_TILE			
+	1.0,						// CHAR_TEX_UNUSED		
+	0.75,						// CHAR_TEX_VENT			
+	0.75,						// CHAR_TEX_WOOD			
+	1.0,						// CHAR_TEX_UNUSED		
+	0.9,						// CHAR_TEX_GLASS			
+	1.0,						// CHAR_TEX_WARPSHIELD
+};
+
+void TestPenetrationTrace(trace_t &penetrationTrace,
+		const trace_t &tr, const Vector &vecDir, ITraceFilter *pTraceFilter);
+


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Bots should now be able to shoot through glass if not using a shotgun
* If using a shotgun, try to change to a weapon that can utilize the glass if possible
* Change back to a shotgun if not behind glass?
* Tested/check if it doesn't straight up shoot through any penetrable like wallhack ability, non-glass penetrable only shoot through if it's recently seen enemy
* Enemy player that can shoot towards the ghoster behind penetrable should be able to try shooting at it
* Test/check for non-penetrable glass (tarmac non-penetrable vs oilstain penetrable)
* Slight scale between weapon penetration on when the bots will attempt to do penetration, so like SRS will do longer distance than SRM.
* Limited wallbang at ghoster ability to hard + expert bots

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Gentoo/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1282

