### PR TITLE
Fix seeing enemy team in squad HUD

### DIFF
--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -625,7 +625,7 @@ void CNEOHud_RoundState::DrawPlayerList()
 		const int localPlayerTeam = GetLocalPlayerTeam();
 		const int localPlayerIndex = GetLocalPlayerIndex();
 		const bool localPlayerSpec = !(localPlayerTeam == TEAM_JINRAI || localPlayerTeam == TEAM_NSF);
-		const int leftTeam = cl_neo_hud_team_swap_sides.GetBool() ? (localPlayerSpec ? TEAM_JINRAI : localPlayerTeam) : TEAM_JINRAI;
+		const int leftTeam = localPlayerSpec ? TEAM_JINRAI : localPlayerTeam;
 
 		if (localPlayerSpec)
 		{


### PR DESCRIPTION
## Description
Undo a really cool bug I introduced that lets you see the enemy teams health and classes for no reason

## Toolchain
- Windows MSVC VS2022


