### PR TITLE
Sync up deathcam duration between client/server and predict observer target

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -645,12 +645,6 @@ void C_BasePlayer::SetObserverMode ( int iNewMode )
 		{
 			// On a change of viewing mode or target, we may want to reset both head and torso to point at the new target.
 			g_ClientVirtualReality.AlignTorsoAndViewToWeapon();
-#ifdef NEO
-			if (iNewMode != OBS_MODE_DEATHCAM)
-			{
-				vieweffects->ClearAllFades();
-			}
-#endif
 		}
 	}
 }

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1401,6 +1401,11 @@ void CNEO_Player::PostThink(void)
 		}
 
 		auto observerMode = GetObserverMode();
+		if ((observerMode == OBS_MODE_DEATHCAM || observerMode == OBS_MODE_NONE) && gpGlobals->curtime >= (GetDeathTime() + DEATH_ANIMATION_TIME))
+		{ 
+			SetObserverMode(OBS_MODE_IN_EYE);
+		}
+
 		if (observerMode == OBS_MODE_CHASE || observerMode == OBS_MODE_IN_EYE)
 		{
 			auto target = GetObserverTarget();
@@ -1413,21 +1418,6 @@ void CNEO_Player::PostThink(void)
 				}
 			}
 		}
-
-		if ((observerMode == OBS_MODE_DEATHCAM || observerMode == OBS_MODE_NONE) && gpGlobals->curtime >= (GetDeathTime() + DEATH_ANIMATION_TIME))
-		{ // We switch observer mode to none to view own body in third person so assume should still be changing observer targets
-			auto target = GetObserverTarget();
-			if (!IsValidObserverTarget(target))
-			{
-				auto nextTarget = FindNextObserverTarget(false);
-				if (nextTarget && nextTarget != target)
-				{
-					SetObserverTarget(nextTarget);
-				}
-			}
-			SetObserverMode(OBS_MODE_IN_EYE);
-		}
-
 
 		return;
 	}

--- a/src/game/shared/baseplayer_shared.h
+++ b/src/game/shared/baseplayer_shared.h
@@ -31,7 +31,7 @@
 #define UPDATE_PLAYER_RADAR	2
 
 #ifdef NEO
-#define DEATH_ANIMATION_TIME	12.0f
+#define DEATH_ANIMATION_TIME	10.0f
 #else
 #define DEATH_ANIMATION_TIME	3.0f
 #endif


### PR DESCRIPTION
## Description
The client didn't set the observer mode to in eye after the deathcam animation, and moreover the duration differed by 2 seconds between client and server. The client now also predicts the new observer target, so high ping players shouldn't be able to see things they shouldn't.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1436
- fixes #1370 

