### PR TITLE
Fix dangling gamerules ghost ptr

### DIFF
--- a/src/game/shared/neo/weapons/weapon_ghost.cpp
+++ b/src/game/shared/neo/weapons/weapon_ghost.cpp
@@ -6,6 +6,7 @@
 #include "c_neo_player.h"
 #else
 #include "neo_player.h"
+#include "neo_gamerules.h"
 #endif
 
 #ifdef CLIENT_DLL
@@ -49,6 +50,15 @@ CWeaponGhost::CWeaponGhost(void)
 	m_flLastGhostBeepTime = 0;
 #endif
 }
+
+#ifdef GAME_DLL
+CWeaponGhost::~CWeaponGhost()
+{
+	// At map exit, the rules may be gone before the ghost, so we check.
+	if (auto* rules = NEORules())
+		rules->ResetGhost();
+}
+#endif
 
 void CWeaponGhost::ItemPreFrame(void)
 {

--- a/src/game/shared/neo/weapons/weapon_ghost.h
+++ b/src/game/shared/neo/weapons/weapon_ghost.h
@@ -27,7 +27,10 @@ public:
 #endif
 
 	CWeaponGhost(void);
-	
+#ifdef GAME_DLL
+	virtual ~CWeaponGhost();
+#endif
+
 	virtual void ItemPreFrame(void) OVERRIDE;
 	virtual void PrimaryAttack(void) OVERRIDE { }
 	virtual void SecondaryAttack(void) OVERRIDE { }


### PR DESCRIPTION
## Description
Fix server crash due to dangling ptr if ghost is deleted mid-match.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1351 

