### PR TITLE
Reduce likelihood that bots fire through friendlies

### DIFF
--- a/src/game/server/neo/bot/neo_bot.h
+++ b/src/game/server/neo/bot/neo_bot.h
@@ -212,6 +212,7 @@ public:
 	bool IsLineOfFireClear(CBaseEntity* who, const LineOfFireFlags flags) const;				// return true if a weapon has no obstructions along the line from our eye to the given entity
 	bool IsLineOfFireClear(const Vector& from, const Vector& to, const LineOfFireFlags flags) const;			// return true if a weapon has no obstructions along the line between the given points
 	bool IsLineOfFireClear(const Vector& from, CBaseEntity* who, const LineOfFireFlags flags) const;			// return true if a weapon has no obstructions along the line between the given point and entity
+	bool IsLineOfFireClearOfFriendlies(const Vector& from, CBaseEntity* who) const;
 
 	bool IsEntityBetweenTargetAndSelf(CBaseEntity* other, CBaseEntity* target);	// return true if "other" is positioned inbetween us and "target"
 


### PR DESCRIPTION
## Description
Check for friendlies between bot and target before opening fire.

## Toolchain
- Windows MSVC VS2022

## Linked Issues

