### PR TITLE
Antialias NeoUINormal font at low resolutions

### DIFF
--- a/game/neo/resource/ClientScheme.res
+++ b/game/neo/resource/ClientScheme.res
@@ -2136,6 +2136,7 @@ Scheme
 				"weight"	"550"
 				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
 				"yres"	"480 599"
+				"antialias"	"1"
 				//"additive"	"1"
 			}
 			"2"
@@ -2145,6 +2146,7 @@ Scheme
 				"weight"	"550"
 				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
 				"yres"	"600 767"
+				"antialias"	"1"
 				//"additive"	"1"
 			}
 			"3"


### PR DESCRIPTION
## Description
Add antialiasing for the NeoUINormal (the main menu) font also for the lower resolutions.

More information in [the issue page](https://github.com/NeotokyoRebuild/neo/issues/1451).

## Toolchain
N/A

## Linked Issues
- fixes #1451 

