### PR TITLE
Don't show ghost indicator on compass when spectating carrier.

### DIFF
--- a/src/game/client/neo/ui/neo_hud_compass.cpp
+++ b/src/game/client/neo/ui/neo_hud_compass.cpp
@@ -94,22 +94,21 @@ static float safeAngle(float angle) {
 
 void CNEOHud_Compass::UpdateStateForNeoHudElementDraw()
 {
-	auto pLocalPlayer = C_NEO_Player::GetLocalNEOPlayer();
-	Assert(pLocalPlayer);
+	auto pFPPlayer = GetFirstPersonPlayer();
+	Assert(pFPPlayer);
 
 	// Point the objective arrow to the ghost, if it exists
 	if (NEORules()->GhostExists() || NEORules()->JuggernautItemExists())
 	{
 		const Vector objPos = NEORules()->GetGameType() == NEO_GAME_TYPE_JGR ? NEORules()->GetJuggernautMarkerPos() : NEORules()->GetGhostPos();
-		const Vector objVec = objPos - pLocalPlayer->EyePosition();
+		const Vector objVec = objPos - pFPPlayer->EyePosition();
 		const float objYaw = RAD2DEG(atan2f(objVec.y, objVec.x));
-		float objAngle = safeAngle(- objYaw + pLocalPlayer->EyeAngles()[YAW]);
+		float objAngle = safeAngle(- objYaw + pFPPlayer->EyeAngles()[YAW]);
 		m_objAngle = Clamp(objAngle, -(float)m_fov / 2, (float)m_fov / 2);
 	}
 
 	if (cl_neo_hud_rangefinder_enabled.GetBool())
 	{
-		C_NEO_Player *pFPPlayer = GetFirstPersonPlayer();
 		if (pFPPlayer->IsInAim())
 		{
 			// Update Rangefinder
@@ -174,7 +173,7 @@ void CNEOHud_Compass::DrawCompass() const
 		L"S", L"|", L"SW", L"|", L"W", L"|", L"NW", L"|", L"N", L"|", L"NE", L"|", L"E", L"|", L"SE", L"|",
 	};
 
-	auto player = C_NEO_Player::GetLocalNEOPlayer();
+	auto player = GetFirstPersonPlayer();
 	Assert(player);
 
 	surface()->DrawSetTextFont(m_hFont);


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Don't show ghost indicator on compass when spectating carrier and reduce ghost indicator jitter when spectating in first person by using the spectator target position and angles instead of the local player.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1427 
- related #

