### PR TITLE
Clean up ready players center text. Print number in chat when players ready up.

### DIFF
--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -2182,7 +2182,7 @@ void CNEORules::CheckChatCommand(CNEO_Player *pNeoCmdPlayer, const char *pSzChat
 				}
 				else
 				{
-					char szReadyText[256];
+					char szReadyText[32];
 					V_sprintf_safe(szReadyText, "%d/%d players are ready.", readyPlayers.array[TEAM_JINRAI] + readyPlayers.array[TEAM_NSF], iThres * 2);
 					UTIL_ClientPrintAll(HUD_PRINTTALK, szReadyText);
 				}
@@ -2192,7 +2192,7 @@ void CNEORules::CheckChatCommand(CNEO_Player *pNeoCmdPlayer, const char *pSzChat
 				m_readyAccIDs.Remove(steamID.GetAccountID());
 				ClientPrint(pNeoCmdPlayer, HUD_PRINTTALK, "You are now marked as unready.");
 
-				char szReadyText[256];
+				char szReadyText[32];
 				const auto readyPlayers = FetchReadyPlayers();
 				V_sprintf_safe(szReadyText, "%d/%d players are ready.", readyPlayers.array[TEAM_JINRAI] + readyPlayers.array[TEAM_NSF], iThres * 2);
 				UTIL_ClientPrintAll(HUD_PRINTTALK, szReadyText);
@@ -2451,7 +2451,7 @@ void CNEORules::StartNextRound()
 				m_bIgnoreOverThreshold = false;
 			}
 
-			char szPrint[128];
+			char szPrint[64];
 			int needed = Max(2 * iThres - (readyPlayers.array[TEAM_JINRAI] + readyPlayers.array[TEAM_NSF]), 0);
 			V_sprintf_safe(szPrint, "- WAITING FOR %d %s TO READY UP -\n",
 				needed,


### PR DESCRIPTION
## Description
We can't make the center text stay longer, so instead clean it up to be more readable. Also print the actual number of ready players in chat each time a players readies or unreadies.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1438

