### PR TITLE
Fix crash when winning by capping the ghost during match point.

### DIFF
--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -1511,42 +1511,29 @@ void CNEORules::Think(void)
 			}
 		}
 	}
-	else if (!IsRoundLive())
+	else if (IsRoundLive())
 	{
-		if (!IsRoundOver())
+		COMPILE_TIME_ASSERT(TEAM_JINRAI == 2 && TEAM_NSF == 3);
+		if (GetGameType() != NEO_GAME_TYPE_TDM && GetGameType() != NEO_GAME_TYPE_DM && GetGameType() != NEO_GAME_TYPE_JGR)
 		{
-			if (GetGlobalTeam(TEAM_JINRAI)->GetAliveMembers() > 0 && GetGlobalTeam(TEAM_NSF)->GetAliveMembers() > 0)
+			for (int team = TEAM_JINRAI; team <= TEAM_NSF; ++team)
 			{
-				StartNextRound();
+				if (GetGlobalTeam(team)->GetAliveMembers() == 0)
+				{
+					SetWinningTeam(GetOpposingTeam(team), NEO_VICTORY_TEAM_ELIMINATION, false, true, false, false);
+				}
 			}
 		}
-	}
-	else
-	{
-		if (IsRoundLive())
+		if (GetGameType() == NEO_GAME_TYPE_DM && sv_neo_dm_win_xp.GetInt() > 0)
 		{
-			COMPILE_TIME_ASSERT(TEAM_JINRAI == 2 && TEAM_NSF == 3);
-			if (GetGameType() != NEO_GAME_TYPE_TDM && GetGameType() != NEO_GAME_TYPE_DM && GetGameType() != NEO_GAME_TYPE_JGR)
+			// End game early if there's already a player past the winning XP
+			CNEO_Player *pHighestPlayers[MAX_PLAYERS + 1] = {};
+			int iWinningTotal = 0;
+			int iWinningXP = 0;
+			GetDMHighestScorers(&pHighestPlayers, &iWinningTotal, &iWinningXP);
+			if (iWinningXP >= sv_neo_dm_win_xp.GetInt() && iWinningTotal == 1)
 			{
-				for (int team = TEAM_JINRAI; team <= TEAM_NSF; ++team)
-				{
-					if (GetGlobalTeam(team)->GetAliveMembers() == 0)
-					{
-						SetWinningTeam(GetOpposingTeam(team), NEO_VICTORY_TEAM_ELIMINATION, false, true, false, false);
-					}
-				}
-			}
-			if (GetGameType() == NEO_GAME_TYPE_DM && sv_neo_dm_win_xp.GetInt() > 0)
-			{
-				// End game early if there's already a player past the winning XP
-				CNEO_Player *pHighestPlayers[MAX_PLAYERS + 1] = {};
-				int iWinningTotal = 0;
-				int iWinningXP = 0;
-				GetDMHighestScorers(&pHighestPlayers, &iWinningTotal, &iWinningXP);
-				if (iWinningXP >= sv_neo_dm_win_xp.GetInt() && iWinningTotal == 1)
-				{
-					SetWinningDMPlayer(pHighestPlayers[0]);
-				}
+				SetWinningDMPlayer(pHighestPlayers[0]);
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Send `ghost_capture` event before ending the match and clearing `m_iGhosterPlayer`.

I'm very unsure about calling `StartNextRound` there because I don't understand the purpose of that if-statement, but if we set the match to Live after calling `ResetMapSessionCommon` in `SetWinningTeam` we end up in a weird limbo state. I'd much prefer not calling `ResetMapSessionCommon`, like in #1443, which does fix this crash on it's own, but, as mentioned there, causes a bot crash instead for whatever reason.
 
## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1461 
- related #1437 
