### PR TITLE
Fix cloak/vision sfx stutter at high ping.

### DIFF
--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -512,6 +512,7 @@ void C_NEO_Player::CheckVisionButtons()
 				C_RecipientFilter filter;
 				filter.AddRecipient(this);
 				filter.MakeReliable();
+				filter.UsePredictionRules();
 
 				EmitSound_t params;
 				params.m_bEmitCloseCaption = false;
@@ -1778,6 +1779,7 @@ void C_NEO_Player::PlayCloakSound(void)
 	C_RecipientFilter filter;
 	filter.AddRecipient(this);
 	filter.MakeReliable();
+	filter.UsePredictionRules();
 
 	static int tocOn = CBaseEntity::PrecacheScriptSound("NeoPlayer.ThermOpticOn");
 	static int tocOff = CBaseEntity::PrecacheScriptSound("NeoPlayer.ThermOpticOff");


### PR DESCRIPTION
## Description
Fix cloak/vision sound effect stutter by enabling prediction rules on the sound filter.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #963 

