### PR TITLE
Compass revamp

### DIFF
--- a/game/neo/scripts/HudLayout.res
+++ b/game/neo/scripts/HudLayout.res
@@ -819,10 +819,15 @@
 	{
 		"fieldName"		"NHudCompass"
 		"visible"		"1"
-		"y_bottom_pos"		"3"
-		"needle_visible"	"0"
-		"needle_colored"	"0"
+		"xpos"			"c-100"
+		"ypos"			"469"
+		"wide"			"200"
+		"tall"			"8"
+		"fov"			"90"
+		"separators"	"1"
 		"objective_visible"	"1"
+		"text_fade_exp"	"1"
+		"text_color"	"255 255 255 150"
 		"box_color"		"200 200 200 40"
 	}
 	NHudWeapon

--- a/src/game/client/neo/ui/neo_hud_compass.cpp
+++ b/src/game/client/neo/ui/neo_hud_compass.cpp
@@ -188,7 +188,10 @@ void CNEOHud_Compass::DrawCompass() const
 	const int steps = ARRAYSIZE(ROSE);
 	for (int i = 0; i < steps; i += m_separators ? 1 : 2) {
 		const float stepAngle = (float)(i * 360) / steps;
-		float drawAngle = safeAngle(stepAngle - angle + (float)m_fov / 2) + 180;
+		float drawAngle = safeAngle(stepAngle - angle + (float)m_fov / 2);
+		if (drawAngle < 0) {
+			drawAngle += 360;
+		}
 		if (drawAngle >= m_fov) {
 			continue;
 		}

--- a/src/game/client/neo/ui/neo_hud_compass.cpp
+++ b/src/game/client/neo/ui/neo_hud_compass.cpp
@@ -19,24 +19,7 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
-#define UNICODE_NEO_COMPASS_SIZE_BYTES (UNICODE_NEO_COMPASS_STR_LENGTH * sizeof(wchar_t))
-
 using vgui::surface;
-
-ConVar cl_neo_hud_debug_compass_enabled("cl_neo_hud_debug_compass_enabled", "0", FCVAR_USERINFO | FCVAR_CHEAT,
-	"Whether the Debug HUD compass is enabled or not.", true, 0.0f, true, 1.0f);
-ConVar cl_neo_hud_debug_compass_pos_x("cl_neo_hud_debug_compass_pos_x", "0.45", FCVAR_USERINFO | FCVAR_CHEAT,
-	"Horizontal position of the Debug compass, in range 0 to 1.", true, 0.0f, true, 1.0f);
-ConVar cl_neo_hud_debug_compass_pos_y("cl_neo_hud_debug_compass_pos_y", "0.925", FCVAR_USERINFO | FCVAR_CHEAT,
-	"Vertical position of the Debug compass, in range 0 to 1.", true, 0.0f, true, 1.0f);
-ConVar cl_neo_hud_debug_compass_color_r("cl_neo_hud_debug_compass_color_r", "190", FCVAR_USERINFO | FCVAR_CHEAT,
-	"Red color value of the Debug compass, in range 0 - 255.", true, 0.0f, true, 255.0f);
-ConVar cl_neo_hud_debug_compass_color_g("cl_neo_hud_debug_compass_color_g", "185", FCVAR_USERINFO | FCVAR_CHEAT,
-	"Green color value of the Debug compass, in range 0 - 255.", true, 0.0f, true, 255.0f);
-ConVar cl_neo_hud_debug_compass_color_b("cl_neo_hud_debug_compass_color_b", "205", FCVAR_USERINFO | FCVAR_CHEAT,
-	"Blue value of the Debug compass, in range 0 - 255.", true, 0.0f, true, 255.0f);
-ConVar cl_neo_hud_debug_compass_color_a("cl_neo_hud_debug_compass_color_a", "255", FCVAR_USERINFO | FCVAR_CHEAT,
-	"Alpha color value of the Debug compass, in range 0 - 255.", true, 0.0f, true, 255.0f);
 
 ConVar cl_neo_hud_rangefinder_enabled("cl_neo_hud_rangefinder_enabled", "1", FCVAR_ARCHIVE,
 									  "Whether the rangefinder HUD is enabled or not.", true, 0.0f, true, 1.0f);
@@ -72,10 +55,6 @@ CNEOHud_Compass::CNEOHud_Compass(const char *pElementName, vgui::Panel *parent)
 	m_hFont = 0;
 
 	SetVisible(true);
-
-	COMPILE_TIME_ASSERT(sizeof(m_wszCompassUnicode) == UNICODE_NEO_COMPASS_SIZE_BYTES);
-	Assert(g_pVGuiLocalize);
-	g_pVGuiLocalize->ConvertANSIToUnicode("\0", m_wszCompassUnicode, UNICODE_NEO_COMPASS_SIZE_BYTES);
 }
 
 void CNEOHud_Compass::Paint()
