### PR TITLE
Fix bad assert

### DIFF
--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -1142,7 +1142,19 @@ bool CNEOBaseCombatWeapon::ShouldDraw(void)
 	// No supernatural gunowners allowed here
 	if (!pOwner->IsAlive())
 	{
-		Assert(false);
+#if DEBUG
+		static int deathTicks[MAX_PLAYERS]{};
+		if (!*deathTicks)
+			for (int i = 0; i < ARRAYSIZE(deathTicks); ++i) deathTicks[i] = -1;
+		const int ownerIdx = pOwner->entindex();
+		const int deathTick = deathTicks[ownerIdx];
+		if (deathTick != -1)
+		{
+			int tickDelta = gpGlobals->tickcount - deathTick;
+			AssertMsg(tickDelta != 1, "Owner has been dead for two consecutive ticks!!");
+		}
+		deathTicks[ownerIdx] = gpGlobals->tickcount;
+#endif
 		return false;
 	}
 


### PR DESCRIPTION
## Description
Fix a case where a debug assert at client frame draw would fail before a weapon's dead owner was cleared from the weapon at the following tick. This assert would then keep spamming several times, depending on frame rate.

The faulty assert was originally introduced as part of #1394

## Toolchain
- Windows MSVC VS2022

## Linked Issues
