### PR TITLE
chore: fix ChapterBackgrounds.txt ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,10 +51,6 @@ out
 /game/neo/resource/mp3player_db.txt
 /game/neo/resource/mp3settings.txt
 
-# Selected Background
-/game/neo/scripts/ChapterBackgrounds.txt
-/game/neo/scripts/chapterbackgrounds.txt
-
 # Object files
 *.o
 *.p
@@ -682,3 +678,7 @@ FodyWeavers.xsd
 !/game/bin/x64/
 !/game/bin/rebuild.fgd
 !/game/bin/**/[Gg]ame[Cc]onfig.txt
+
+
+# Selected Background
+/game/neo/scripts/[Cc]hapter[Bb]ackgrounds.txt


### PR DESCRIPTION
Something in our gitignore is overriding this base rule, and it's supremely annoying to have this file pop up in every single git staging. So here's a quick and dirty fix to make it go away, by simply moving the rule to the bottom of the file.