### PR TITLE
Remove incorrect assert

### DIFF
--- a/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
@@ -256,8 +256,6 @@ void CNEOHud_GhostMarker::DrawNeoHudElement()
 					break;
 				}
 			}
-
-			Assert(m_jgrInPVS);
 		}
 
 		// Use PVS over networked-given position if possible as it'll give a smoother visual


### PR DESCRIPTION
This fixes a problem where the dev assert would spam warnings incorrectly inside any (sufficiently large) `ntre_<map>_jgr.bsp` map.

Remove an incorrect assertion on the m_jgrInPVS ptr.

We should *not* assert on the ptr after a client-side entity iteration, because there is no guarantee of the JGR ptr being in the client PVS, and when that is not the case, we would spam the incorrect assertion.

Steps to reproduce the bug:
* Build the game in dev mode
* Load `ntre_terminal_jgr`
* Wait for warmup to end
* Roam around the map

What should happen:
* No debug Assert triggers for the m_jgrInPVS incorrectly

What actually happens:
* The opposite