### PR TITLE
zero out ragdoll velocity if ragdoll is settled, refactor ragdoll velocity stuff out of c_baseanimating into cragdoll

### DIFF
--- a/src/game/client/c_baseanimating.cpp
+++ b/src/game/client/c_baseanimating.cpp
@@ -3283,7 +3283,7 @@ int C_BaseAnimating::DrawModel( int flags )
 		Vector vel;
 		if (IsRagdoll())
 		{
-			vel = m_pRagdoll->IsSettled() ? vec3_origin : m_pRagdoll->m_vecLastVelocity;
+			vel = m_pRagdoll->m_vecLastVelocity;
 		}
 		else
 		{

--- a/src/game/client/c_baseanimating.cpp
+++ b/src/game/client/c_baseanimating.cpp
@@ -3283,7 +3283,7 @@ int C_BaseAnimating::DrawModel( int flags )
 		Vector vel;
 		if (IsRagdoll())
 		{
-			vel = rootMoveParent->GetOldVelocity();
+			vel = m_pRagdoll->IsSettled() ? vec3_origin : m_pRagdoll->m_vecLastVelocity;
 		}
 		else
 		{
@@ -4753,22 +4753,6 @@ void C_BaseAnimating::RagdollMoved( void )
 	m_pRagdoll->GetRagdollBounds( mins, maxs );
 	SetCollisionBounds( mins, maxs );
 
-#ifdef NEO
-	if (GetOldOrigin() != vec3_origin)
-	{
-		if (m_flLastOriginChangeTime != gpGlobals->curtime)
-		{
-			SetOldVelocity((GetAbsOrigin() - GetOldOrigin()) / (gpGlobals->curtime - m_flLastOriginChangeTime));
-			SetOldOrigin(GetAbsOrigin());
-		}
-	}
-	else
-	{ // First time
-		auto ragdoll = static_cast<C_HL2MPRagdoll*>(GetBaseAnimating());
-		SetOldVelocity(ragdoll->GetRagdollVelocity());
-		SetOldOrigin(GetAbsOrigin());
-	}
-#endif // NEO
 	// If the ragdoll moves, its render-to-texture shadow is dirty
 	InvalidatePhysicsRecursive( ANIMATION_CHANGED ); 
 }

--- a/src/game/client/c_baseentity.h
+++ b/src/game/client/c_baseentity.h
@@ -1388,10 +1388,6 @@ public:
 	void							SetWaterType( int nType );
 
 	float							GetElasticity( void ) const;
-#ifdef NEO
-	inline void						SetOldVelocity( const Vector& oldVelocity ) { m_vecOldVelocity = oldVelocity; }
-	inline const Vector&			GetOldVelocity() const { return m_vecOldVelocity; };
-#endif // NEO
 
 	int								GetTextureFrameIndex( void );
 	void							SetTextureFrameIndex( int iIndex );
@@ -1625,9 +1621,6 @@ private:
 
 	Vector							m_vecOldOrigin;
 	QAngle							m_vecOldAngRotation;
-#ifdef NEO
-	Vector							m_vecOldVelocity;
-#endif // NEO
 
 	Vector							m_vecOrigin;
 	CInterpolatedVar< Vector >		m_iv_vecOrigin;

--- a/src/game/client/hl2mp/c_hl2mp_player.cpp
+++ b/src/game/client/hl2mp/c_hl2mp_player.cpp
@@ -1392,6 +1392,13 @@ void C_HL2MPRagdoll::CreateHL2MPRagdoll( void )
 	}
 
 	InitAsClientRagdoll( boneDelta0, boneDelta1, currentBones, boneDt );
+#ifdef NEO
+	if (m_pRagdoll)
+	{
+		m_pRagdoll->SetInitialVelocity(GetInitialRagdollVelocity());
+		m_pRagdoll->SetLastOrigin(GetInitialRagdollOrigin());
+	}
+#endif // NEO
 }
 
 

--- a/src/game/client/hl2mp/c_hl2mp_player.h
+++ b/src/game/client/hl2mp/c_hl2mp_player.h
@@ -213,7 +213,8 @@ public:
 	void UpdateOnRemove( void );
 	virtual void SetupWeights( const matrix3x4_t *pBoneToWorld, int nFlexWeightCount, float *pFlexWeights, float *pFlexDelayedWeights );
 #ifdef NEO
