### PR TITLE
Parity SetTeam input for players

### DIFF
--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -124,6 +124,7 @@ DEFINE_FIELD(m_bClientWantNeoName, FIELD_BOOLEAN),
 // Inputs
 DEFINE_INPUTFUNC(FIELD_STRING, "SetPlayerModel", InputSetPlayerModel),
 DEFINE_INPUTFUNC(FIELD_VOID, "RefillAmmo", InputRefillAmmo),
+DEFINE_INPUTFUNC(FIELD_INTEGER, "SetTeam", InputSetTeam),
 
 END_DATADESC()
 
@@ -2282,7 +2283,7 @@ void CNEO_Player::SetPlayerTeamModel( void )
 }
 
 // Input to set the player's model (not skin)
-void CNEO_Player::InputSetPlayerModel( inputdata_t & inputdata )
+void CNEO_Player::InputSetPlayerModel( inputdata_t &inputdata )
 {
 	const char* modelpath = inputdata.value.String();
 
@@ -2296,7 +2297,7 @@ void CNEO_Player::InputSetPlayerModel( inputdata_t & inputdata )
 	}
 }
 
-void CNEO_Player::InputRefillAmmo( inputdata_t & inputdata)
+void CNEO_Player::InputRefillAmmo( inputdata_t &inputdata)
 {
 	CBaseCombatWeapon* pWeapon = GetActiveWeapon();
 
@@ -2308,6 +2309,11 @@ void CNEO_Player::InputRefillAmmo( inputdata_t & inputdata)
 			pWeapon->SetSecondaryAmmoCount(pWeapon->GetDefaultClip2());
 		}
 	}
+}
+
+void CNEO_Player::InputSetTeam( inputdata_t &inputdata )
+{
+	CBasePlayer::ChangeTeam( inputdata.value.Int() );
 }
 
 void CNEO_Player::PickupObject( CBaseEntity *pObject,

--- a/src/game/server/neo/neo_player.h
+++ b/src/game/server/neo/neo_player.h
@@ -213,8 +213,9 @@ public:
 
 	IMPLEMENT_NETWORK_VAR_FOR_DERIVED(m_EyeAngleOffset);
 
-	void InputSetPlayerModel( inputdata_t & inputData );
-	void InputRefillAmmo( inputdata_t & inputData );
+	void InputSetPlayerModel( inputdata_t &inputData );
+	void InputRefillAmmo( inputdata_t &inputData );
+	void InputSetTeam( inputdata_t &inputdata);
 	void CloakFlash(float time = 0.f);
 
 	void BecomeJuggernaut();


### PR DESCRIPTION
## Description
This intentionally bypasses all the checks and does not update the player's model

To test:
`ent_fire player setteam (value)`
`0` = unassigned
`1` = spec
`2` = jinrai
`3` = nsf

## Toolchain
- Windows MSVC VS2022

## Linked Issues

- fixes #876

