### PR TITLE
Don't reset until after the post round intermission.

### DIFF
--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -729,6 +729,7 @@ void CNEORules::ResetMapSessionCommon()
 	m_vecPreviousJuggernautSpawn = vec3_origin;
 	m_pJuggernautItem = nullptr;
 	m_pJuggernautPlayer = nullptr;
+	m_bGotMatchWinner = false;
 #endif
 }
 
@@ -1187,7 +1188,21 @@ void CNEORules::Think(void)
 		// Else if it's time to start the next round
 		else if (gpGlobals->curtime >= m_flNeoNextRoundStartTime)
 		{
-			StartNextRound();
+			if (m_bGotMatchWinner)
+			{
+				if (sv_neo_readyup_lobby.GetBool() && !sv_neo_readyup_autointermission.GetBool())
+				{
+					ResetMapSessionCommon();
+				}
+				else
+				{
+					GoToIntermission();
+				}
+			}
+			else
+			{
+				StartNextRound();
+			}
 		}
 
 		return;
@@ -3617,15 +3632,6 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 
 	if (gotMatchWinner)
 	{
-		if (sv_neo_readyup_lobby.GetBool() && !sv_neo_readyup_autointermission.GetBool())
-		{
-			ResetMapSessionCommon();
-		}
-		else
-		{
-			GoToIntermission();
-		}
-
 		IGameEvent *event = gameeventmanager->CreateEvent("game_end");
 		if (event)
 		{
@@ -3633,6 +3639,7 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 			gameeventmanager->FireEvent(event);
 		}
 	}
+	m_bGotMatchWinner = gotMatchWinner;
 }
 #endif
 

--- a/src/game/shared/neo/neo_gamerules.h
+++ b/src/game/shared/neo/neo_gamerules.h
@@ -439,6 +439,7 @@ private:
 	friend class CNEO_GhostBoundary;
 	Vector m_vecPreviousGhostSpawn = vec3_origin;
 	Vector m_vecPreviousJuggernautSpawn = vec3_origin;
+	bool m_bGotMatchWinner = false;
 #endif
 	CNetworkVar(int, m_nRoundStatus);
 	CNetworkVar(int, m_iHiddenHudElements);


### PR DESCRIPTION
## Description
Set a flag when a winner has been determined, and check that when it's time to start the new round.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
- fixes #1437
- fixes #1439

