### PR TITLE
Show loading screen if unsure what map we're loading into

### DIFF
--- a/src/game/client/neo/ui/neo_loading.cpp
+++ b/src/game/client/neo/ui/neo_loading.cpp
@@ -187,7 +187,7 @@ void CNeoLoading::OnMainLoop(const NeoUI::Mode eMode)
 
 	static bool bStaticInitNeoUI = false;
 	bool bSkipRender = false;
-	if (iStrIdx == m_aStrIdxMap[LOADINGSTATE_LOADING])
+	if (iStrIdx == m_aStrIdxMap[LOADINGSTATE_LOADING] && m_pHostMap)
 	{
 		auto hostMapName = m_pHostMap->GetString();
 		if (Q_stristr(hostMapName, "background_"))

--- a/src/game/client/neo/ui/neo_loading.cpp
+++ b/src/game/client/neo/ui/neo_loading.cpp
@@ -189,18 +189,7 @@ void CNeoLoading::OnMainLoop(const NeoUI::Mode eMode)
 	bool bSkipRender = false;
 	if (iStrIdx == m_aStrIdxMap[LOADINGSTATE_LOADING])
 	{
-		auto hostMapName = engine->GetLevelName();
-		
-		if (V_strlen(hostMapName) == 0 && m_pHostMap)
-		{
-			hostMapName = m_pHostMap->GetString();
-		}
-
-		if (V_strlen(hostMapName) == 0)
-		{
-			bSkipRender = true;
-		}
-
+		auto hostMapName = m_pHostMap->GetString();
 		if (Q_stristr(hostMapName, "background_"))
 		{
 			bSkipRender = true;

--- a/src/game/client/neo/ui/neo_loading.cpp
+++ b/src/game/client/neo/ui/neo_loading.cpp
@@ -187,9 +187,15 @@ void CNeoLoading::OnMainLoop(const NeoUI::Mode eMode)
 
 	static bool bStaticInitNeoUI = false;
 	bool bSkipRender = false;
-	if (iStrIdx == m_aStrIdxMap[LOADINGSTATE_LOADING] && m_pHostMap)
+	if (iStrIdx == m_aStrIdxMap[LOADINGSTATE_LOADING])
 	{
-		auto hostMapName = m_pHostMap->GetString();
+		auto hostMapName = engine->GetLevelName();
+		
+		if (V_strlen(hostMapName) == 0 && m_pHostMap)
+		{
+			hostMapName = m_pHostMap->GetString();
+		}
+
 		if (V_strlen(hostMapName) == 0)
 		{
 			bSkipRender = true;


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

When creating a listen server, the host_map convar gets updated almost immediately with the name of the map we're loading into, if connecting to a dedicated server however this only happens when we're almost finished loading. 

Since the whole reason we're doing this is to stop the loading screen from showing up when loading into a background map, and we should only really be loading into a background map on a listen server, we can assume that if host_map doesn't return a value, that we are connecting to a dedicated server at which point we should be showing a loading screen. In reality we still see the loading screen for a couple frames but that's much better than the current behavior.

As a side note, engine->GetLevelName() will return the map on a dedicated server when connecting quicker than host_map, but it's still quite far into the loading process.

Under the notes section https://developer.valvesoftware.com/wiki/Custom_loading_screen there is mention that some mods were able to obtain this value almost instantly, presumably when connecting to a dedicated server, but the author explains that this is probably impossible without engine access and I'm not sure what mods exactly were able to do this. The linked github repo also uses host_map for near instantaneous access to the map name when connecting to a listen server.

This only applies to using the "connect" command from the console. When looking at dedicated servers in the server browser we can see the map that was loaded when the server list was refreshed, so keeping track of what map we're most likely loading into should be easy if we ever want to extend the loading screen functionality to change the background to an image appropriate to the map we're loading into regardless of whether we're connecting to a listen server or dedicated server.
