### PR TITLE
Option to make the round info and scoreboard HUD not swap team sides

### DIFF
--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -30,7 +30,7 @@ DECLARE_NAMED_HUDELEMENT(CNEOHud_RoundState, NRoundState);
 
 NEO_HUD_ELEMENT_DECLARE_FREQ_CVAR(RoundState, 0.1)
 
-ConVar cl_neo_round_hud_swap_sides("cl_neo_round_hud_swap_sides", "0", FCVAR_ARCHIVE, "Make the team of the local player always appear on the left side of the round info", true, 0.0, true, 1.0);
+ConVar cl_neo_round_hud_swap_sides("cl_neo_round_hud_swap_sides", "1", FCVAR_ARCHIVE, "Make the team of the local player always appear on the left side of the round info", true, 0.0, true, 1.0);
 ConVar cl_neo_squad_hud_original("cl_neo_squad_hud_original", "1", FCVAR_ARCHIVE, "Use the old squad HUD", true, 0.0, true, 1.0);
 ConVar cl_neo_squad_hud_star_scale("cl_neo_squad_hud_star_scale", "0", FCVAR_ARCHIVE, "Scaling to apply from 1080p, 0 disables scaling");
 extern ConVar sv_neo_dm_win_xp;

--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -30,12 +30,10 @@ DECLARE_NAMED_HUDELEMENT(CNEOHud_RoundState, NRoundState);
 
 NEO_HUD_ELEMENT_DECLARE_FREQ_CVAR(RoundState, 0.1)
 
-static void teamSwapSidesCallback(IConVar* var, const char* pOldValue, float flOldValue)
-{
-	g_pNeoScoreBoard->UpdateTeamColumnsPosition(GetLocalPlayerTeam());
-}
-
-ConVar cl_neo_hud_team_swap_sides("cl_neo_hud_team_swap_sides", "1", FCVAR_ARCHIVE, "Make the team of the local player always appear on the left side of the round info and scoreboard", true, 0.0, true, 1.0, teamSwapSidesCallback);
+ConVar cl_neo_hud_team_swap_sides("cl_neo_hud_team_swap_sides", "1", FCVAR_ARCHIVE, "Make the team of the local player always appear on the left side of the round info and scoreboard", true, 0.0, true, 1.0,
+	[]([[maybe_unused]] IConVar* var, [[maybe_unused]] const char* pOldValue, [[maybe_unused]] float flOldValue) {
+		g_pNeoScoreBoard->UpdateTeamColumnsPosition(GetLocalPlayerTeam());
+	});
 ConVar cl_neo_squad_hud_original("cl_neo_squad_hud_original", "1", FCVAR_ARCHIVE, "Use the old squad HUD", true, 0.0, true, 1.0);
 ConVar cl_neo_squad_hud_star_scale("cl_neo_squad_hud_star_scale", "0", FCVAR_ARCHIVE, "Scaling to apply from 1080p, 0 disables scaling");
 extern ConVar sv_neo_dm_win_xp;

--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -35,7 +35,7 @@ static void teamSwapSidesCallback(IConVar* var, const char* pOldValue, float flO
 	g_pNeoScoreBoard->UpdateTeamColumnsPosition(GetLocalPlayerTeam());
 }
 
-ConVar cl_neo_hud_team_swap_sides("cl_neo_hud_team_swap_sides", "1", FCVAR_ARCHIVE, "Make the team of the local player always appear on the left side of the round info", true, 0.0, true, 1.0, teamSwapSidesCallback);
+ConVar cl_neo_hud_team_swap_sides("cl_neo_hud_team_swap_sides", "1", FCVAR_ARCHIVE, "Make the team of the local player always appear on the left side of the round info and scoreboard", true, 0.0, true, 1.0, teamSwapSidesCallback);
 ConVar cl_neo_squad_hud_original("cl_neo_squad_hud_original", "1", FCVAR_ARCHIVE, "Use the old squad HUD", true, 0.0, true, 1.0);
 ConVar cl_neo_squad_hud_star_scale("cl_neo_squad_hud_star_scale", "0", FCVAR_ARCHIVE, "Scaling to apply from 1080p, 0 disables scaling");
 extern ConVar sv_neo_dm_win_xp;

--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -30,6 +30,7 @@ DECLARE_NAMED_HUDELEMENT(CNEOHud_RoundState, NRoundState);
 
 NEO_HUD_ELEMENT_DECLARE_FREQ_CVAR(RoundState, 0.1)
 
