### PR TITLE
Grenade trajectory parity

### DIFF
--- a/src/game/shared/neo/weapons/weapon_grenade.cpp
+++ b/src/game/shared/neo/weapons/weapon_grenade.cpp
@@ -246,13 +246,12 @@ void CWeaponGrenade::ThrowGrenade(CNEO_Player *pPlayer, bool isAlive, CBaseEntit
 
 	Vector vForward, vRight, vUp;
 
-	if (angThrow.x < 90)
+	if (angThrow.x >= 0)
+		// Below horizon
 		angThrow.x = -10 + angThrow.x * ((90 + 10) / 90.0);
 	else
-	{
-		angThrow.x = 360.0f - angThrow.x;
-		angThrow.x = -10 + angThrow.x * -((90 - 10) / 90.0);
-	}
+		// Above horizon
+		angThrow.x = -10 + angThrow.x * ((90 - 10) / 90.0);
 
 	float flVel = (90 - angThrow.x) * 6;
 

--- a/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
+++ b/src/game/shared/neo/weapons/weapon_smokegrenade.cpp
@@ -223,13 +223,12 @@ void CWeaponSmokeGrenade::ThrowGrenade(CNEO_Player* pPlayer, bool isAlive, CBase
 
 	Vector vForward, vRight, vUp;
 
-	if (angThrow.x < 90)
+	if (angThrow.x >= 0)
+		// Below horizon
 		angThrow.x = -10 + angThrow.x * ((90 + 10) / 90.0);
 	else
-	{
-		angThrow.x = 360.0f - angThrow.x;
-		angThrow.x = -10 + angThrow.x * -((90 - 10) / 90.0);
-	}
+		// Above horizon
+		angThrow.x = -10 + angThrow.x * ((90 - 10) / 90.0);
 
 	float flVel = (90 - angThrow.x) * 6;
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Seems like pPlayer->LocalEyeAngles() now returns (-180, 180) whereas in SDK/OGNT it used to be (0, 360). This causes the trajectory equation to fail. This rewrites it to work with the new interval.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1384 

