### PR TITLE
Don't show gamemode description during warmup

### DIFF
--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -383,7 +383,7 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	}
 
 	if (NEORules()->GetRoundStatus() == NeoRoundStatus::Pause ||
-			NEORules()->GetRoundStatus() == NeoRoundStatus::Countdown)
+			NEORules()->GetRoundStatus() == NeoRoundStatus::Countdown || NEORules()->GetRoundStatus() == NeoRoundStatus::Warmup)
 	{
 		szGameTypeDescription[0] = '\0';
 	}


### PR DESCRIPTION
## Description
title

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1308 