### PR TITLE
Use class name for killer info, unify name for all neo_npc_targetsystem

### DIFF
--- a/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
+++ b/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
@@ -587,10 +587,9 @@ static void __MsgFunc_DamageInfo(bf_read& msg)
 		g_neoKDmgInfos.killerInfo.wszKilledWith[0] = L'\0';
 		if (foundKilledBy)
 		{
-			const char *pszMap = IGameSystem::MapName();
-			if (V_strcmp(killedBy, "tank_targetsystem") == 0 && V_strcmp(pszMap, "ntre_rogue_ctg") == 0)
+			if (V_strcmp(killedBy, "neo_npc_targetsystem") == 0)
 			{
-				V_wcscpy_safe(g_neoKDmgInfos.killerInfo.wszKilledWith, L"Jeff");
+				V_wcscpy_safe(g_neoKDmgInfos.killerInfo.wszKilledWith, L"Turret");
 			}
 		}
 	}

--- a/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
+++ b/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
@@ -587,7 +587,7 @@ static void __MsgFunc_DamageInfo(bf_read& msg)
 		g_neoKDmgInfos.killerInfo.wszKilledWith[0] = L'\0';
 		if (foundKilledBy && V_strcmp(killedBy, "neo_npc_targetsystem") == 0)
 		{
-			const char* pszMap = IGameSystem::MapName();
+			const char *pszMap = IGameSystem::MapName();
 			if (V_strcmp(pszMap, "ntre_rogue_ctg") == 0)
 			{
 				V_wcscpy_safe(g_neoKDmgInfos.killerInfo.wszKilledWith, L"184-J IFV");

--- a/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
+++ b/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
@@ -585,9 +585,14 @@ static void __MsgFunc_DamageInfo(bf_read& msg)
 	{
 		g_neoKDmgInfos.killerInfo.iEntIndex = NEO_ENVIRON_KILLED;
 		g_neoKDmgInfos.killerInfo.wszKilledWith[0] = L'\0';
-		if (foundKilledBy)
+		if (foundKilledBy && V_strcmp(killedBy, "neo_npc_targetsystem") == 0)
 		{
-			if (V_strcmp(killedBy, "neo_npc_targetsystem") == 0)
+			const char* pszMap = IGameSystem::MapName();
+			if (V_strcmp(pszMap, "ntre_rogue_ctg") == 0)
+			{
+				V_wcscpy_safe(g_neoKDmgInfos.killerInfo.wszKilledWith, L"184-J IFV");
+			}
+			else
 			{
 				V_wcscpy_safe(g_neoKDmgInfos.killerInfo.wszKilledWith, L"Turret");
 			}

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1820,7 +1820,7 @@ void CNEO_Player::StartShowDmgStats(const CTakeDamageInfo *info)
 				}
 				else
 				{
-					killedWithName = killedWithInflictor->GetDebugName();
+					killedWithName = killedWithInflictor->GetClassname();
 				}
 			}
 			if (!Q_strcmp(killedWithName, "neo_grenade_frag")) { killedWithName = "Frag Grenade"; }
@@ -1830,7 +1830,7 @@ void CNEO_Player::StartShowDmgStats(const CTakeDamageInfo *info)
 		{
 			// Set it to NEO_ENVIRON_KILLED to indicate the map killed the player
 			attackerIdx = NEO_ENVIRON_KILLED;
-			killedWithName = killedWithInflictor->GetDebugName();
+			killedWithName = killedWithInflictor->GetClassname();
 		}
 		WRITE_SHORT(attackerIdx);
 		WRITE_STRING(killedWithName);


### PR DESCRIPTION
## Description
`GetClassname` instead of `GetDebugName` as mappers can set the targetname to pretty much anything

## Toolchain
- Windows MSVC VS2022
