### PR TITLE
gitignore chapterbackgrounds.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ out
 
 # Selected Background
 /game/neo/scripts/ChapterBackgrounds.txt
+/game/neo/scripts/chapterbackgrounds.txt
 
 # Object files
 *.o


### PR DESCRIPTION
Linux have case-sensitive filesystem, it needs exact match