### PR TITLE
Fix loading UI vanishing when using a background map

### DIFF
--- a/src/game/client/neo/ui/neo_loading.cpp
+++ b/src/game/client/neo/ui/neo_loading.cpp
@@ -33,9 +33,6 @@ CNeoLoading::CNeoLoading()
 
 	vgui::IScheme *pScheme = vgui::scheme()->GetIScheme(neoscheme);
 	ApplySchemeSettings(pScheme);
-
-	m_pHostMap = g_pCVar->FindVar("host_map");
-	Assert(m_pHostMap != nullptr);
 }
 
 CNeoLoading::~CNeoLoading()
@@ -193,10 +190,9 @@ void CNeoLoading::OnMainLoop(const NeoUI::Mode eMode)
 
 	static bool bStaticInitNeoUI = false;
 	bool bSkipRender = false;
-	if (iStrIdx == m_aStrIdxMap[LOADINGSTATE_LOADING] && m_pHostMap)
+	if (iStrIdx == m_aStrIdxMap[LOADINGSTATE_LOADING])
 	{
-		auto hostMapName = m_pHostMap->GetString();
-		if (Q_stristr(hostMapName, "background_"))
+		if (engine->IsLevelMainMenuBackground())
 		{
 			bSkipRender = true;
 		}

--- a/src/game/client/neo/ui/neo_loading.h
+++ b/src/game/client/neo/ui/neo_loading.h
@@ -30,8 +30,6 @@ public:
 	int m_iRowsInScreen = 0;
 	int m_iRootSubPanelWide = 0;
 
-	ConVar* m_pHostMap;
-
 	bool m_bValidGameUIPanels = false;
 	vgui::Frame *m_pLoadingPanel = nullptr;
 	vgui::ProgressBar *m_pProgressBarMain = nullptr;


### PR DESCRIPTION
## Description
It seems the loading bar would still not appear if the user had a background selected other than the default. Not sure why, guessing host_map gets changed or something but this should fix it for good.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1365
- related #1311

