### PR TITLE
Zoom sensitivity ratio in settings

### DIFF
--- a/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/src/game/client/neo/ui/neo_root_settings.cpp
@@ -302,6 +302,7 @@ void NeoSettingsRestore(NeoSettings *ns, const NeoSettings::Keys::Flags flagsKey
 	{
 		NeoSettings::Mouse *pMouse = &ns->mouse;
 		pMouse->flSensitivity = cvr->sensitivity.GetFloat();
+		pMouse->flZoomSensitivityRatio = cvr->zoom_sensitivity_ratio.GetFloat();
 		pMouse->bRawInput = cvr->m_rawinput.GetBool();
 		pMouse->bFilter = cvr->m_filter.GetBool();
 		pMouse->bReverse = (cvr->m_pitch.GetFloat() < 0.0f);
@@ -538,6 +539,7 @@ void NeoSettingsSave(const NeoSettings *ns)
 	{
 		const NeoSettings::Mouse *pMouse = &ns->mouse;
 		cvr->sensitivity.SetValue(pMouse->flSensitivity);
+		cvr->zoom_sensitivity_ratio.SetValue(pMouse->flZoomSensitivityRatio);
 		cvr->m_rawinput.SetValue(pMouse->bRawInput);
 		cvr->m_filter.SetValue(pMouse->bFilter);
 		const float absPitch = abs(cvr->m_pitch.GetFloat());
@@ -800,6 +802,7 @@ void NeoSettings_Mouse(NeoSettings *ns)
 {
 	NeoSettings::Mouse *pMouse = &ns->mouse;
 	NeoUI::Slider(L"Sensitivity", &pMouse->flSensitivity, 0.1f, 10.0f, 2, 0.25f);
+	NeoUI::Slider(L"Zoom Sensitivity Ratio", &pMouse->flZoomSensitivityRatio, 0.f, 10.0f, 2, 0.25f);
 	NeoUI::RingBoxBool(L"Raw input", &pMouse->bRawInput);
 	NeoUI::RingBoxBool(L"Mouse Filter", &pMouse->bFilter);
 	NeoUI::RingBoxBool(L"Mouse Reverse", &pMouse->bReverse);

--- a/src/game/client/neo/ui/neo_root_settings.h
+++ b/src/game/client/neo/ui/neo_root_settings.h
@@ -96,6 +96,7 @@ struct NeoSettings
 	struct Mouse
 	{
 		float flSensitivity;
+		float flZoomSensitivityRatio;
 		bool bRawInput;
 		bool bFilter;
 		bool bReverse;
@@ -206,6 +207,7 @@ struct NeoSettings
 
 		// Mouse
 		CONVARREF_DEF(sensitivity);
+		CONVARREF_DEF(zoom_sensitivity_ratio);
 		CONVARREF_DEF(m_filter);
 		CONVARREF_DEF(m_pitch);
 		CONVARREF_DEF(m_customaccel);


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

exposes the zoom_sensitivity_ratio convar.

negative values invert controls when aimed in ( can only be set via console/config file )
a value of 0 removes the scaling of mouse sensitivity with fov
a value less than 1 scales down sensitivity when aimed in
a value greater than 1 scales up sensitivity when aimed in ( values greater than 10 only via console/config file )