@@ -86,44 +65,6 @@ void CNEOHud_Compass::Paint()
 	SetBgColor(Color(0, 0, 0, 0));
 
 	BaseClass::Paint();
-}
-
-void CNEOHud_Compass::GetCompassUnicodeString(const float angle, wchar_t* outUnicodeStr) const
-{
-	// Char representation of the compass strip
-	static constexpr char ROSE[] =
-		"N                |                NE                |\
-                E                |                SE                |\
-                S                |                SW                |\
-                W                |                NW                |\
-                ";
-
-	// One compass tick represents this many degrees of rotation
-	const float unitAccuracy = 360.0f / sizeof(ROSE);
-
-	// Get index offset for this angle's compass position
-	int offset = RoundFloatToInt(angle / unitAccuracy) - UNICODE_NEO_COMPASS_VIS_AROUND;
-	if (offset < 0)
-	{
-		offset += sizeof(ROSE);
-	}
-
-	// Both sides + center + terminator
-	char compass[UNICODE_NEO_COMPASS_STR_LENGTH];
-	int i;
-	for (i = 0; i < UNICODE_NEO_COMPASS_STR_LENGTH - 1; i++)
-	{
-		// Get our index by circling around the compass strip.
-		// We do modulo -1, because sizeof would land us on NULL
-		// and terminate the string early.
-		const int wrappedIndex = (offset + i) % (sizeof(ROSE) - 1);
-
-		compass[i] = ROSE[wrappedIndex];
-	}
-	// Finally, make sure we have a null terminator
-	compass[i] = '\0';
-
-	g_pVGuiLocalize->ConvertANSIToUnicode(compass, outUnicodeStr, UNICODE_NEO_COMPASS_SIZE_BYTES);
 }
 
 static C_NEO_Player *GetFirstPersonPlayer()
@@ -141,29 +82,30 @@ static C_NEO_Player *GetFirstPersonPlayer()
 	return pFPPlayer;
 }
 
