### PR TITLE
Remove assister from suicide with assist notice, reverse highlight and non highlight colours

### DIFF
--- a/game/neo/scripts/HudLayout.res
+++ b/game/neo/scripts/HudLayout.res
@@ -397,8 +397,8 @@
 		"LineMargin"		"2"
 		"MaxDeathNotices" 	"8"
 		"RightJustify"		"1"
-		"BackgroundColor"	"200 200 200 40"
-		"BackgroundColourInvolved"	"20 20 20 220"
+		"BackgroundColor"	"20 20 20 220"
+		"BackgroundColourInvolved"	"200 200 200 40"
 	}
 
 	HudVehicle

--- a/game/neo/scripts/HudLayout.res
+++ b/game/neo/scripts/HudLayout.res
@@ -397,7 +397,7 @@
 		"LineMargin"		"2"
 		"MaxDeathNotices" 	"8"
 		"RightJustify"		"1"
-		"BackgroundColor"	"20 20 20 220"
+		"BackgroundColour"	"20 20 20 220"
 		"BackgroundColourInvolved"	"200 200 200 40"
 	}
 

--- a/src/game/client/neo/ui/neo_hud_deathnotice.cpp
+++ b/src/game/client/neo/ui/neo_hud_deathnotice.cpp
@@ -109,8 +109,8 @@ private:
 	CPanelAnimationVarAliasType( int, m_iLineMargin, "LineMargin", "2", "proportional_ypos");
 	CPanelAnimationVar( int, m_iMaxDeathNotices, "MaxDeathNotices", "8" );
 	CPanelAnimationVar( bool, m_bRightJustify, "RightJustify", "1" );
-	CPanelAnimationVar( Color, m_BackgroundColour, "BackgroundColour", "200 200 200 40");
-	CPanelAnimationVar( Color, m_BackgroundColourInvolved, "BackgroundColourInvolved", "50 50 50 200");
+	CPanelAnimationVar( Color, m_BackgroundColour, "BackgroundColour", "20 20 20 220");
+	CPanelAnimationVar( Color, m_BackgroundColourInvolved, "BackgroundColourInvolved", "200 200 200 40");
 
 	CUtlVector<DeathNoticeItem> m_DeathNotices;
 };
@@ -386,7 +386,7 @@ void CNEOHud_DeathNotice::SetDeathNoticeItemDimensions(DeathNoticeItem* deathNot
 			surface()->GetTextSize(g_hFontKillfeed, deathNoticeItem->Killer.szName, width, height);
 			totalWidth += width;
 		}
-		if (deathNoticeItem->Assist.iEntIndex != 0)
+		if (deathNoticeItem->Assist.iEntIndex != 0 && !deathNoticeItem->bSuicide)
 		{
 			surface()->GetTextSize(g_hFontKillfeed, deathNoticeItem->Assist.szName, width, height);
 			totalWidth += width;
@@ -396,7 +396,11 @@ void CNEOHud_DeathNotice::SetDeathNoticeItemDimensions(DeathNoticeItem* deathNot
 		if (deathNoticeItem->Victim.iEntIndex != 0)
 		{
 			surface()->GetTextSize(g_hFontKillfeed, deathNoticeItem->Victim.szName, width, height);
-			totalWidth += width + spaceLength;
+			totalWidth += width;
+			if (!deathNoticeItem->bSuicide)
+			{
+				totalWidth += spaceLength;
+			}
 		}
 		if (deathNoticeItem->bSuicide)
 		{
@@ -452,29 +456,28 @@ void CNEOHud_DeathNotice::DrawPlayerDeath(int i)
 {
 	DrawCommon(i);
 
-	surface()->DrawSetTextFont(g_hFontKillfeed);
-	// Killer
-	if (m_DeathNotices[i].Killer.iEntIndex != 0 && !m_DeathNotices[i].bSuicide)
-	{
-		SetColorForNoticePlayer(m_DeathNotices[i].Killer.iTeam);
-		surface()->DrawSetTextFont(g_hFontKillfeed);
-		surface()->DrawPrintText(m_DeathNotices[i].Killer.szName, m_DeathNotices[i].Killer.iNameLength);
-	}
-
-	// Assister
-	if (m_DeathNotices[i].Assist.iEntIndex != 0)
-	{
-		surface()->DrawSetTextColor(COLOR_NEO_WHITE);
-		surface()->DrawPrintText(ASSIST_SEPARATOR, ASSIST_SEPARATOR_LENGTH - 1);
-
-		SetColorForNoticePlayer(m_DeathNotices[i].Assist.iTeam);
-		surface()->DrawSetTextFont(g_hFontKillfeed);
-		surface()->DrawPrintText(m_DeathNotices[i].Assist.szName, m_DeathNotices[i].Assist.iNameLength);
-	}
-
-	// Icons
 	if (!m_DeathNotices[i].bSuicide)
 	{
+		// Killer
+		if (m_DeathNotices[i].Killer.iEntIndex != 0)
+		{
+			SetColorForNoticePlayer(m_DeathNotices[i].Killer.iTeam);
+			surface()->DrawSetTextFont(g_hFontKillfeed);
+			surface()->DrawPrintText(m_DeathNotices[i].Killer.szName, m_DeathNotices[i].Killer.iNameLength);
+		}
+
+		// Assister
+		if (m_DeathNotices[i].Assist.iEntIndex != 0)
+		{
+			surface()->DrawSetTextColor(COLOR_NEO_WHITE);
+			surface()->DrawPrintText(ASSIST_SEPARATOR, ASSIST_SEPARATOR_LENGTH - 1);
+
+			SetColorForNoticePlayer(m_DeathNotices[i].Assist.iTeam);
+			surface()->DrawSetTextFont(g_hFontKillfeed);
+			surface()->DrawPrintText(m_DeathNotices[i].Assist.szName, m_DeathNotices[i].Assist.iNameLength);
+		}
+
+		// Icons
 		surface()->DrawSetTextFont(g_hFontKillfeed);
 		surface()->DrawPrintText(L" ", 1);
 		surface()->DrawSetTextFont(g_hFontKillfeedIcons);
@@ -502,7 +505,10 @@ void CNEOHud_DeathNotice::DrawPlayerDeath(int i)
 	if (m_DeathNotices[i].Victim.iEntIndex != 0)
 	{
 		surface()->DrawSetTextFont(g_hFontKillfeed);
-		surface()->DrawPrintText(L" ", 1);
+		if (!m_DeathNotices[i].bSuicide)
+		{
+			surface()->DrawPrintText(L" ", 1);
+		}
 		SetColorForNoticePlayer(m_DeathNotices[i].Victim.iTeam);
 		surface()->DrawPrintText(m_DeathNotices[i].Victim.szName, m_DeathNotices[i].Victim.iNameLength);
 	}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Fix suicide with assister display, reverse highlight and non highlight colours

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1230 