+ConVar cl_neo_round_hud_swap_sides("cl_neo_round_hud_swap_sides", "0", FCVAR_ARCHIVE, "Make the team of the local player always appear on the left side of the round info", true, 0.0, true, 1.0);
 ConVar cl_neo_squad_hud_original("cl_neo_squad_hud_original", "1", FCVAR_ARCHIVE, "Use the old squad HUD", true, 0.0, true, 1.0);
 ConVar cl_neo_squad_hud_star_scale("cl_neo_squad_hud_star_scale", "0", FCVAR_ARCHIVE, "Scaling to apply from 1080p, 0 disables scaling");
 extern ConVar sv_neo_dm_win_xp;
@@ -294,7 +295,7 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	const int localPlayerTeam = GetLocalPlayerTeam();
 	if (NEORules()->IsTeamplay())
 	{
-		if (localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF) {
+		if (cl_neo_round_hud_swap_sides.GetBool() && (localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF)) {
 			V_snwprintf(m_wszLeftTeamScore, 3, L"%i", GetGlobalTeam(localPlayerTeam)->GetRoundsWon());
 			V_snwprintf(m_wszRightTeamScore, 3, L"%i", GetGlobalTeam(NEORules()->GetOpposingTeam(localPlayerTeam))->GetRoundsWon());
 		}
@@ -324,7 +325,7 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	}
 	else if (NEORules()->GetGameType() == NEO_GAME_TYPE_TDM)
 	{
-		if (localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF) {
+		if (cl_neo_round_hud_swap_sides.GetBool() && (localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF)) {
 			V_sprintf_safe(szPlayersAliveANSI, "%i:%i", GetGlobalTeam(localPlayerTeam)->Get_Score(), GetGlobalTeam(NEORules()->GetOpposingTeam(localPlayerTeam))->Get_Score());
 		}
 		else {
@@ -456,8 +457,9 @@ void CNEOHud_RoundState::DrawNeoHudElement()
 	const int localPlayerIndex = GetLocalPlayerIndex();
 	const bool localPlayerSpecOrNoTeam = !NEORules()->IsTeamplay() || !(localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF);
 
-	const int leftTeam = localPlayerSpecOrNoTeam ? TEAM_JINRAI : localPlayerTeam;
-	const int rightTeam = (leftTeam == TEAM_JINRAI) ? TEAM_NSF : TEAM_JINRAI;
+	bool swapTeamSides = cl_neo_round_hud_swap_sides.GetBool();
+	const int leftTeam = swapTeamSides ? (localPlayerSpecOrNoTeam ? TEAM_JINRAI : localPlayerTeam) : TEAM_JINRAI;
+	const int rightTeam = swapTeamSides ? ((leftTeam == TEAM_JINRAI) ? TEAM_NSF : TEAM_JINRAI) : TEAM_NSF;
 	const auto leftTeamInfo = m_teamLogoColors[leftTeam];
 	const auto rightTeamInfo = m_teamLogoColors[rightTeam];
 
@@ -616,7 +618,7 @@ void CNEOHud_RoundState::DrawPlayerList()
 		const int localPlayerTeam = GetLocalPlayerTeam();
 		const int localPlayerIndex = GetLocalPlayerIndex();
 		const bool localPlayerSpec = !(localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF);
-		const int leftTeam = localPlayerSpec ? TEAM_JINRAI : localPlayerTeam;
+		const int leftTeam = cl_neo_round_hud_swap_sides.GetBool() ? (localPlayerSpec ? TEAM_JINRAI : localPlayerTeam) : TEAM_JINRAI;
 
 		if (localPlayerSpec)
 		{

--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -30,7 +30,12 @@ DECLARE_NAMED_HUDELEMENT(CNEOHud_RoundState, NRoundState);
 
 NEO_HUD_ELEMENT_DECLARE_FREQ_CVAR(RoundState, 0.1)
 
-ConVar cl_neo_round_hud_swap_sides("cl_neo_round_hud_swap_sides", "1", FCVAR_ARCHIVE, "Make the team of the local player always appear on the left side of the round info", true, 0.0, true, 1.0);
+static void teamSwapSidesCallback(IConVar* var, const char* pOldValue, float flOldValue)
+{
+	g_pNeoScoreBoard->UpdateTeamColumnsPosition(GetLocalPlayerTeam());
+}
+
+ConVar cl_neo_hud_team_swap_sides("cl_neo_hud_team_swap_sides", "1", FCVAR_ARCHIVE, "Make the team of the local player always appear on the left side of the round info", true, 0.0, true, 1.0, teamSwapSidesCallback);
 ConVar cl_neo_squad_hud_original("cl_neo_squad_hud_original", "1", FCVAR_ARCHIVE, "Use the old squad HUD", true, 0.0, true, 1.0);
 ConVar cl_neo_squad_hud_star_scale("cl_neo_squad_hud_star_scale", "0", FCVAR_ARCHIVE, "Scaling to apply from 1080p, 0 disables scaling");
 extern ConVar sv_neo_dm_win_xp;
@@ -295,7 +300,7 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	const int localPlayerTeam = GetLocalPlayerTeam();
 	if (NEORules()->IsTeamplay())
 	{
-		if (cl_neo_round_hud_swap_sides.GetBool() && (localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF)) {
+		if (cl_neo_hud_team_swap_sides.GetBool() && (localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF)) {
 			V_snwprintf(m_wszLeftTeamScore, 3, L"%i", GetGlobalTeam(localPlayerTeam)->GetRoundsWon());
 			V_snwprintf(m_wszRightTeamScore, 3, L"%i", GetGlobalTeam(NEORules()->GetOpposingTeam(localPlayerTeam))->GetRoundsWon());
 		}
@@ -325,7 +330,7 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	}
 	else if (NEORules()->GetGameType() == NEO_GAME_TYPE_TDM)
 	{
-		if (cl_neo_round_hud_swap_sides.GetBool() && (localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF)) {
+		if (cl_neo_hud_team_swap_sides.GetBool() && (localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF)) {
 			V_sprintf_safe(szPlayersAliveANSI, "%i:%i", GetGlobalTeam(localPlayerTeam)->Get_Score(), GetGlobalTeam(NEORules()->GetOpposingTeam(localPlayerTeam))->Get_Score());
 		}
 		else {
@@ -457,7 +462,7 @@ void CNEOHud_RoundState::DrawNeoHudElement()
 	const int localPlayerIndex = GetLocalPlayerIndex();
 	const bool localPlayerSpecOrNoTeam = !NEORules()->IsTeamplay() || !(localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF);
 
-	bool swapTeamSides = cl_neo_round_hud_swap_sides.GetBool();
+	bool swapTeamSides = cl_neo_hud_team_swap_sides.GetBool();
 	const int leftTeam = swapTeamSides ? (localPlayerSpecOrNoTeam ? TEAM_JINRAI : localPlayerTeam) : TEAM_JINRAI;
 	const int rightTeam = swapTeamSides ? ((leftTeam == TEAM_JINRAI) ? TEAM_NSF : TEAM_JINRAI) : TEAM_NSF;
 	const auto leftTeamInfo = m_teamLogoColors[leftTeam];
@@ -618,7 +623,7 @@ void CNEOHud_RoundState::DrawPlayerList()
 		const int localPlayerTeam = GetLocalPlayerTeam();
 		const int localPlayerIndex = GetLocalPlayerIndex();
 		const bool localPlayerSpec = !(localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF);
-		const int leftTeam = cl_neo_round_hud_swap_sides.GetBool() ? (localPlayerSpec ? TEAM_JINRAI : localPlayerTeam) : TEAM_JINRAI;
+		const int leftTeam = cl_neo_hud_team_swap_sides.GetBool() ? (localPlayerSpec ? TEAM_JINRAI : localPlayerTeam) : TEAM_JINRAI;
 
 		if (localPlayerSpec)
 		{

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -235,6 +235,19 @@ void CNEOScoreBoard::PostApplySchemeSettings( vgui::IScheme *pScheme )
 
 	// light up scoreboard a bit
 	SetBgColor( Color( 0,0,0,0) );
+
+	// What happens if PostApplySchemeSettings runs the instant the local player's team changes?
+	if (GetLocalPlayerTeam() == TEAM_NSF)
+	{
+		m_pJinraiPlayerList->GetPos(m_iRightTeamXPos, m_iRightTeamYPos);
+		m_pNSFPlayerList->GetPos(m_iLeftTeamXPos, m_iLeftTeamYPos);
+	}
+	else
+	{
+		m_pJinraiPlayerList->GetPos(m_iLeftTeamXPos, m_iLeftTeamYPos);
+		m_pNSFPlayerList->GetPos(m_iRightTeamXPos, m_iRightTeamYPos);
+	}
+	UpdateTeamColumnsPosition(GetLocalPlayerTeam());
 }
 
 //-----------------------------------------------------------------------------
@@ -330,6 +343,10 @@ void CNEOScoreBoard::FireGameEvent( IGameEvent *event )
 		if (pPlayer)
 		{
 			UpdatePlayerAvatar(pPlayer->index, nullptr);
+			if (GetLocalPlayerIndex() == pPlayer->entindex())
+			{
+				UpdateTeamColumnsPosition(event->GetInt("team"));
+			}
 		}
 	}
 
@@ -858,4 +875,18 @@ void CNEOScoreBoard::MoveToCenterOfScreen()
 	int wx, wy, ww, wt;
 	surface()->GetWorkspaceBounds(wx, wy, ww, wt);
 	SetPos((ww - GetWide()) / 2, (wt - GetTall()) / 2);
+}
+
+void CNEOScoreBoard::UpdateTeamColumnsPosition(int team)
+{
+	if (team == TEAM_NSF)
+	{
+		m_pJinraiPlayerList->SetPos(m_iRightTeamXPos, m_iRightTeamYPos);
+		m_pNSFPlayerList->SetPos(m_iLeftTeamXPos, m_iLeftTeamYPos);
+	}
+	else
+	{
+		m_pJinraiPlayerList->SetPos(m_iLeftTeamXPos, m_iLeftTeamYPos);
+		m_pNSFPlayerList->SetPos(m_iRightTeamXPos, m_iRightTeamYPos);
+	}
 }

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -49,6 +49,7 @@ using namespace vgui;
 
 ConVar neo_show_scoreboard_avatars("neo_show_scoreboard_avatars", "1", FCVAR_ARCHIVE, "Show avatars on scoreboard.", true, 0.0, true, 1.0 );
 extern ConVar cl_neo_streamermode;
+extern ConVar cl_neo_hud_team_swap_sides;
 
 CNEOScoreBoard* g_pNeoScoreBoard = NULL;
 
@@ -877,9 +878,12 @@ void CNEOScoreBoard::MoveToCenterOfScreen()
 	SetPos((ww - GetWide()) / 2, (wt - GetTall()) / 2);
 }
 
+//-----------------------------------------------------------------------------
+// Purpose:
+//-----------------------------------------------------------------------------
 void CNEOScoreBoard::UpdateTeamColumnsPosition(int team)
 {
-	if (team == TEAM_NSF)
+	if (team == TEAM_NSF && cl_neo_hud_team_swap_sides.GetBool())
 	{
 		m_pJinraiPlayerList->SetPos(m_iRightTeamXPos, m_iRightTeamYPos);
 		m_pNSFPlayerList->SetPos(m_iLeftTeamXPos, m_iLeftTeamYPos);

--- a/src/game/client/neo/ui/neo_scoreboard.h
+++ b/src/game/client/neo/ui/neo_scoreboard.h
@@ -81,6 +81,11 @@ protected:
 	vgui::SectionedListPanel *m_pNSFPlayerList;
 	vgui::SectionedListPanel *m_pSpectatorsPlayerList;
 
+	int m_iLeftTeamXPos = 0;
+	int m_iLeftTeamYPos = 0;
+	int m_iRightTeamXPos = 0;
+	int m_iRightTeamYPos = 0;
+
 	int s_VoiceImage[5];
 	int TrackerImage;
 	int	m_HLTVSpectators;
@@ -112,6 +117,7 @@ private:
 	int GetSectionFromTeamNumber( int teamNumber );
 	vgui::SectionedListPanel *GetPanelForTeam(int team);
 	void RemoveItemForPlayerIndex(int index);
+	void UpdateTeamColumnsPosition(int team);
 };
 
 extern CNEOScoreBoard* g_pNeoScoreBoard;

--- a/src/game/client/neo/ui/neo_scoreboard.h
+++ b/src/game/client/neo/ui/neo_scoreboard.h
@@ -49,6 +49,7 @@ public:
 	virtual void FireGameEvent( IGameEvent *event);
 
 	virtual void UpdatePlayerAvatar(int playerIndex, KeyValues* kv);
+	void UpdateTeamColumnsPosition(int team);
 
 	vgui::ImageList				*m_pImageList;
 	CUtlMap<CSteamID,int>		m_mapAvatarsToImageList;
@@ -117,7 +118,6 @@ private:
 	int GetSectionFromTeamNumber( int teamNumber );
 	vgui::SectionedListPanel *GetPanelForTeam(int team);
 	void RemoveItemForPlayerIndex(int index);
-	void UpdateTeamColumnsPosition(int team);
 };
 
 extern CNEOScoreBoard* g_pNeoScoreBoard;


### PR DESCRIPTION
## Description
Playtesters expressed confusion regarding the teams icon/score swapping sides, as currently the local player's team is always left.
This can cause it to become misaligned with the scoreboard and not appear where the player expected their team's score to be

## Toolchain
- Windows MSVC VS2022


