### PR TITLE
Hide squad list and killfeed if the scoreboard is showing

### DIFF
--- a/src/game/client/neo/ui/neo_hud_deathnotice.cpp
+++ b/src/game/client/neo/ui/neo_hud_deathnotice.cpp
@@ -23,6 +23,7 @@
 #include "spectatorgui.h"
 #include "takedamageinfo.h"
 #include "c_neo_killer_damage_infos.h"
+#include "neo_scoreboard.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -224,7 +225,7 @@ void CNEOHud_DeathNotice::VidInit( void )
 //-----------------------------------------------------------------------------
 bool CNEOHud_DeathNotice::ShouldDraw( void )
 {
-	return ( CHudElement::ShouldDraw() && ( m_DeathNotices.Count() ) );
+	return ( CHudElement::ShouldDraw() && ( m_DeathNotices.Count() ) && !g_pNeoScoreBoard->IsVisible() );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/client/neo/ui/neo_hud_deathnotice.cpp
+++ b/src/game/client/neo/ui/neo_hud_deathnotice.cpp
@@ -29,6 +29,7 @@
 #include "tier0/memdbgon.h"
 
 static ConVar hud_deathnotice_time( "hud_deathnotice_time", "20", 0 );
+extern ConVar cl_neo_hud_scoreboard_hide_others;
 
 // Player entries in a death notice
 struct DeathNoticePlayer
@@ -225,7 +226,7 @@ void CNEOHud_DeathNotice::VidInit( void )
 //-----------------------------------------------------------------------------
 bool CNEOHud_DeathNotice::ShouldDraw( void )
 {
-	return ( CHudElement::ShouldDraw() && ( m_DeathNotices.Count() ) && !g_pNeoScoreBoard->IsVisible() );
+	return ( CHudElement::ShouldDraw() && ( m_DeathNotices.Count() ) && ( !cl_neo_hud_scoreboard_hide_others.GetBool() || !g_pNeoScoreBoard->IsVisible() ) );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -602,7 +602,7 @@ void CNEOHud_RoundState::DrawNeoHudElement()
 			}
 		}
 	}
-	else
+	else if (!g_pNeoScoreBoard->IsVisible())
 	{
 		DrawPlayerList();
 	}

--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -36,6 +36,7 @@ extern ConVar sv_neo_dm_win_xp;
 extern ConVar cl_neo_streamermode;
 extern ConVar snd_victory_volume;
 extern ConVar sv_neo_readyup_countdown;
+extern ConVar cl_neo_hud_scoreboard_hide_others;
 
 namespace {
 constexpr int Y_POS = 0;
@@ -602,7 +603,7 @@ void CNEOHud_RoundState::DrawNeoHudElement()
 			}
 		}
 	}
-	else if (!g_pNeoScoreBoard->IsVisible())
+	else if (!cl_neo_hud_scoreboard_hide_others.GetBool() || !g_pNeoScoreBoard->IsVisible())
 	{
 		DrawPlayerList();
 	}

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -47,6 +47,7 @@ using namespace vgui;
 
 #define SHOW_ENEMY_STATUS true
 
+ConVar cl_neo_hud_scoreboard_hide_others("cl_neo_hud_scoreboard_hide_others", "1", FCVAR_ARCHIVE, "Hide some other HUD elements when the scoreboard is displayed to prevent overlap", true, 0.0, true, 1.0);
 ConVar neo_show_scoreboard_avatars("neo_show_scoreboard_avatars", "1", FCVAR_ARCHIVE, "Show avatars on scoreboard.", true, 0.0, true, 1.0 );
 extern ConVar cl_neo_streamermode;
 


### PR DESCRIPTION
## Description
This is to prevent readability issues on the scoreboard.
Much of the information provided by these two HUD elements is on the scoreboard, and the scoreboard can be quickly turned on/off as it has to be held open

## Toolchain
- Windows MSVC VS2022
