### PR TITLE
Fix custom crosshair misalign at odd-px

### DIFF
--- a/src/game/client/neo/ui/neo_hud_crosshair.cpp
+++ b/src/game/client/neo/ui/neo_hud_crosshair.cpp
@@ -35,13 +35,14 @@ void PaintCrosshair(const CrosshairInfo &crh, const int x, const int y)
 		}
 
 		const bool bOdd = ((crh.iThick % 2) == 1);
+		const int iRBOffset = bOdd ? -1 : 0; // Right + bottom, odd-px offset
 		const int iHalf = crh.iThick / 2;
 		const int iStartThick = bOdd ? iHalf + 1 : iHalf;
 		const int iEndThick = iHalf;
 		vgui::IntRect iRects[4] = {
 			{ -iSize - crh.iGap, -iStartThick, -crh.iGap, iEndThick },	// Left
-			{ crh.iGap, -iStartThick, crh.iGap + iSize, iEndThick },	// Right
-			{ -iStartThick, crh.iGap, iEndThick, crh.iGap + iSize },	// Bottom
+			{ crh.iGap + iRBOffset, -iStartThick, crh.iGap + iSize + iRBOffset, iEndThick },	// Right
+			{ -iStartThick, crh.iGap + iRBOffset, iEndThick, crh.iGap + iSize + iRBOffset },	// Bottom
 			{ -iStartThick, -iSize - crh.iGap, iEndThick, -crh.iGap },	// Top (Must be last for bTopLine)
 		};
 		for (vgui::IntRect &rect : iRects)


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Just add a -1 px offset to right and bottom if odd-px

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native Gentoo/GCC 14


