### PR TITLE
Fix dropped weapons sometimes appearing pitch black

### DIFF
--- a/src/game/client/c_baseanimating.cpp
+++ b/src/game/client/c_baseanimating.cpp
@@ -3615,6 +3615,12 @@ int C_BaseAnimating::InternalDrawModel( int flags )
 			pInfo->pLightingOrigin = &ownerOrigin;
 		}
 	}
+	else if (IsBaseCombatWeapon())
+	{
+		static Vector worldSpaceCenter;
+		worldSpaceCenter = WorldSpaceCenter();
+		pInfo->pLightingOrigin = &worldSpaceCenter;
+	}
 #endif // NEO
 
 	DrawModelState_t state;


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

It appears that when drawing entities, their origin is used as the lighting origin. Since the origins of weapons are often placed at the handle, or in the case of grenades outside the weapons model completely, some weapons can appear very dark when dropped as their origin falls through the floor. This PR sets the lighting origin of weapons to their world space center instead. While not ideal, with some really small weapons like the grenades still appearing a bit dark sometimes, it either improves or solves the issue in all cases from what I've tested.

Before:
<img width="2034" height="790" alt="image" src="https://github.com/user-attachments/assets/4e7765b4-16a3-49d3-b2d1-1caa53ad5b46" />

After:
<img width="2159" height="800" alt="image2" src="https://github.com/user-attachments/assets/8cd6aaf6-8a33-47f4-b063-a908f969216e" />

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
