### PR TITLE
Bots retreat when in danger of threats

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_attack.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_attack.cpp
@@ -73,10 +73,14 @@ ActionResult< CNEOBot >	CNEOBotAttack::Update( CNEOBot *me, float interval )
 		 !me->IsLineOfFireClear( threat->GetEntity()->EyePosition(), CNEOBot::LINE_OF_FIRE_FLAGS_DEFAULT ) )
 	{
 		// SUPA7 reload can be interrupted so proactively reload
-		if (myWeapon && (myWeapon->GetNeoWepBits() & NEO_WEP_SUPA7) && (myWeapon->Clip1() < myWeapon->GetMaxClip1()))
+		if (myWeapon && (myWeapon->GetNeoWepBits() & NEO_WEP_SUPA7) && (myWeapon->Clip1() < myWeapon->GetMaxClip1()) && !me->IsReloading())
 		{
 			me->ReleaseFireButton();
-			me->PressReloadButton(); // is not a blocking reload so don't set CNEOBot::RELOADING attribute
+			me->StartReload(myWeapon); // Supa reload can be interrupted so continue pursuit
+		}
+		else if (me->IsReloading())
+		{
+			return SuspendFor(new CNEOBotRetreatToCover(0.0f), "Need to reload in presence of threat, looking for cover");
 		}
 		
 		if ( threat->IsVisibleRecently() )

--- a/src/game/server/neo/bot/behavior/neo_bot_attack.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_attack.cpp
@@ -4,6 +4,7 @@
 #include "team_control_point_master.h"
 #include "bot/neo_bot.h"
 #include "bot/behavior/neo_bot_attack.h"
+#include "bot/behavior/neo_bot_retreat_to_cover.h"
 
 #include "nav_mesh.h"
 
@@ -53,6 +54,11 @@ ActionResult< CNEOBot >	CNEOBotAttack::Update( CNEOBot *me, float interval )
 		}
 	}
 
+	if (me->IsLineOfFireClear(threat->GetEntity()->EyePosition(), CNEOBot::LINE_OF_FIRE_FLAGS_DEFAULT))
+	{
+		return SuspendFor(new CNEOBotRetreatToCover(0.0f), "Threat has bead on me, retreating to cover to break line of sight");
+	}
+
 	bool bHasRangedWeapon = me->IsRanged( myWeapon );
 
 	// Go after them!
@@ -70,7 +76,7 @@ ActionResult< CNEOBot >	CNEOBotAttack::Update( CNEOBot *me, float interval )
 		if (myWeapon && (myWeapon->GetNeoWepBits() & NEO_WEP_SUPA7) && (myWeapon->Clip1() < myWeapon->GetMaxClip1()))
 		{
 			me->ReleaseFireButton();
-			me->PressReloadButton();
+			me->PressReloadButton(); // is not a blocking reload so don't set CNEOBot::RELOADING attribute
 		}
 		
 		if ( threat->IsVisibleRecently() )

--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -556,8 +556,7 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 				me->ReleaseFireButton();
 				me->EnableCloak(3.0f);
 				m_isWaitingForFullReload = true;
-				me->SetAttribute(CNEOBot::RELOADING); // Set RELOADING attribute
-				me->PressReloadButton();
+				me->StartReload(myWeapon);
 			}
 
 			if ( m_isWaitingForFullReload )
@@ -706,8 +705,7 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 				else
 				{
 					me->ReleaseFireButton();
-					me->SetAttribute(CNEOBot::RELOADING); // Set RELOADING attribute
-					me->PressReloadButton();
+					me->StartReload(myWeapon);
 					m_isWaitingForFullReload = true;
 				}
 				return;

--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -556,6 +556,7 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 				me->ReleaseFireButton();
 				me->EnableCloak(3.0f);
 				m_isWaitingForFullReload = true;
+				me->SetAttribute(CNEOBot::RELOADING); // Set RELOADING attribute
 				me->PressReloadButton();
 			}
 
@@ -570,6 +571,7 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 
 				// we are fully reloaded
 				m_isWaitingForFullReload = false;
+				me->ClearAttribute(CNEOBot::RELOADING); // Clear RELOADING attribute
 			}
 		}
 	}
@@ -704,10 +706,16 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 				else
 				{
 					me->ReleaseFireButton();
+					me->SetAttribute(CNEOBot::RELOADING); // Set RELOADING attribute
 					me->PressReloadButton();
 					m_isWaitingForFullReload = true;
 				}
 				return;
