### PR TITLE
Remove JGR marker assert, fix remembering chosen class after spawn when using the JGR

### DIFF
--- a/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
@@ -256,8 +256,6 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 					break;
 				}
 			}
-
-			Assert(m_jgrInPVS);
 		}
 
 		// Use PVS over networked-given position if possible as it'll give a smoother visual

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -3313,7 +3313,7 @@ void CNEO_Player::ModifyFireBulletsDamage(CTakeDamageInfo* dmgInfo)
 void CNEO_Player::BecomeJuggernaut()
 {
 	NEORules()->JuggernautActivated(this);
-	if (m_iNextSpawnClassChoice = -1)
+	if (m_iNextSpawnClassChoice == -1)
 	{
 		m_iNextSpawnClassChoice = GetClass(); // Don't let the player respawn as the juggernaut
 	}


### PR DESCRIPTION
## Description
Related: 
https://github.com/NeotokyoRebuild/neo/issues/1355#issuecomment-3315236455
https://github.com/NeotokyoRebuild/neo/pull/1197#discussion_r2365854463

## Toolchain
- Windows MSVC VS2022