-	inline const Vector& GetRagdollVelocity(void) const { return m_vecRagdollVelocity.Get(); }
+	inline const Vector& GetInitialRagdollOrigin(void) const { return m_vecRagdollOrigin.Get(); }
+	inline const Vector& GetInitialRagdollVelocity(void) const { return m_vecRagdollVelocity.Get(); }
 #ifdef CLIENT_DLL
 	virtual int DrawModel(int flags) override;
 #endif // CLIENT_DLL

--- a/src/game/client/proxyplayer.cpp
+++ b/src/game/client/proxyplayer.cpp
@@ -279,7 +279,7 @@ void CEntitySpeedProxy::OnBind( void *pC_BaseEntity )
 		C_BaseAnimating* baseAnimating = pEntity->GetBaseAnimating();
 		if (baseAnimating && baseAnimating->IsRagdoll())
 		{
-			velocity = baseAnimating->m_pRagdoll->IsSettled() ? vec3_origin : pEntity->GetOldVelocity();
+			velocity = baseAnimating->m_pRagdoll->IsSettled() ? vec3_origin : baseAnimating->m_pRagdoll->m_vecLastVelocity;
 		}
 		else
 		{

--- a/src/game/client/proxyplayer.cpp
+++ b/src/game/client/proxyplayer.cpp
@@ -279,7 +279,7 @@ void CEntitySpeedProxy::OnBind( void *pC_BaseEntity )
 		C_BaseAnimating* baseAnimating = pEntity->GetBaseAnimating();
 		if (baseAnimating && baseAnimating->IsRagdoll())
 		{
-			velocity = baseAnimating->m_pRagdoll->IsSettled() ? vec3_origin : baseAnimating->m_pRagdoll->m_vecLastVelocity;
+			velocity = baseAnimating->m_pRagdoll->m_vecLastVelocity;
 		}
 		else
 		{

--- a/src/game/client/proxyplayer.cpp
+++ b/src/game/client/proxyplayer.cpp
@@ -272,19 +272,16 @@ void CEntitySpeedProxy::OnBind( void *pC_BaseEntity )
 
 	Assert( m_pResult );
 #ifdef NEO
-	auto rootMoveParent = pEntity->GetRootMoveParent();
-	auto velocity = rootMoveParent->GetAbsVelocity();
-	if (velocity == vec3_origin)
+	C_BaseAnimating *baseAnimating = pEntity->GetBaseAnimating();
+	C_BaseEntity *rootMoveParent = pEntity->GetRootMoveParent();
+	Vector velocity = vec3_origin;
+	if (baseAnimating && baseAnimating->IsRagdoll())
 	{
-		C_BaseAnimating* baseAnimating = pEntity->GetBaseAnimating();
-		if (baseAnimating && baseAnimating->IsRagdoll())
-		{
-			velocity = baseAnimating->m_pRagdoll->m_vecLastVelocity;
-		}
-		else
-		{
-			rootMoveParent->EstimateAbsVelocity(velocity);
-		}
+		velocity = baseAnimating->m_pRagdoll->m_vecLastVelocity;
+	}
+	else
+	{
+		rootMoveParent->EstimateAbsVelocity(velocity);
 	}
 	m_pResult->SetFloatValue(velocity.Length());
 #else

--- a/src/game/client/proxyplayer.cpp
+++ b/src/game/client/proxyplayer.cpp
@@ -279,7 +279,7 @@ void CEntitySpeedProxy::OnBind( void *pC_BaseEntity )
 		C_BaseAnimating* baseAnimating = pEntity->GetBaseAnimating();
 		if (baseAnimating && baseAnimating->IsRagdoll())
 		{
-			velocity = pEntity->GetOldVelocity();
+			velocity = baseAnimating->m_pRagdoll->IsSettled() ? vec3_origin : pEntity->GetOldVelocity();
 		}
 		else
 		{

--- a/src/game/client/ragdoll.cpp
+++ b/src/game/client/ragdoll.cpp
@@ -265,6 +265,9 @@ bool CRagdoll::TransformVectorToWorld(int iBoneIndex, const Vector *vPosition, V
 //-----------------------------------------------------------------------------
 void CRagdoll::PhysForceRagdollToSleep()
 {
+#ifdef NEO
+	m_vecLastVelocity = vec3_origin;
+#endif // NEO
 	for ( int i = 0; i < m_ragdoll.listCount; i++ )
 	{
 		if ( m_ragdoll.list[i].pObject )
@@ -301,17 +304,11 @@ void CRagdoll::CheckSettleStationaryRagdoll()
 		return;
 
 	// Msg( "%d [%p] Settling\n", gpGlobals->tickcount, this );
-#ifdef NEO
-	if (!IsSettled())
-	{
-		return;
-	}
-#else
+	
 	// It has stopped moving, see if it
 	float dt = gpGlobals->curtime - m_flLastOriginChangeTime;
 	if ( dt < ragdoll_sleepaftertime.GetFloat() )
 		return;
-#endif // NEO
 
 	// Msg( "%d [%p] FORCE SLEEP\n",gpGlobals->tickcount, this );
 
@@ -324,13 +321,6 @@ void CRagdoll::ResetRagdollSleepAfterTime( void )
 	m_flLastOriginChangeTime = gpGlobals->curtime;
 }
 
-#ifdef NEO
-inline bool CRagdoll::IsSettled()
-{ 
-	if (gpGlobals->curtime - m_flLastOriginChangeTime >= ragdoll_sleepaftertime.GetFloat()) { return true; }
-}
-
-#endif // NEO
 void CRagdoll::DrawWireframe()
 {
 	IMaterial *pWireframe = materials->FindMaterial("shadertest/wireframevertexcolor", TEXTURE_GROUP_OTHER);

--- a/src/game/client/ragdoll.cpp
+++ b/src/game/client/ragdoll.cpp
@@ -290,11 +290,17 @@ void CRagdoll::CheckSettleStationaryRagdoll()
 		return;
 
 	// Msg( "%d [%p] Settling\n", gpGlobals->tickcount, this );
-
+#ifdef NEO
+	if (!IsSettled())
+	{
+		return;
+	}
+#else
 	// It has stopped moving, see if it
 	float dt = gpGlobals->curtime - m_flLastOriginChangeTime;
 	if ( dt < ragdoll_sleepaftertime.GetFloat() )
 		return;
+#endif // NEO
 
 	// Msg( "%d [%p] FORCE SLEEP\n",gpGlobals->tickcount, this );
 
@@ -307,6 +313,13 @@ void CRagdoll::ResetRagdollSleepAfterTime( void )
 	m_flLastOriginChangeTime = gpGlobals->curtime;
 }
 
+#ifdef NEO
+inline bool CRagdoll::IsSettled()
+{ 
+	if (gpGlobals->curtime - m_flLastOriginChangeTime >= ragdoll_sleepaftertime.GetFloat()) { return true; }
+}
+
+#endif // NEO
 void CRagdoll::DrawWireframe()
 {
 	IMaterial *pWireframe = materials->FindMaterial("shadertest/wireframevertexcolor", TEXTURE_GROUP_OTHER);

--- a/src/game/client/ragdoll.cpp
+++ b/src/game/client/ragdoll.cpp
@@ -128,6 +128,14 @@ void CRagdoll::Init(
 
 	// It's moving now...
 	m_flLastOriginChangeTime = gpGlobals->curtime;
+#ifdef NEO
+	auto pCHL2mpRagdoll = static_cast<C_HL2MPRagdoll*>(ent);
+	if (pCHL2mpRagdoll)
+	{
+		m_vecInitialVelocity = pCHL2mpRagdoll->GetInitialRagdollVelocity();
+		m_vecLastOrigin = pCHL2mpRagdoll->GetInitialRagdollOrigin();
+	}
+#endif // NEO
 
 	// So traces hit it.
 	ent->AddEFlags( EFL_USE_PARTITION_WHEN_NOT_SOLID );
@@ -273,6 +281,9 @@ static ConVar ragdoll_sleepaftertime( "ragdoll_sleepaftertime", "5.0f", 0, "Afte
 void CRagdoll::CheckSettleStationaryRagdoll()
 {
 	Vector delta = GetRagdollOrigin() - m_vecLastOrigin;
+#ifdef NEO
+	m_vecLastVelocity = delta / (gpGlobals->frametime);
+#endif // NEO
 	m_vecLastOrigin = GetRagdollOrigin();
 	for ( int i = 0; i < 3; ++i )
 	{

--- a/src/game/client/ragdoll.cpp
+++ b/src/game/client/ragdoll.cpp
@@ -128,14 +128,6 @@ void CRagdoll::Init(
 
 	// It's moving now...
 	m_flLastOriginChangeTime = gpGlobals->curtime;
-#ifdef NEO
-	auto pCHL2mpRagdoll = static_cast<C_HL2MPRagdoll*>(ent);
-	if (pCHL2mpRagdoll)
-	{
-		m_vecInitialVelocity = pCHL2mpRagdoll->GetInitialRagdollVelocity();
-		m_vecLastOrigin = pCHL2mpRagdoll->GetInitialRagdollOrigin();
-	}
-#endif // NEO
 
 	// So traces hit it.
 	ent->AddEFlags( EFL_USE_PARTITION_WHEN_NOT_SOLID );
@@ -285,7 +277,10 @@ void CRagdoll::CheckSettleStationaryRagdoll()
 {
 	Vector delta = GetRagdollOrigin() - m_vecLastOrigin;
 #ifdef NEO
-	m_vecLastVelocity = delta / (gpGlobals->frametime);
+	if (gpGlobals->frametime > 0)
+	{
+		m_vecLastVelocity = delta / (gpGlobals->frametime);
+	}
 #endif // NEO
 	m_vecLastOrigin = GetRagdollOrigin();
 	for ( int i = 0; i < 3; ++i )

--- a/src/game/client/ragdoll.h
+++ b/src/game/client/ragdoll.h
@@ -104,6 +104,12 @@ private:
 	bool		m_allAsleep;
 	Vector		m_vecLastOrigin;
 	float		m_flLastOriginChangeTime;
+#ifdef NEO
+public:
+	Vector		m_vecLastVelocity;
+	Vector		m_vecInitialVelocity;
+private:
+#endif // NEO
 
 #if RAGDOLL_VISUALIZE
 	matrix3x4_t			m_savedBone1[MAXSTUDIOBONES];

--- a/src/game/client/ragdoll.h
+++ b/src/game/client/ragdoll.h
@@ -87,6 +87,9 @@ public:
 
 	void ResetRagdollSleepAfterTime( void );
 	float GetLastVPhysicsUpdateTime() const { return m_lastUpdate; }
+#ifdef NEO
+	bool IsSettled();
+#endif // NEO
 
 private:
 

--- a/src/game/client/ragdoll.h
+++ b/src/game/client/ragdoll.h
@@ -88,6 +88,11 @@ public:
 	void ResetRagdollSleepAfterTime( void );
 	float GetLastVPhysicsUpdateTime() const { return m_lastUpdate; }
 
+#ifdef NEO
+	void SetInitialVelocity(const Vector& velocity) { m_vecInitialVelocity = velocity; }
+	void SetLastOrigin(const Vector& velocity) { m_vecLastOrigin = velocity; }
+
+#endif // NEO
 private:
 
 	void			CheckSettleStationaryRagdoll();
@@ -104,8 +109,8 @@ private:
 #ifdef NEO
 public:
 	Vector		m_vecLastVelocity;
-	Vector		m_vecInitialVelocity;
 private:
+	Vector		m_vecInitialVelocity;
 #endif // NEO
 
 #if RAGDOLL_VISUALIZE

--- a/src/game/client/ragdoll.h
+++ b/src/game/client/ragdoll.h
@@ -87,9 +87,6 @@ public:
 
 	void ResetRagdollSleepAfterTime( void );
 	float GetLastVPhysicsUpdateTime() const { return m_lastUpdate; }
-#ifdef NEO
-	bool IsSettled();
-#endif // NEO
 
 private:
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

There is an issue on master thats kinda difficult to replicate, but sometimes you will notice some ragdolls will freeze while still being slightly highlighted in motion vision, with the velocity no longer updated as the ragdoll goes to sleep. This PR sets the value of the ragdoll velocity to 0 when a ragdoll goes to sleep

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