+			}
+			// Add a check here to clear RELOADING if the clip is now full
+			else if (myWeapon->m_iClip1 >= myWeapon->GetMaxClip1() && me->HasAttribute(CNEOBot::RELOADING))
+			{
+				me->ClearAttribute(CNEOBot::RELOADING);
 			}
 			else if (myWeapon->GetNeoWepBits() & NEO_WEP_SUPPRESSED)
 			{
@@ -722,7 +730,8 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 			if ( me->IsContinuousFireWeapon( myWeapon ) )
 			{
 				// spray for a bit
-				me->PressFireButton( neo_bot_fire_weapon_min_time.GetFloat() );
+				// NEO Jank: Spraying wastes bullets into friends and walls, so just tap fire
+				me->PressFireButton( /*neo_bot_fire_weapon_min_time.GetFloat()*/ );
 			}
 			else 
 			{

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
@@ -182,14 +182,12 @@ ActionResult< CNEOBot >	CNEOBotRetreatToCover::Update( CNEOBot *me, float interv
 	me->EquipBestWeaponForThreat( threat );
 
 	// reload while moving to cover
-	bool isDoingAFullReload = false;
 	CNEOBaseCombatWeapon *myPrimary = (CNEOBaseCombatWeapon*)me->GetActiveWeapon();
-	if ( myPrimary && myPrimary->GetPrimaryAmmoCount() > 0 && me->IsBarrageAndReloadWeapon(myPrimary))
+	if ( myPrimary && myPrimary->GetPrimaryAmmoCount() > 0 && me->IsBarrageAndReloadWeapon(myPrimary) && !me->IsReloading())
 	{
 		if ( myPrimary->Clip1() < myPrimary->GetMaxClip1() )
 		{
-			me->PressReloadButton();  // is not a blocking reload so don't set CNEOBot::RELOADING attribute
-			isDoingAFullReload = true;
+			me->StartReload(myPrimary);
 		}
 	}
 
@@ -216,8 +214,9 @@ ActionResult< CNEOBot >	CNEOBotRetreatToCover::Update( CNEOBot *me, float interv
 		}
 
 		// stay in cover while we fully reload
-		if ( isDoingAFullReload )
+		if ( me->IsReloading() )
 		{
+			me->PressCrouchButton(0.3f);
 			return Continue();
 		}
 

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
@@ -188,7 +188,7 @@ ActionResult< CNEOBot >	CNEOBotRetreatToCover::Update( CNEOBot *me, float interv
 	{
 		if ( myPrimary->Clip1() < myPrimary->GetMaxClip1() )
 		{
-			me->PressReloadButton();
+			me->PressReloadButton();  // is not a blocking reload so don't set CNEOBot::RELOADING attribute
 			isDoingAFullReload = true;
 		}
 	}

--- a/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.cpp
@@ -113,8 +113,13 @@ ActionResult< CNEOBot >	CNEOBotSeekAndDestroy::Update( CNEOBot *me, float interv
 			if (shouldReload)
 			{
 				me->ReleaseFireButton();
+				me->SetAttribute(CNEOBot::RELOADING);
 				me->PressReloadButton();
 				me->PressCrouchButton(0.3f);
+			}
+			else
+			{
+				me->ClearAttribute(CNEOBot::RELOADING);
 			}
 
 		}

--- a/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.cpp
@@ -110,18 +110,10 @@ ActionResult< CNEOBot >	CNEOBotSeekAndDestroy::Update( CNEOBot *me, float interv
 				}
 			}
 
-			if (shouldReload)
+			if (shouldReload && !me->IsReloading())
 			{
-				me->ReleaseFireButton();
-				me->SetAttribute(CNEOBot::RELOADING);
-				me->PressReloadButton();
-				me->PressCrouchButton(0.3f);
+				me->StartReload(myWeapon);
 			}
-			else
-			{
-				me->ClearAttribute(CNEOBot::RELOADING);
-			}
-
 		}
 	}
 

--- a/src/game/server/neo/bot/neo_bot.h
+++ b/src/game/server/neo/bot/neo_bot.h
@@ -101,6 +101,7 @@ public:
 	virtual void PressFireButton(float duration = -1.0f) OVERRIDE;
 	virtual void PressAltFireButton(float duration = -1.0f) OVERRIDE;
 	virtual void PressSpecialFireButton(float duration = -1.0f) OVERRIDE;
+	virtual bool CanSprint(void) OVERRIDE;
 
 	// INextBot
 	virtual CNEOBotLocomotion* GetLocomotionInterface(void) const { return m_locomotor; }
@@ -232,6 +233,7 @@ public:
 		ALWAYS_FIRE_WEAPON = 1 << 10,				// constantly fire our weapon
 		TELEPORT_TO_HINT = 1 << 11,				// bot will teleport to hint target instead of walking out from the spawn point
 		AUTO_JUMP = 1 << 12,				// auto jump
+		RELOADING = 1 << 13,				// bot is actively reloading
 	};
 	void SetAttribute(int attributeFlag);
 	void ClearAttribute(int attributeFlag);

--- a/src/game/server/neo/bot/neo_bot.h
+++ b/src/game/server/neo/bot/neo_bot.h
@@ -505,6 +505,10 @@ private:
 	float m_flPhyscannonPickupTime = 0.0f;
 
 	CUtlVector< const EventChangeAttributes_t* > m_eventChangeAttributes;
+
+public:
+	void StartReload(CNEOBaseCombatWeapon* weapon);
+	bool IsReloading();
 };
 
 class CNEOBotBehavior : public Behavior<CNEOBot>, public CNEOBotContextualQueryInterface


### PR DESCRIPTION
## Description
Bots retreat to cover when in immediate danger, such as when an enemy is firing back or a bot is reloading in the presence of an enemy.

## Toolchain
- Windows MSVC VS2022

