### PR TITLE
Fix duplicate weps for non-CTG modes

### DIFF
--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -2250,12 +2250,6 @@ bool CNEO_Player::Weapon_CanSwitchTo(CBaseCombatWeapon *pWeapon)
 
 bool CNEO_Player::BumpWeapon( CBaseCombatWeapon *pWeapon )
 {
-	// We had some cases of dead players chilling around with visible guns.
-	// While that will be addressed in ShouldDraw, here's a preventive measure
-	// to avoid that situation from occurring altogether.
-	if (IsDead())
-		return false;
-
 	auto weaponSlot = pWeapon->GetSlot();
 	// Only pick up grenades if we don't have grenades of that type NEOTODO (Adam) What if we have less than the maximum of that type (i.e one smoke grenade)? Can I carry more of a grenade than I spawn with?
 	if (weaponSlot == 3 && Weapon_GetPosition(weaponSlot, pWeapon->GetPosition()))
@@ -2278,7 +2272,16 @@ bool CNEO_Player::BumpWeapon( CBaseCombatWeapon *pWeapon )
 		}
 	}
 
-	return BaseClass::BumpWeapon(pWeapon);
+	// We need to run this for its side-effects, even in the IsDead case below... should be refactored.
+	const bool okRet = BaseClass::BumpWeapon(pWeapon);
+
+	// We had some cases of dead players chilling around with visible guns.
+	// While that will be addressed in ShouldDraw, here's a preventive measure
+	// to avoid that situation from occurring altogether.
+	if (IsDead())
+		return false;
+
+	return okRet;
 }
 
 bool CNEO_Player::Weapon_GetPosition(int slot, int position)


### PR DESCRIPTION
## Description
Fix regression from 20b5821

We need to run the base class code for `CNEO_Player::BumpWeapon` even in the `IsDead` case, because the current weapon spawning logic is reliant on it for game modes other than CTG.

This is just a hotfix, this whole thing could use a rework. For example it appears we apply `GiveDefaultItems` several times pointlessly, which could be cleaned up also.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1396 

