### PR TITLE
Change killer info to match HUD style + custom positioning

### DIFF
--- a/game/neo/scripts/HudLayout.res
+++ b/game/neo/scripts/HudLayout.res
@@ -996,9 +996,10 @@
 	neo_killer_damage_info
 	{
 		"fieldName"		"neo_killer_damage_info"
-		"xpos"	"0"
-		"ypos"	"0"
+		"xpos"	"50"
+		"ypos"	"150"
 		"wide"	"640"
 		"tall"	"480"
+		"box_color"		"200 200 200 40"
 	}
 }

--- a/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
+++ b/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
@@ -193,8 +193,8 @@ void CNEOHud_KillerDamageInfo::UpdateStateForNeoHudElementDraw()
 	// This is the baseline width, text width will determine full width
 	const int iBaselineWide = (iScrWide / 3) * UI_SCALE;
 	m_uiCtx.dPanel.tall = (iScrTall / 2) * UI_SCALE;
-	m_uiCtx.dPanel.x = m_uiCtx.iMarginX * 10;
-	m_uiCtx.dPanel.y = (iScrTall / 2) - (m_uiCtx.dPanel.tall / 2);
+	m_uiCtx.dPanel.x = xpos;
+	m_uiCtx.dPanel.y = ypos;
 
 	// Set keybind message
 	{
@@ -290,7 +290,7 @@ void CNEOHud_KillerDamageInfo::DrawNeoHudElement()
 	const C_NEO_Player *localPlayer = C_NEO_Player::GetLocalNEOPlayer();
 
 	// Show info box while it just died spectating itself
-	m_uiCtx.bgColor = COLOR_FADED_DARK;
+	DrawNeoHudRoundedBox(m_uiCtx.dPanel.x, m_uiCtx.dPanel.y, m_uiCtx.dPanel.x + m_uiCtx.dPanel.wide, m_uiCtx.dPanel.y + m_uiCtx.dPanel.tall, m_boxColor);
 	NeoUI::BeginContext(&m_uiCtx, NeoUI::MODE_PAINT, nullptr, "NeoHudKillerDmgInfo");
 	NeoUI::BeginSection();
 	{

--- a/src/game/client/neo/ui/neo_hud_killer_damage_info.h
+++ b/src/game/client/neo/ui/neo_hud_killer_damage_info.h
@@ -53,4 +53,9 @@ protected:
 	int m_iTeamIdxsList[MAX_PLAYERS] = {};
 	int m_iEntIdxsList[MAX_PLAYERS] = {};
 	int m_iAttackersTotalsSize = 0;
+
+private:
+	CPanelAnimationVarAliasType(int, xpos, "xpos", "50", "proportional_xpos");
+	CPanelAnimationVarAliasType(int, ypos, "ypos", "150", "proportional_ypos");
+	CPanelAnimationVar(Color, m_boxColor, "box_color", "200 200 200 40");
 };


### PR DESCRIPTION
## Description
Makes the killer info box match the the other HUD elements (rounded corners, same colour)
Also allows users to set a custom position and colour like other HUD elements in HudLayout

## Toolchain
- Windows MSVC VS2022


