### PR TITLE
Introduce air friction as a replacement for the hard speed cap to prevent ghost hopping

### DIFF
--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -833,7 +833,6 @@ void C_NEO_Player::PlayStepSound( Vector &vecOrigin,
 	BaseClass::PlayStepSound(vecOrigin, psurface, fvol, force);
 }
 
-extern ConVar neo_ghost_bhopping;
 void C_NEO_Player::CalculateSpeed(void)
 {
 	float speed = GetNormSpeed();
@@ -877,17 +876,6 @@ void C_NEO_Player::CalculateSpeed(void)
 		speed = MIN(GetFlags() & FL_DUCKING ? NEO_CROUCH_WALK_SPEED : NEO_WALK_SPEED, speed);
 	}
 
-	Vector absoluteVelocity = GetAbsVelocity();
-	absoluteVelocity.z = 0.f;
-	float currentSpeed = absoluteVelocity.Length();
-
-	if (((!neo_ghost_bhopping.GetBool() && m_bCarryingGhost) || m_iNeoClass == NEO_CLASS_JUGGERNAUT) && GetMoveType() == MOVETYPE_WALK && currentSpeed > speed)
-	{
-		float overSpeed = currentSpeed - speed;
-		absoluteVelocity.NormalizeInPlace();
-		absoluteVelocity *= -overSpeed;
-		ApplyAbsVelocityImpulse(absoluteVelocity);
-	}
 	speed = MAX(speed, 55);
 
 	// Slowdown after jumping
@@ -1768,6 +1756,11 @@ void C_NEO_Player::Weapon_SetZoom(const bool bZoomIn)
 bool C_NEO_Player::IsCarryingGhost(void) const
 {
 	return GetNeoWepWithBits(this, NEO_WEP_GHOST) != NULL;
+}
+
+bool C_NEO_Player::IsObjective(void) const
+{
+	return IsCarryingGhost() || GetClass() == NEO_CLASS_VIP || GetClass() == NEO_CLASS_JUGGERNAUT;
 }
 
 const Vector C_NEO_Player::GetPlayerMins(void) const

--- a/src/game/client/neo/c_neo_player.h
+++ b/src/game/client/neo/c_neo_player.h
@@ -133,6 +133,7 @@ public:
 	int GetDisplayedHealth(bool asPercent) const;
 
 	bool IsCarryingGhost(void) const;
+	bool IsObjective(void) const;
 
 	virtual void SetLocalViewAngles( const QAngle &viewAngles ) OVERRIDE
 	{

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -685,7 +685,6 @@ void CNEO_Player::CheckLeanButtons()
 	}
 }
 
-extern ConVar neo_ghost_bhopping;
 void CNEO_Player::CalculateSpeed(void)
 {
 	float speed = GetNormSpeed();
@@ -729,17 +728,6 @@ void CNEO_Player::CalculateSpeed(void)
 		speed = MIN(GetFlags() & FL_DUCKING ? NEO_CROUCH_WALK_SPEED : NEO_WALK_SPEED, speed);
 	}
 
-	Vector absoluteVelocity = GetAbsVelocity();
-	absoluteVelocity.z = 0.f;
-	float currentSpeed = absoluteVelocity.Length();
-
-	if (((!neo_ghost_bhopping.GetBool() && m_bCarryingGhost) || m_iNeoClass == NEO_CLASS_JUGGERNAUT) && GetMoveType() == MOVETYPE_WALK && currentSpeed > speed)
-	{
-		float overSpeed = currentSpeed - speed;
-		absoluteVelocity.NormalizeInPlace();
-		absoluteVelocity *= -overSpeed;
-		ApplyAbsVelocityImpulse(absoluteVelocity);
-	}
 	speed = MAX(speed, 55);
 
 	// Slowdown after jumping
@@ -2396,6 +2384,11 @@ void CNEO_Player::PlayStepSound( Vector &vecOrigin,
 bool CNEO_Player::IsCarryingGhost(void) const
 {
 	return GetNeoWepWithBits(this, NEO_WEP_GHOST) != NULL;
+}
+
+bool CNEO_Player::IsObjective(void) const
+{
+	return IsCarryingGhost() || GetClass() == NEO_CLASS_VIP || GetClass() == NEO_CLASS_JUGGERNAUT;
 }
 
 void CNEO_Player::Weapon_Drop( CBaseCombatWeapon *pWeapon,

--- a/src/game/server/neo/neo_player.h
+++ b/src/game/server/neo/neo_player.h
@@ -126,6 +126,7 @@ public:
 	virtual bool	CanHearAndReadChatFrom(CBasePlayer *pPlayer) OVERRIDE;
 
 	bool IsCarryingGhost(void) const;
+	bool IsObjective(void) const;
 
 	void Weapon_AimToggle(CNEOBaseCombatWeapon *pWep, const NeoWeponAimToggleE toggleType);
 

--- a/src/game/shared/gamemovement.h
+++ b/src/game/shared/gamemovement.h
@@ -102,6 +102,10 @@ protected:
 	// Handles both ground friction and water friction
 	void			Friction( void );
 
+#ifdef NEO
+	void			AirFriction( void );
+#endif
+
 	virtual void	AirAccelerate( Vector& wishdir, float wishspeed, float accel );
 
 	virtual void	AirMove( void );

--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -38,7 +38,6 @@ ConVar cl_autoreload_when_empty("cl_autoreload_when_empty", "1", FCVAR_USERINFO 
 ConVar neo_aim_hold("neo_aim_hold", "0", FCVAR_USERINFO | FCVAR_ARCHIVE, "Hold to aim as opposed to toggle aim.", true, 0.0f, true, 1.0f);
 #endif
 
-ConVar neo_ghost_bhopping("neo_ghost_bhopping", "0", FCVAR_REPLICATED, "Allow ghost bunnyhopping", true, 0, true, 1);
 ConVar sv_neo_dev_loadout("sv_neo_dev_loadout", "0", FCVAR_CHEAT | FCVAR_REPLICATED | FCVAR_HIDDEN | FCVAR_DONTRECORD, "", true, 0.0f, true, 1.0f);
 
 bool IsAllowedToZoom(CNEOBaseCombatWeapon *pWep)


### PR DESCRIPTION
## Description
This is intended to replace the current hard speed cap that comes with the neo_ghost_bhopping cvar. Air friction is applied when going faster than the current max walking speed (based on class and active weapon), and scales linearly with how much faster the player is going.

The friction can be controlled with the following new cvars:
* **sv_neo_airfriction** _(Default: 0)_: The amount of air friction applied to everyone.
* **sv_neo_airfriction_objective** _(Default: 0.5)_: The amount of air friction applied to the ghost carrier, VIP and juggernaut.
* **sv_neo_airstopspeed** _(Default: 0)_: The minimum stopping speed when in the air. Doesn't seem necessary with the default friction value of 0.5, but it's added for parity with ground friction.

For testing purposes, a cheat protected cvar has been added to allow jump buffering.
* **sv_neo_jump_buffer** _(Default: 0)_

For reference, the max speeds set by the nt-anti-ghosthop plugin are:
#define MAX_SPEED_RECON 255.59
#define MAX_SPEED_ASSAULT 204.47
#define MAX_SPEED_SUPPORT 204.47

The default friction value of 0.5 gives us speeds in the same ballpark (tested with jump buffer enabled). Further testing will let us know if the value needs to be tweaked further.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes
- related