+static float safeAngle(float angle) {
+	while (angle < -180) {
+		angle += 360;
+	}
+	while (angle >= 180) {
+		angle -= 360;
+	}
+	return angle;
+}
+
 void CNEOHud_Compass::UpdateStateForNeoHudElementDraw()
 {
 	auto pLocalPlayer = C_NEO_Player::GetLocalNEOPlayer();
 	Assert(pLocalPlayer);
 
-	static auto safeAngle = [](const float angle) -> float {
-		if (angle > 180.0f)
-		{
-			return angle - 360.0f;
-		}
-		else if (angle < -180.0f)
-		{
-			return angle + 360.0f;
-		}
-		return angle;
-	};
-
-	// Direction in -180 to 180
-	float angle = pLocalPlayer->EyeAngles()[YAW] * -1;
-	angle = safeAngle(angle);
-	angle += 180.0f;	// NEO NOTE (nullsystem): Adjust it again to match OG:NT's compass angle
-	angle = safeAngle(angle);
-	GetCompassUnicodeString(angle, m_wszCompassUnicode);
+	// Point the objective arrow to the ghost, if it exists
+	if (NEORules()->GhostExists() || NEORules()->JuggernautItemExists())
+	{
+		const Vector objPos = NEORules()->GetGameType() == NEO_GAME_TYPE_JGR ? NEORules()->GetJuggernautMarkerPos() : NEORules()->GetGhostPos();
+		const Vector objVec = objPos - pLocalPlayer->EyePosition();
+		const float objYaw = RAD2DEG(atan2f(objVec.y, objVec.x));
+		float objAngle = safeAngle(- objYaw + pLocalPlayer->EyeAngles()[YAW]);
+		m_objAngle = Clamp(objAngle, -(float)m_fov / 2, (float)m_fov / 2);
+	}
 
 	if (cl_neo_hud_rangefinder_enabled.GetBool())
 	{
@@ -201,11 +143,6 @@ void CNEOHud_Compass::DrawNeoHudElement(void)
 		DrawCompass();
 	}
 
-	if (cl_neo_hud_debug_compass_enabled.GetBool())
-	{
-		DrawDebugCompass();
-	}
-
 	if (cl_neo_hud_rangefinder_enabled.GetBool() && GetFirstPersonPlayer()->IsInAim())
 	{
 		surface()->DrawSetTextColor(COLOR_NEO_WHITE);
@@ -223,174 +160,74 @@ void CNEOHud_Compass::ApplySchemeSettings(vgui::IScheme *pScheme)
 	LoadControlSettings("scripts/HudLayout.res");
 
 	m_hFont = pScheme->GetFont("NHudOCRSmall");
-	m_savedXBoxWidth = 0;
 
 	surface()->GetScreenSize(m_resX, m_resY);
 	SetBounds(0, 0, m_resX, m_resY);
 	SetZPos(90);
+	m_fov = Clamp(m_fov, 45, 360);
+	m_fadeExp = Clamp(m_fadeExp, 0, 10);
 }
 
 void CNEOHud_Compass::DrawCompass() const
 {
+	static const wchar_t* ROSE[] = {
+		L"S", L"|", L"SW", L"|", L"W", L"|", L"NW", L"|", L"N", L"|", L"NE", L"|", L"E", L"|", L"SE", L"|",
+	};
+
 	auto player = C_NEO_Player::GetLocalNEOPlayer();
 	Assert(player);
 
 	surface()->DrawSetTextFont(m_hFont);
 
-	int fontWidth, fontHeight;
-	surface()->GetTextSize(m_hFont, m_wszCompassUnicode, fontWidth, fontHeight);
-
-	if (m_savedXBoxWidth == 0)
-	{
-		// Using the fontHeight for padding works out
-		m_savedXBoxWidth = fontWidth + fontHeight;
-	}
-	// These are the compass box dimension, just based on the font's dimensions
-	const int xBoxWidth = m_savedXBoxWidth;
-	const int yBoxHeight = fontHeight;
-
-	const int resXHalf = m_resX / 2;
-	const int xBoxWidthHalf = xBoxWidth / 2;
-	const int margin = m_yFromBottomPos;
-
 	DrawNeoHudRoundedBox(
-		resXHalf - xBoxWidthHalf, m_resY - yBoxHeight - margin,
-		resXHalf + xBoxWidthHalf, m_resY - margin,
+		m_xPos, m_yPos,
+		m_xPos + m_width, m_yPos + m_height,
 		m_boxColor);
 
-	// Draw the compass "needle"
-	if (m_needleVisible)
-	{
-		static const Color COMPASS_NEEDLE_COLOR_GREEN{25, 255, 25, 150};
-		static const Color COMPASS_NEEDLE_COLOR_BLUE{25, 25, 255, 150};
-		static const Color COMPASS_NEEDLE_COLOR_WHITE{255, 255, 255, 150};
-		Color needleColor = COMPASS_NEEDLE_COLOR_WHITE;
-		if (m_needleColored)
-		{
-			const int playerTeam = player->GetTeamNumber();
-			switch (playerTeam)
-			{
-			break; case TEAM_JINRAI: needleColor = COMPASS_NEEDLE_COLOR_GREEN;
-			break; case TEAM_NSF: needleColor = COMPASS_NEEDLE_COLOR_BLUE;
-			break; default: break;
-			}
+	const float angle = -player->EyeAngles()[YAW];
+	const int steps = ARRAYSIZE(ROSE);
+	for (int i = 0; i < steps; i += m_separators ? 1 : 2) {
+		const float stepAngle = (float)(i * 360) / steps;
+		float drawAngle = safeAngle(stepAngle - angle + (float)m_fov / 2) + 180;
+		if (drawAngle >= m_fov) {
+			continue;
 		}
-		surface()->DrawSetColor(needleColor);
-		surface()->DrawFilledRect(resXHalf - 1, m_resY - yBoxHeight - margin, resXHalf + 1, m_resY - margin);
+		const float proportion = drawAngle / m_fov;
+		const float alpha = !m_fadeExp ? 1 : 1 - pow(abs(2 * (proportion - 0.5)), m_fadeExp);
+		surface()->DrawSetTextColor(m_textColor.r(), m_textColor.g(), m_textColor.b(), alpha * m_textColor.a());
+		int labelWidth, labelHeight;
+		surface()->GetTextSize(m_hFont, ROSE[i], labelWidth, labelHeight);
+		const float padding = (float)labelHeight;
+		surface()->DrawSetTextPos(m_xPos + padding + (m_width - padding * 2) * proportion - (float)labelWidth / 2, m_yPos + (float)m_height / 2 - (float)labelHeight / 2);
+		surface()->DrawPrintText(ROSE[i], Q_UnicodeLength(ROSE[i]));	
 	}
 
-	surface()->DrawSetTextColor(COLOR_WHITE);
-	surface()->DrawSetTextPos(resXHalf - fontWidth / 2, m_resY - fontHeight - margin);
-	surface()->DrawPrintText(m_wszCompassUnicode, UNICODE_NEO_COMPASS_STR_LENGTH);
-
 	// Print compass objective arrow
-	if (m_objectiveVisible && !player->IsCarryingGhost())
+	if (m_objectiveVisible && !player->IsObjective())
 	{
 		// Point the objective arrow to the ghost, if it exists
 		if (NEORules()->GhostExists() || NEORules()->JuggernautItemExists())
 		{
-			int ghostMarkerX, ghostMarkerY;
-			bool ghostIsInView = false;
-			if (NEORules()->GetGameType() != NEO_GAME_TYPE_JGR)
-			{
-				ghostIsInView = GetVectorInScreenSpace(NEORules()->GetGhostPos(), ghostMarkerX, ghostMarkerY);
-			}
-			else
-			{
-				ghostIsInView = GetVectorInScreenSpace(NEORules()->GetJuggernautMarkerPos(), ghostMarkerX, ghostMarkerY);
-			}
-			if (ghostIsInView) {
-				// Print a unicode arrow to signify compass needle
-				const wchar_t arrowUnicode[] = L"▼";
+			const float proportion = m_objAngle / m_fov + 0.5;
+			
+			// Print a unicode arrow to signify objective
+			const wchar_t arrowUnicode[] = L"▼";
 
-				ghostMarkerX = clamp(ghostMarkerX, resXHalf - xBoxWidthHalf, resXHalf + xBoxWidthHalf);
+			const int ghosterTeam = NEORules()->GetGhosterTeam();
+			const int ownTeam = player->GetTeam()->GetTeamNumber();
 
-				const int ghosterTeam = NEORules()->GetGhosterTeam();
-				const int ownTeam = player->GetTeam()->GetTeamNumber();
+			const auto teamClr32 = player->GetTeam()->GetRenderColor();
+			const Color teamColor = Color(teamClr32.r, teamClr32.g, teamClr32.b, teamClr32.a);
 
-				const auto teamClr32 = player->GetTeam()->GetRenderColor();
-				const Color teamColor = Color(teamClr32.r, teamClr32.g, teamClr32.b, teamClr32.a);
+			const bool ghostIsBeingCarried = (ghosterTeam == TEAM_JINRAI || ghosterTeam == TEAM_NSF);
+			const bool ghostIsCarriedByEnemyTeam = (ghosterTeam != ownTeam);
 
-				const bool ghostIsBeingCarried = (ghosterTeam == TEAM_JINRAI || ghosterTeam == TEAM_NSF);
-				const bool ghostIsCarriedByEnemyTeam = (ghosterTeam != ownTeam);
-
-				surface()->DrawSetTextColor(ghostIsBeingCarried ? ghostIsCarriedByEnemyTeam ? COLOR_RED : teamColor : COLOR_WHITE);
-				surface()->DrawSetTextPos(ghostMarkerX, m_resY - fontHeight - margin * 2.25f);
-				surface()->DrawPrintText(arrowUnicode, Q_UnicodeLength(arrowUnicode));
-			}
+			surface()->DrawSetTextColor(ghostIsBeingCarried ? ghostIsCarriedByEnemyTeam ? COLOR_RED : teamColor : COLOR_WHITE);
+			int labelWidth, labelHeight;
+			surface()->GetTextSize(m_hFont, arrowUnicode, labelWidth, labelHeight);
+			const float padding = (float)labelHeight;
+			surface()->DrawSetTextPos(m_xPos + padding + (m_width - padding * 2) * proportion - (float)labelWidth / 2, m_yPos - labelHeight);
+			surface()->DrawPrintText(arrowUnicode, Q_UnicodeLength(arrowUnicode));
 		}
 	}
-
-	static const Color FADE_END_COLOR(116, 116, 116, 255);
-	DrawNeoHudRoundedBoxFaded(
-		resXHalf - xBoxWidthHalf, m_resY - yBoxHeight - margin,
-		resXHalf, m_resY - margin,
-		FADE_END_COLOR, 255, 0, true,
-		true, false, true, false);
-	DrawNeoHudRoundedBoxFaded(
-		resXHalf, m_resY - yBoxHeight - margin,
-		resXHalf + xBoxWidthHalf, m_resY - margin,
-		FADE_END_COLOR, 0, 255, true,
-		false, true, false, true);
-}
-
-void CNEOHud_Compass::DrawDebugCompass() const
-{
-	auto player = C_NEO_Player::GetLocalNEOPlayer();
-	Assert(player);
-
-	// Direction in -180 to 180
-	float angle = -(player->EyeAngles()[YAW]);
-
-	// Clamp in 180 turn range.
-	if (angle > 180)
-	{
-		angle -= 360;
-	}
-	else if (angle < -180)
-	{
-		angle += 360;
-	}
-
-	// Char representation of the compass strip
-	const char rose[] = "N -- ne -- E -- se -- S -- sw -- W -- nw -- ";
-
-	// One compass tick represents this many degrees of rotation
-	const float unitAccuracy = 360.0f / sizeof(rose);
-
-	// How many characters should be visible around each side of the needle position
-	const int numCharsVisibleAroundNeedle = 6;
-
-	// Get index offset for this angle's compass position
-	int offset = RoundFloatToInt((angle / unitAccuracy)) - numCharsVisibleAroundNeedle;
-	if (offset < 0)
-	{
-		offset += sizeof(rose);
-	}
-
-	// Both sides + center + terminator
-	char compass[numCharsVisibleAroundNeedle * 2 + 2];
-	int i;
-	for (i = 0; i < sizeof(compass) - 1; i++)
-	{
-		// Get our index by circling around the compass strip.
-		// We do modulo -1, because sizeof would land us on NULL
-		// and terminate the string early.
-		const int wrappedIndex = (offset + i) % (sizeof(rose) - 1);
-
-		compass[i] = rose[wrappedIndex];
-	}
-	// Finally, make sure we have a null terminator
-	compass[i] = '\0';
-
-	// Draw the compass for this frame
-	debugoverlay->AddScreenTextOverlay(
-		cl_neo_hud_debug_compass_pos_x.GetFloat(),
-		cl_neo_hud_debug_compass_pos_y.GetFloat(),
-		gpGlobals->frametime,
-		cl_neo_hud_debug_compass_color_r.GetInt(),
-		cl_neo_hud_debug_compass_color_g.GetInt(),
-		cl_neo_hud_debug_compass_color_b.GetInt(),
-		cl_neo_hud_debug_compass_color_a.GetInt(),
-		compass);
 }

--- a/src/game/client/neo/ui/neo_hud_compass.h
+++ b/src/game/client/neo/ui/neo_hud_compass.h
@@ -8,9 +8,6 @@
 #include "hudelement.h"
 #include <vgui_controls/EditablePanel.h>
 
-static constexpr size_t UNICODE_NEO_COMPASS_VIS_AROUND = 33; // How many characters should be visible around each side of the needle position
-static constexpr size_t UNICODE_NEO_COMPASS_STR_LENGTH = ((UNICODE_NEO_COMPASS_VIS_AROUND * 2) + 2);
-
 class CNEOHud_Compass : public CNEOHud_ChildElement, public CHudElement, public vgui::EditablePanel
 {
 	DECLARE_CLASS_SIMPLE(CNEOHud_Compass, EditablePanel);
@@ -28,23 +25,25 @@ protected:
 
 private:
 	void DrawCompass() const;
-	void DrawDebugCompass() const;
-	void GetCompassUnicodeString(const float angle, wchar_t* outUnicodeStr) const;
 
 private:
 	vgui::HFont m_hFont;
 
 	int m_resX, m_resY;
-	mutable int m_savedXBoxWidth = 0;
+	float m_objAngle;
 
-	wchar_t m_wszCompassUnicode[UNICODE_NEO_COMPASS_STR_LENGTH];
 	wchar_t m_wszRangeFinder[11];
 
 	CPanelAnimationVarAliasType(bool, m_showCompass, "visible", "1", "bool");
-	CPanelAnimationVarAliasType(int, m_yFromBottomPos, "y_bottom_pos", "3", "proportional_ypos");
-	CPanelAnimationVarAliasType(bool, m_needleVisible, "needle_visible", "0", "bool");
-	CPanelAnimationVarAliasType(bool, m_needleColored, "needle_colored", "0", "bool");
+	CPanelAnimationVarAliasType(int, m_xPos, "xpos", "c-50", "proportional_xpos");
+	CPanelAnimationVarAliasType(int, m_yPos, "ypos", "469", "proportional_ypos");
+	CPanelAnimationVarAliasType(int, m_width, "wide", "100", "proportional_xpos");
+	CPanelAnimationVarAliasType(int, m_height, "tall", "8", "proportional_ypos");
+	CPanelAnimationVarAliasType(int, m_fov, "fov", "90", "int");
+	CPanelAnimationVarAliasType(bool, m_separators, "separators", "1", "bool")
 	CPanelAnimationVarAliasType(bool, m_objectiveVisible, "objective_visible", "1", "bool");
+	CPanelAnimationVarAliasType(int, m_fadeExp, "text_fade_exp", "2", "int")
+	CPanelAnimationVar(Color, m_textColor, "text_color", "255 255 255 150");
 	CPanelAnimationVar(Color, m_boxColor, "box_color", "200 200 200 40");
 
 private:


### PR DESCRIPTION
## Description
Implements proper text fade at the edges instead of a gradient overlay. Instead of drawing one long string, each direction label is drawn separately.

The objective now has an actual compass direction instead of using screen space.

All the customizability (in HudLayout.res);
* Position and size
* Text and background color
* Fade exponent
* Field of view
* Whether to draw separators

<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/e5334442-c577-43f0-aa3c-f0c25b2ee103" />


## Toolchain
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes
- related #970

