### PR TITLE
Cleanup GCC compiler warnings + `VEC_` neo_bot_body overrides

### DIFF
--- a/src/game/client/c_baseanimating.cpp
+++ b/src/game/client/c_baseanimating.cpp
@@ -2181,7 +2181,11 @@ bool C_BaseAnimating::GetAttachment( int number, Vector &origin, QAngle &angles 
 	if ( pData->m_bAnglesComputed == 0 )
 	{
 		MatrixAngles( pData->m_AttachmentToWorld, pData->m_angRotation );
+#ifdef NEO // NEO NOTE (nullsystem): warning: conversion from ‘unsigned int’ to ‘unsigned char:1’ changes value from ‘4294967295’ to ‘1’
+		pData->m_bAnglesComputed = 1;
+#else
 		pData->m_bAnglesComputed = -1;
+#endif
 	}
 	angles = pData->m_angRotation;
 	MatrixPosition( pData->m_AttachmentToWorld, origin );

--- a/src/game/client/c_soundscape.cpp
+++ b/src/game/client/c_soundscape.cpp
@@ -924,7 +924,11 @@ void C_SoundscapeSystem::ProcessPlayRandom( KeyValues *pPlayRandom, const subsou
 		{
 			interval_t atten = ReadInterval( pKey->GetString() );
 			sound.soundlevel.start = ATTN_TO_SNDLVL( atten.start );
+#ifdef NEO // NEO NOTE (nullsystem): -Wdeprecated-enum-float-conversion
+			sound.soundlevel.range = static_cast<float>(ATTN_TO_SNDLVL( atten.start + atten.range )) - sound.soundlevel.start;
+#else
 			sound.soundlevel.range = ATTN_TO_SNDLVL( atten.start + atten.range ) - sound.soundlevel.start;
+#endif
 		}
 		else if ( !Q_strcasecmp( pKey->GetName(), "soundlevel" ) )
 		{

--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -1864,7 +1864,11 @@ ClientShadowHandle_t CClientShadowMgr::CreateFlashlight( const FlashlightState_t
 	// We don't really need a model entity handle for a projective light source, so use an invalid one.
 	static ClientEntityHandle_t invalidHandle = INVALID_CLIENTENTITY_HANDLE;
 
+#ifdef NEO // NEO NOTE (nullsystem): -Wdeprecated-enum-enum-conversion
+	int shadowFlags = static_cast<int>(SHADOW_FLAGS_FLASHLIGHT) | static_cast<int>(SHADOW_FLAGS_LIGHT_WORLD);
+#else
 	int shadowFlags = SHADOW_FLAGS_FLASHLIGHT | SHADOW_FLAGS_LIGHT_WORLD;
+#endif
 	if( lightState.m_bEnableShadows && r_flashlightdepthtexture.GetBool() )
 	{
 		shadowFlags |= SHADOW_FLAGS_USE_DEPTH_TEXTURE;
@@ -1881,7 +1885,11 @@ ClientShadowHandle_t CClientShadowMgr::CreateShadow( ClientEntityHandle_t entity
 {
 	// We don't really need a model entity handle for a projective light source, so use an invalid one.
 	flags &= ~SHADOW_FLAGS_PROJECTED_TEXTURE_TYPE_MASK;
+#ifdef NEO // NEO NOTE (nullsystem): -Wdeprecated-enum-enum-conversion
+	flags |= static_cast<int>(SHADOW_FLAGS_SHADOW) | static_cast<int>(SHADOW_FLAGS_TEXTURE_DIRTY);
+#else
 	flags |= SHADOW_FLAGS_SHADOW | SHADOW_FLAGS_TEXTURE_DIRTY;
+#endif
 	ClientShadowHandle_t shadowHandle = CreateProjectedTexture( entity, flags );
 
 	IClientRenderable *pRenderable = ClientEntityList().GetClientRenderableFromHandle( entity );

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -748,7 +748,7 @@ void CNEOScoreBoard::GetPlayerScoreInfo(int playerIndex, KeyValues *kv)
 	int statusIcon = -1;
 	if (neoTeam == TEAM_JINRAI || neoTeam == TEAM_NSF)
 	{
-		statusIcon = (!SHOW_ENEMY_STATUS && oppositeTeam || g_PR->IsAlive(playerIndex)) ? -1 : m_iDeadIcon;
+		statusIcon = ((!SHOW_ENEMY_STATUS && oppositeTeam) || g_PR->IsAlive(playerIndex)) ? -1 : m_iDeadIcon;
 	}
 	kv->SetInt("status", statusIcon);
 	kv->SetString("class", oppositeTeam ? "" : GetNeoClassName(neoClassIdx));

--- a/src/game/client/smoke_fog_overlay.h
+++ b/src/game/client/smoke_fog_overlay.h
@@ -12,7 +12,9 @@
 
 #include "basetypes.h"
 #include "mathlib/vector.h"
+#ifndef NEO
 #include "smoke_fog_overlay_shared.h"
+#endif
 
 #ifdef NEO
 #define ROTATION_SPEED				0.6

--- a/src/game/server/NextBot/Player/NextBotPlayerBody.cpp
+++ b/src/game/server/NextBot/Player/NextBotPlayerBody.cpp
@@ -9,14 +9,17 @@
 #include "NextBotPlayerBody.h"
 #include "NextBotPlayer.h"
 
-#ifdef NEO // TODO (nullsystem): 2025-02-18 SOURCE SDK 2013 CHECK
-#define VEC_HULL_MIN_SCALED( player )			( g_pGameRules->GetViewVectors()->m_vHullMin * player->GetModelScale() )
-#define VEC_HULL_MAX_SCALED( player )			( g_pGameRules->GetViewVectors()->m_vHullMax * player->GetModelScale() )
-#define VEC_VIEW_SCALED( player )				( g_pGameRules->GetViewVectors()->m_vView * player->GetModelScale() )
+// NEO NOTE (nullsystem): CNEOBotBody will overload the VEC_ usage functions instead
+// and here will use the SDK_ prefix macros to not warn out about redefining VEC_... macros
+// and making it clear it's using what was the base SDK's version not NT;RE's version here
+#ifdef NEO
+#define SDK_VEC_HULL_MIN_SCALED( player )			( g_pGameRules->GetViewVectors()->m_vHullMin * player->GetModelScale() )
+#define SDK_VEC_HULL_MAX_SCALED( player )			( g_pGameRules->GetViewVectors()->m_vHullMax * player->GetModelScale() )
+#define SDK_VEC_VIEW_SCALED( player )				( g_pGameRules->GetViewVectors()->m_vView * player->GetModelScale() )
 
-#define VEC_DUCK_HULL_MIN_SCALED( player )		( g_pGameRules->GetViewVectors()->m_vDuckHullMin * player->GetModelScale() )
-#define VEC_DUCK_HULL_MAX_SCALED( player )		( g_pGameRules->GetViewVectors()->m_vDuckHullMax * player->GetModelScale() )
-#define VEC_DUCK_VIEW_SCALED( player )			( g_pGameRules->GetViewVectors()->m_vDuckView * player->GetModelScale() )
+#define SDK_VEC_DUCK_HULL_MIN_SCALED( player )		( g_pGameRules->GetViewVectors()->m_vDuckHullMin * player->GetModelScale() )
+#define SDK_VEC_DUCK_HULL_MAX_SCALED( player )		( g_pGameRules->GetViewVectors()->m_vDuckHullMax * player->GetModelScale() )
+#define SDK_VEC_DUCK_VIEW_SCALED( player )			( g_pGameRules->GetViewVectors()->m_vDuckView * player->GetModelScale() )
 #endif
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -810,7 +813,11 @@ bool PlayerBody::IsArousal( ArousalType arousal ) const
  */
 float PlayerBody::GetHullWidth( void ) const
 {
+#ifdef NEO
+	return SDK_VEC_HULL_MAX_SCALED( m_player ).x - SDK_VEC_HULL_MIN_SCALED( m_player ).x;
+#else
 	return VEC_HULL_MAX_SCALED( m_player ).x - VEC_HULL_MIN_SCALED( m_player ).x;
+#endif
 }
 
 
@@ -835,7 +842,11 @@ float PlayerBody::GetHullHeight( void ) const
  */
 float PlayerBody::GetStandHullHeight( void ) const
 {
+#ifdef NEO
+	return SDK_VEC_HULL_MAX_SCALED( m_player ).z - SDK_VEC_HULL_MIN_SCALED( m_player ).z;
+#else
 	return VEC_HULL_MAX_SCALED( m_player ).z - VEC_HULL_MIN_SCALED( m_player ).z;
+#endif
 }
 
 
@@ -845,7 +856,11 @@ float PlayerBody::GetStandHullHeight( void ) const
  */
 float PlayerBody::GetCrouchHullHeight( void ) const
 {
+#ifdef NEO
+	return SDK_VEC_DUCK_HULL_MAX_SCALED( m_player ).z - SDK_VEC_DUCK_HULL_MIN_SCALED( m_player ).z;
+#else
 	return VEC_DUCK_HULL_MAX_SCALED( m_player ).z - VEC_DUCK_HULL_MIN_SCALED( m_player ).z;
+#endif
 }
 
 
@@ -855,6 +870,16 @@ float PlayerBody::GetCrouchHullHeight( void ) const
  */
 const Vector &PlayerBody::GetHullMins( void ) const
 {
+#ifdef NEO
+	if ( m_posture == CROUCH )
+	{
+		m_hullMins = SDK_VEC_DUCK_HULL_MIN_SCALED( m_player );
+	}
+	else
+	{
+		m_hullMins = SDK_VEC_HULL_MIN_SCALED( m_player );
+	}
+#else
 	if ( m_posture == CROUCH )
 	{
 		m_hullMins = VEC_DUCK_HULL_MIN_SCALED( m_player );
@@ -863,6 +888,7 @@ const Vector &PlayerBody::GetHullMins( void ) const
 	{
 		m_hullMins = VEC_HULL_MIN_SCALED( m_player );
 	}
+#endif
 	
 	return m_hullMins;
 }
@@ -874,6 +900,16 @@ const Vector &PlayerBody::GetHullMins( void ) const
  */
 const Vector &PlayerBody::GetHullMaxs( void ) const
 {
+#ifdef NEO
+	if ( m_posture == CROUCH )
+	{
+		m_hullMaxs = SDK_VEC_DUCK_HULL_MAX_SCALED( m_player );
+	}
+	else
+	{
+		m_hullMaxs = SDK_VEC_HULL_MAX_SCALED( m_player );
+	}
+#else
 	if ( m_posture == CROUCH )
 	{
 		m_hullMaxs = VEC_DUCK_HULL_MAX_SCALED( m_player );
@@ -882,6 +918,7 @@ const Vector &PlayerBody::GetHullMaxs( void ) const
 	{
 		m_hullMaxs = VEC_HULL_MAX_SCALED( m_player );
 	}
+#endif
 
 	return m_hullMaxs;	
 }

--- a/src/game/server/NextBot/Player/NextBotPlayerBody.h
+++ b/src/game/server/NextBot/Player/NextBotPlayerBody.h
@@ -8,6 +8,10 @@
 
 #include "NextBotBodyInterface.h"
 
+#ifdef NEO
+class CNEOBotBody;
+#endif
+
 
 //----------------------------------------------------------------------------------------------------------------
 /**
@@ -115,6 +119,9 @@ public:
 
 	CBaseEntity *GetLookAtSubject( void ) const;
 private:
+#ifdef NEO
+	friend class CNEOBotBody;
+#endif
 	CBasePlayer *m_player;
 	
 	PostureType m_posture;

--- a/src/game/server/baseflex.cpp
+++ b/src/game/server/baseflex.cpp
@@ -2556,7 +2556,11 @@ void CFlexCycler::Think( void )
 			for ( LocalFlexController_t i = LocalFlexController_t(0); i < GetNumFlexControllers(); i++ )
 			{
 				// Throw a differently offset sine wave on all of the flex controllers
+#ifdef NEO // NEO NOTE (nullsystem): -Wdeprecated-enum-float-conversion]
+				float fFlexTime = static_cast<float>(i) * (1.0f / static_cast<float>(GetNumFlexControllers())) + gpGlobals->curtime;
+#else
 				float fFlexTime = i * (1.0f / (float)GetNumFlexControllers()) + gpGlobals->curtime;
+#endif
 				m_flextarget[i] = sinf( fFlexTime ) * 0.5f + 0.5f;
 				SetFlexWeight( i, m_flextarget[i] );
 			}
@@ -2620,7 +2624,11 @@ void CFlexCycler::Think( void )
 		else if (m_flextime < gpGlobals->curtime)
 		{
 			// m_flextime = gpGlobals->curtime + 1.0; // RandomFloat( 0.1, 0.5 );
+#ifdef NEO // NEO NOTE (nullsystem): -Wdeprecated-enum-float-conversion]
+			m_flextime = gpGlobals->curtime + random->RandomFloat( 0.3, 0.5 ) * (30.0 / static_cast<float>(GetNumFlexControllers()));
+#else
 			m_flextime = gpGlobals->curtime + random->RandomFloat( 0.3, 0.5 ) * (30.0 / GetNumFlexControllers());
+#endif
 			m_flexnum = (LocalFlexController_t)random->RandomInt( 0, GetNumFlexControllers() - 1 );
 
 			// m_flexnum = (pflex->num + 1) % r_psubmodel->numflexes;

--- a/src/game/server/genericactor.cpp
+++ b/src/game/server/genericactor.cpp
@@ -387,7 +387,11 @@ void CFlextalkActor::ProcessSceneEvents( void )
 		} 
 		else if (m_flextime < gpGlobals->curtime)
 		{
+#ifdef NEO // NEO NOTE (nullsystem): -Wdeprecated-enum-float-conversion]
+			m_flextime = gpGlobals->curtime + random->RandomFloat( 0.3, 0.5 ) * (30.0 / static_cast<float>(GetNumFlexControllers()));
+#else
 			m_flextime = gpGlobals->curtime + random->RandomFloat( 0.3, 0.5 ) * (30.0 / GetNumFlexControllers());
+#endif
 			m_flexnum = (LocalFlexController_t)random->RandomInt( 0, GetNumFlexControllers() - 1 );
 
 			if (m_flextarget[m_flexnum] == 1)

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -825,7 +825,7 @@ void CNEOBot::FireGameEvent(IGameEvent* event)
 }
 
 extern ConVar nb_update_frequency;
-inline void CNEOBot::Update()
+void CNEOBot::Update()
 {
 	if (!TheNavMesh->IsLoaded())
 	{

--- a/src/game/server/neo/bot/neo_bot.h
+++ b/src/game/server/neo/bot/neo_bot.h
@@ -78,7 +78,7 @@ public:
 
 	virtual void		Spawn();
 	virtual void		FireGameEvent(IGameEvent* event);
-	inline void			Update() OVERRIDE;
+	void				Update() override;
 	virtual void		Event_Killed(const CTakeDamageInfo& info);
 	virtual void		PhysicsSimulate(void);
 	virtual void		Touch(CBaseEntity* pOther);

--- a/src/game/server/neo/bot/neo_bot_body.cpp
+++ b/src/game/server/neo/bot/neo_bot_body.cpp
@@ -8,7 +8,7 @@
 // Return how often we should sample our target's position and 
 // velocity to update our aim tracking, to allow realistic slop in tracking
 //
-float CNEOBotBody::GetHeadAimTrackingInterval( void ) const
+float CNEOBotBody::GetHeadAimTrackingInterval() const
 {
 	CNEOBot *me = (CNEOBot *)GetBot();
 
@@ -30,17 +30,73 @@ float CNEOBotBody::GetHeadAimTrackingInterval( void ) const
 	return 0.0f;
 }
 
-float CNEOBotBody::GetCloakPower( void ) const
+CNEO_Player *CNEOBotBody::NEOPlayerEnt() const
 {
-	auto me = ToNEOPlayer(GetBot()->GetEntity());
+	return ToNEOPlayer(GetBot()->GetEntity());
+}
+
+float CNEOBotBody::GetCloakPower() const
+{
+	auto me = NEOPlayerEnt();
 	return me ? me->CloakPower_Get() : 0.0f;
 }
 
-bool CNEOBotBody::IsCloakEnabled( void ) const
+bool CNEOBotBody::IsCloakEnabled() const
 {
 	// used for determining if bot needs to press thermoptic button
 	// we are only interested in the toggle state not visibility in this context
 	// so do not use GetBotPerceivedCloakState() here
-	auto me = ToNEOPlayer(GetBot()->GetEntity());
+	auto me = NEOPlayerEnt();
 	return me && me->GetInThermOpticCamo();
 }
+
+float CNEOBotBody::GetHullWidth() const
+{
+	const auto *neoPlayer = NEOPlayerEnt();
+	return VEC_HULL_MAX_SCALED(neoPlayer).x - VEC_HULL_MIN_SCALED(neoPlayer).x;
+}
+
+float CNEOBotBody::GetStandHullHeight() const
+{
+	const auto *neoPlayer = NEOPlayerEnt();
+	return VEC_HULL_MAX_SCALED(neoPlayer).z - VEC_HULL_MIN_SCALED(neoPlayer).z;
+}
+
+float CNEOBotBody::GetCrouchHullHeight() const
+{
+	const auto *neoPlayer = NEOPlayerEnt();
+	return VEC_DUCK_HULL_MAX_SCALED(neoPlayer).z - VEC_DUCK_HULL_MIN_SCALED(neoPlayer).z;
+}
+
+const Vector &CNEOBotBody::GetHullMins() const
+{
+	const auto *neoPlayer = NEOPlayerEnt();
+
+	if ( m_posture == CROUCH )
+	{
+		m_hullMins = VEC_DUCK_HULL_MIN_SCALED(neoPlayer);
+	}
+	else
+	{
+		m_hullMins = VEC_HULL_MIN_SCALED(neoPlayer);
+	}
+
+	return m_hullMins;
+}
+
+const Vector &CNEOBotBody::GetHullMaxs() const
+{
+	const auto *neoPlayer = NEOPlayerEnt();
+
+	if ( m_posture == CROUCH )
+	{
+		m_hullMaxs = VEC_DUCK_HULL_MAX_SCALED(neoPlayer);
+	}
+	else
+	{
+		m_hullMaxs = VEC_HULL_MAX_SCALED(neoPlayer);
+	}
+
+	return m_hullMaxs;	
+}
+

--- a/src/game/server/neo/bot/neo_bot_body.h
+++ b/src/game/server/neo/bot/neo_bot_body.h
@@ -2,6 +2,8 @@
 
 #include "NextBot/Player/NextBotPlayerBody.h"
 
+class CNEO_Player;
+
 //----------------------------------------------------------------------------
 class CNEOBotBody : public PlayerBody
 {
@@ -12,8 +14,17 @@ public:
 
 	virtual ~CNEOBotBody() { }
 
-	virtual float GetHeadAimTrackingInterval( void ) const;			// return how often we should sample our target's position and velocity to update our aim tracking, to allow realistic slop in tracking
-	float GetCloakPower( void ) const;          		    		// return available thermoptic charge
-	bool IsCloakEnabled( void ) const;                  			// return if thermoptic is enabled
+	CNEO_Player *NEOPlayerEnt() const;
+
+	float GetHeadAimTrackingInterval() const override;			// return how often we should sample our target's position and velocity to update our aim tracking, to allow realistic slop in tracking
+	float GetCloakPower() const;          		    		// return available thermoptic charge
+	bool IsCloakEnabled() const;                  			// return if thermoptic is enabled
+
+	// NEO NOTE (nullsystem): These are override to use the NT;RE's VEC_... macros
+	float GetHullWidth() const override;
+	float GetStandHullHeight() const override;
+	float GetCrouchHullHeight() const override;
+	const Vector &GetHullMins() const override;
+	const Vector &GetHullMaxs() const override;
 };
 

--- a/src/game/shared/neo/neo_predicted_viewmodel_muzzleflash.cpp
+++ b/src/game/shared/neo/neo_predicted_viewmodel_muzzleflash.cpp
@@ -89,7 +89,7 @@ void CNEOPredictedViewModelMuzzleFlash::Spawn(void)
 #ifdef CLIENT_DLL
 int CNEOPredictedViewModelMuzzleFlash::DrawModel(int flags)
 {
-	if (!m_bActive || m_flTimeSwitchOffMuzzleFlash <= gpGlobals->curtime && m_bActive)
+	if (!m_bActive || (m_flTimeSwitchOffMuzzleFlash <= gpGlobals->curtime && m_bActive))
 	{
 		return -1;
 	}

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -1208,7 +1208,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 	bool inThermalVision = pTargetPlayer->IsInVision() && pTargetPlayer->GetClass() == NEO_CLASS_SUPPORT;
 	int ret = 0;
 	
-	if (inThermalVision && (!pOwner || pOwner && !pOwner->IsCloaked()))
+	if (inThermalVision && (!pOwner || (pOwner && !pOwner->IsCloaked())))
 	{
 		IMaterial* pass = materials->FindMaterial("dev/thermal_weapon_model", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
@@ -1217,7 +1217,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 		return ret;
 	}
 
-	if (pOwner && pOwner->IsCloaked() && !inThermalVision)
+	if ((pOwner && pOwner->IsCloaked()) && !inThermalVision)
 	{
 		mat_neo_toc_test.SetValue(pOwner->GetCloakFactor());
 		IMaterial* pass = materials->FindMaterial("models/player/toc", TEXTURE_GROUP_CLIENT_EFFECTS);

--- a/src/public/datamap.h
+++ b/src/public/datamap.h
@@ -132,7 +132,11 @@ DECLARE_FIELD_SIZE( FIELD_MATERIALINDEX,	sizeof(int) )
 // legit offsetof from the C headers, so we'll use the old impl here to avoid exposing temptation to others
 #define _hacky_datamap_offsetof(s,m)	((size_t)&(((s *)0)->m))
 
+#ifdef NEO // NEO NOTE (nullsystem): warning: narrowing conversion of ... from 'int' to 'size_t'
+#define _FIELD(name,fieldtype,count,flags,mapname,tolerance)		{ fieldtype, #name, { (size_t)_hacky_datamap_offsetof(classNameTypedef, name), 0 }, count, flags, mapname, NULL, NULL, NULL, sizeof( ((classNameTypedef *)0)->name ), NULL, 0, tolerance }
+#else
 #define _FIELD(name,fieldtype,count,flags,mapname,tolerance)		{ fieldtype, #name, { (int)_hacky_datamap_offsetof(classNameTypedef, name), 0 }, count, flags, mapname, NULL, NULL, NULL, sizeof( ((classNameTypedef *)0)->name ), NULL, 0, tolerance }
+#endif
 #define DEFINE_FIELD_NULL	{ FIELD_VOID,0, {0,0},0,0,0,0,0,0}
 #define DEFINE_FIELD(name,fieldtype)			_FIELD(name, fieldtype, 1,  FTYPEDESC_SAVE, NULL, 0 )
 #define DEFINE_KEYFIELD(name,fieldtype, mapname) _FIELD(name, fieldtype, 1,  FTYPEDESC_KEY | FTYPEDESC_SAVE, mapname, 0 )

--- a/src/public/vgui_controls/PropertySheet.h
+++ b/src/public/vgui_controls/PropertySheet.h
@@ -64,8 +64,13 @@ public:
 
 	// focus handling - passed on to current active page
 	virtual void RequestFocus(int direction = 0);
+#ifdef NEO // NEO NOTE (nullsystem): warning: converting to non-pointer type ‘vgui::VPANEL’ {aka ‘long long unsigned int’} from NULL
+	virtual bool RequestFocusPrev(VPANEL panel = 0);
+	virtual bool RequestFocusNext(VPANEL panel = 0);
+#else
 	virtual bool RequestFocusPrev(VPANEL panel = NULL);
 	virtual bool RequestFocusNext(VPANEL panel = NULL);
+#endif
 
 	// returns the ith panel 
 	virtual Panel *GetPage(int i);


### PR DESCRIPTION



<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Cleanup compiler warnings that showsup in GCC
* neo_bot_body override the `VEC_` usage methods and fix macro redef warning for NextBodyPlayerBody and make then use `SDK_VEC_` prefix macros instead

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Gentoo/GCC 14

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1312

