### PR TITLE
Turn off walk toggle when sprinting

### DIFF
--- a/src/game/client/in_main.cpp
+++ b/src/game/client/in_main.cpp
@@ -1579,7 +1579,8 @@ int CInput::GetButtonBits( int bResetState )
 	CalcButtonBits( bits, IN_VISION, s_ClearInputState, &in_vision, bResetState);
 	if (KeyState(&in_speed))
 	{
-		bits &= ~(IN_WALK);
+		// Cancel walk toggle if sprinting
+		KeyUp(&in_walk, nullptr);
 	}
 #endif
 


### PR DESCRIPTION
## Description
Walking is automatically toggled off when the player starts sprinting.
This means that when sprinting is cancelled the player should return to a state where the movement speed is at a standard pace (neither walking nor sprinting).

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1305

