### PR TITLE
Auto player ping when enemy is shot

### DIFF
--- a/game/neo/resource/NeoModEvents.res
+++ b/game/neo/resource/NeoModEvents.res
@@ -89,7 +89,8 @@
 		"pingy"			"short"		// ping y position
 		"pingz"			"short"		// ping z position
 		"ghosterping"	"bool"		// the player is carrying the ghost
-		"shotping"		"bool"		// the player shot an enemy
+		"shotuserid"	"short"		// the player shot an enemy
+		"deathping"		"bool"		// the player was killed
 	}
 	
 	// inherited from NT

--- a/game/neo/resource/NeoModEvents.res
+++ b/game/neo/resource/NeoModEvents.res
@@ -89,6 +89,7 @@
 		"pingy"			"short"		// ping y position
 		"pingz"			"short"		// ping z position
 		"ghosterping"	"bool"		// the player is carrying the ghost
+		"shotping"		"bool"		// the player shot an enemy
 	}
 	
 	// inherited from NT

--- a/src/game/client/neo/ui/neo_hud_player_ping.cpp
+++ b/src/game/client/neo/ui/neo_hud_player_ping.cpp
@@ -85,12 +85,15 @@ void CNEOHud_PlayerPing::UpdateStateForNeoHudElementDraw()
 	const int playerTeam = localPlayer->GetTeamNumber();
 	for (int playerSlot = 0; playerSlot < gpGlobals->maxClients; playerSlot++)
 	{
-		if (gpGlobals->curtime >= m_iPlayerPings[playerSlot].deathTime || (playerTeam != TEAM_SPECTATOR && m_iPlayerPings[playerSlot].team != playerTeam))
+		if (gpGlobals->curtime < m_iPlayerPings[playerSlot].deathTime && (playerTeam == TEAM_SPECTATOR || m_iPlayerPings[playerSlot].team == playerTeam))
 		{
-			continue;
+			UpdateDistanceToPlayer(localPlayer, playerSlot, false);
 		}
 
-		UpdateDistanceToPlayer(localPlayer, playerSlot);
+		if (gpGlobals->curtime < m_iEnemyHitPings[playerSlot].deathTime && (playerTeam == TEAM_SPECTATOR || m_iEnemyHitPings[playerSlot].team == playerTeam))
+		{
+			UpdateDistanceToPlayer(localPlayer, playerSlot, true);
+		}
 	}
 }
 
@@ -126,14 +129,16 @@ void CNEOHud_PlayerPing::FireGameEvent(IGameEvent* event)
 
 		const int userID = event->GetInt("userid");
 		const int playerIndex = engine->GetPlayerForUserID(userID);
-		if (GetClientVoiceMgr()->IsPlayerBlocked(playerIndex))
+
+		bool isShotPing = event->GetBool("shotping");
+		if (!isShotPing && GetClientVoiceMgr()->IsPlayerBlocked(playerIndex))
 		{
 			return;
 		}
 
 		const Vector worldpos = Vector(event->GetInt("pingx"), event->GetInt("pingy"), event->GetInt("pingz"));
 		bool ghosterPing = event->GetBool("ghosterping");
-		SetPos(playerIndex - 1, playerTeam, worldpos, ghosterPing);
+		SetPos(playerIndex - 1, playerTeam, worldpos, ghosterPing, isShotPing);
 	}
 	else if (!Q_stricmp(eventName, "round_start"))
 	{
@@ -165,6 +170,109 @@ enum NeoPlayerPingsInSpectate
 	NEO_SPECTATE_PINGS_LAST_VALUE =		NEO_SPECTATE_PINGS_ALL
 };
 ConVar cl_neo_player_pings_in_spectate("cl_neo_player_pings_in_spectate", "1", FCVAR_ARCHIVE, "See pings of players playing the game. 0 = disabled, 1 = spectate target team, 2 = all", true, NEO_SPECTATE_PINGS_DISABLED, true, NEO_SPECTATE_PINGS_LAST_VALUE);
+void CNEOHud_PlayerPing::DrawPings(playerPing* pings, int localPlayerTeam, int spectateTargetTeam, int playerPingsInSpectate, bool isEnemyPings)
+{
+	int x, y, x2, y2;
+	for (int i = 0; i < gpGlobals->maxClients; i++)
+	{
+		Vector offset = Vector(0, 0, 32);
+		if (gpGlobals->curtime >= pings[i].deathTime || !GetVectorInScreenSpace(pings[i].worldPos, x, y) || !GetVectorInScreenSpace(pings[i].worldPos, x2, y2, &offset))
+		{
+			continue;
+		}
+
+		if (localPlayerTeam == TEAM_SPECTATOR && playerPingsInSpectate == 1 && pings[i].team != spectateTargetTeam)
+		{
+			continue;
+		}
+
+		constexpr float PING_NORMAL_OPACITY = 200;
+		constexpr float PING_OBSTRUCTED_OPACITY = 80;
+		float opacity = pings[i].noLineOfSight ? PING_OBSTRUCTED_OPACITY : PING_NORMAL_OPACITY;
+
+		constexpr float PING_FADE_START = 1.f;
+		const float timeTillDeath = pings[i].deathTime - gpGlobals->curtime;
+		if (timeTillDeath < PING_FADE_START)
+		{
+			opacity *= timeTillDeath / PING_FADE_START;
+		}
+
+		// Land animation
+		constexpr float PLAYER_PING_LIFETIME = 8;
+		constexpr float PING_PLACE_ANIMATION_DURATION = 0.5;
+		if (timeTillDeath > PLAYER_PING_LIFETIME - PING_PLACE_ANIMATION_DURATION)
+		{
+			constexpr float PING_PLACE_ANIMATION_MAX_OFFSET = 0.25;
+			y2 += ((y - y2) * PING_PLACE_ANIMATION_MAX_OFFSET) * sin(M_PI * (timeTillDeath - (PLAYER_PING_LIFETIME - PING_PLACE_ANIMATION_DURATION)) * (1 / PING_PLACE_ANIMATION_DURATION));
+		}
+
+		// Draw Ping Shape
+		const int halfTexture = pings[i].ghosterPing ? m_iTexTall * 0.8 : m_iTexTall * 0.5;
+		Color color = COLOR_RED;
+		if (!isEnemyPings)
+		{
+			color = pings[i].ghosterPing ? COLOR_GREY : (pings[i].team == TEAM_JINRAI) ? COLOR_JINRAI : COLOR_NSF;
+		}
+		color.SetColor(color.r(), color.g(), color.b(), opacity);
+		vgui::surface()->DrawSetColor(color);
+
+		int drawX = x2;
+		int drawY = y2;
+
+		if (isEnemyPings)
+		{
+			drawX = x;
+			drawY = y;
+		}
+
+		vgui::surface()->DrawTexturedRect(
+			drawX - halfTexture,
+			drawY - halfTexture,
+			drawX + halfTexture,
+			drawY + halfTexture);
+
+		if (!isEnemyPings)
+		{
+			// Draw Line to root of Ping
+			const Vector2D directionToOffset = Vector2D(x2 - x, y2 - y);
+			const float offsetLengthOnScreen = Vector2DLength(directionToOffset);
+			if (offsetLengthOnScreen > m_iTexTall)
+			{
+				// Offset the end position of the line so it doesn't draw over the ping icon
+				const int lineX2 = x + directionToOffset.x * ((offsetLengthOnScreen - m_iTexTall) / offsetLengthOnScreen);
+				const int lineY2 = y + directionToOffset.y * ((offsetLengthOnScreen - m_iTexTall) / offsetLengthOnScreen);
+
+				vgui::surface()->DrawLine(x - 1, y, lineX2 - 1, lineY2);
+				color.SetColor(COLOR_BLACK.r(), COLOR_BLACK.g(), COLOR_BLACK.b(), opacity);
+				vgui::surface()->DrawSetColor(color);
+				vgui::surface()->DrawLine(x, y + 1, lineX2, lineY2 + 1);
+			}
+		}
+
+		// Draw Distance to Ping in meters
+		vgui::surface()->DrawSetTextFont(pings[i].ghosterPing ? m_hFont : m_hFontSmall);
+		char m_szMarkerText[4 + 1] = {};
+		wchar_t m_wszMarkerTextUnicode[4 + 1] = {};
+		V_snprintf(m_szMarkerText, sizeof(m_szMarkerText), "%im", (int)pings[i].distance);
+		g_pVGuiLocalize->ConvertANSIToUnicode(m_szMarkerText, m_wszMarkerTextUnicode, sizeof(m_wszMarkerTextUnicode));
+		const int halfTextWidth = 0.5 * GetStringPixelWidth(m_wszMarkerTextUnicode, pings[i].ghosterPing ? m_hFont : m_hFontSmall);
+
+		// Adjust text position based on whether it's an enemy ping
+		int textDrawX = drawX;
+		int textDrawY = drawY;
+
+		color.SetColor(COLOR_BLACK.r(), COLOR_BLACK.g(), COLOR_BLACK.b(), opacity);
+		vgui::surface()->DrawSetTextColor(color);
+		vgui::surface()->DrawSetTextPos(textDrawX - halfTextWidth, textDrawY + 1 - m_iTexTall - m_iFontTall);
+		vgui::surface()->DrawPrintText(m_wszMarkerTextUnicode, 5);
+
+		color.SetColor(COLOR_WHITE.r(), COLOR_WHITE.g(), COLOR_WHITE.b(), opacity);
+		vgui::surface()->DrawSetTextColor(color);
+		vgui::surface()->DrawSetTextPos(textDrawX - 1 - halfTextWidth, textDrawY - m_iTexTall - m_iFontTall);
+		vgui::surface()->DrawPrintText(m_wszMarkerTextUnicode, 5);
+	}
+}
+
 void CNEOHud_PlayerPing::DrawNeoHudElement()
 {
 	if (!ShouldDraw() || !NEORules()->IsTeamplay())
@@ -191,90 +299,10 @@ void CNEOHud_PlayerPing::DrawNeoHudElement()
 		spectateTargetTeam = observerTarget->GetTeamNumber();
 	};
 
-	int x, y, x2, y2;
 	vgui::surface()->DrawSetTexture(m_hTexture);
-	for (int i = 0; i < gpGlobals->maxClients; i++)
-	{
-		Vector offset = Vector(0, 0, 32);
-		if (gpGlobals->curtime >= m_iPlayerPings[i].deathTime || !GetVectorInScreenSpace(m_iPlayerPings[i].worldPos, x, y) || !GetVectorInScreenSpace(m_iPlayerPings[i].worldPos, x2, y2, &offset))
-		{
-			continue;
-		}
-
-		if (localPlayerTeam == TEAM_SPECTATOR && playerPingsInSpectate == NEO_SPECTATE_PINGS_TARGET && m_iPlayerPings[i].team != spectateTargetTeam)
-		{
-			continue;
-		}
-
-		constexpr float PING_NORMAL_OPACITY = 200;
-		constexpr float PING_OBSTRUCTED_OPACITY = 80;
-		float opacity = m_iPlayerPings[i].noLineOfSight ? PING_OBSTRUCTED_OPACITY : PING_NORMAL_OPACITY;
-
-		constexpr float PING_FADE_START = 1.f;
-		const float timeTillDeath = m_iPlayerPings[i].deathTime - gpGlobals->curtime;
-		if (timeTillDeath < PING_FADE_START)
-		{
-			opacity *= timeTillDeath / PING_FADE_START;
-		}
-
-		// Land animation
-		constexpr float PLAYER_PING_LIFETIME = 8;
-		constexpr float PING_PLACE_ANIMATION_DURATION = 0.5;
-		if (timeTillDeath > PLAYER_PING_LIFETIME - PING_PLACE_ANIMATION_DURATION)
-		{
-			constexpr float PING_PLACE_ANIMATION_MAX_OFFSET = 0.25;
-			y2 += ((y - y2) * PING_PLACE_ANIMATION_MAX_OFFSET) * sin(M_PI * (timeTillDeath - (PLAYER_PING_LIFETIME - PING_PLACE_ANIMATION_DURATION)) * (1 / PING_PLACE_ANIMATION_DURATION));
-		}
-
-		// Idle animation
-		/*constexpr float PLAYER_PING_BOUNCE_INTERVAL = 2;
-		constexpr float PING_PLACE_ANIMATION_MAX_OFFSET = 0.2;
-		y2 += ((y - y2) * PING_PLACE_ANIMATION_MAX_OFFSET) * sin(M_PI * timeTillDeath * (2 / PLAYER_PING_BOUNCE_INTERVAL));*/
-
-		// Draw Ping Shape
-		const int halfTexture = m_iPlayerPings[i].ghosterPing ? m_iTexTall * 0.8 : m_iTexTall * 0.5;
-		Color color = m_iPlayerPings[i].ghosterPing ? COLOR_GREY : (m_iPlayerPings[i].team == TEAM_JINRAI) ? COLOR_JINRAI : COLOR_NSF;
-		color.SetColor(color.r(), color.g(), color.b(), opacity);
-		vgui::surface()->DrawSetColor(color);
-		vgui::surface()->DrawTexturedRect(
-			x2 - halfTexture,
-			y2 - halfTexture,
-			x2 + halfTexture,
-			y2 + halfTexture);
-
-		// Draw Line to root of Ping
-		const Vector2D directionToOffset = Vector2D(x2 - x, y2 - y);
-		const float offsetLengthOnScreen = Vector2DLength(directionToOffset);
-		if (offsetLengthOnScreen > m_iTexTall)
-		{
-			// Offset the end position of the line so it doesn't draw over the ping icon
-			const int lineX2 = x + directionToOffset.x * ((offsetLengthOnScreen - m_iTexTall) / offsetLengthOnScreen);
-			const int lineY2 = y + directionToOffset.y * ((offsetLengthOnScreen - m_iTexTall) / offsetLengthOnScreen);
-
-			vgui::surface()->DrawLine(x-1,y,lineX2-1,lineY2);
-			color.SetColor(COLOR_BLACK.r(), COLOR_BLACK.g(), COLOR_BLACK.b(), opacity);
-			vgui::surface()->DrawSetColor(color);
-			vgui::surface()->DrawLine(x, y+1, lineX2, lineY2+1);
-		}
-
-		// Draw Distance to Ping in meters
-		vgui::surface()->DrawSetTextFont(m_iPlayerPings[i].ghosterPing ? m_hFont : m_hFontSmall);
-		char m_szMarkerText[4 + 1] = {};
-		wchar_t m_wszMarkerTextUnicode[4 + 1] = {};
-		V_snprintf(m_szMarkerText, sizeof(m_szMarkerText), "%im", (int)m_iPlayerPings[i].distance);
-		g_pVGuiLocalize->ConvertANSIToUnicode(m_szMarkerText, m_wszMarkerTextUnicode, sizeof(m_wszMarkerTextUnicode));
-		const int halfTextWidth = 0.5 * GetStringPixelWidth(m_wszMarkerTextUnicode, m_iPlayerPings[i].ghosterPing ? m_hFont : m_hFontSmall);
-
-		color.SetColor(COLOR_BLACK.r(), COLOR_BLACK.g(), COLOR_BLACK.b(), opacity);
-		vgui::surface()->DrawSetTextColor(color);
-		vgui::surface()->DrawSetTextPos(x2 - halfTextWidth, y2 + 1 - m_iTexTall - m_iFontTall);
-		vgui::surface()->DrawPrintText(m_wszMarkerTextUnicode, 5);
-
-		color.SetColor(COLOR_WHITE.r(), COLOR_WHITE.g(), COLOR_WHITE.b(), opacity);
-		vgui::surface()->DrawSetTextColor(color);
-		vgui::surface()->DrawSetTextPos(x2 - 1 - halfTextWidth, y2 - m_iTexTall - m_iFontTall);
-		vgui::surface()->DrawPrintText(m_wszMarkerTextUnicode, 5);
-	}
+	
+	DrawPings(m_iPlayerPings, localPlayerTeam, spectateTargetTeam, playerPingsInSpectate, false);
+	DrawPings(m_iEnemyHitPings, localPlayerTeam, spectateTargetTeam, playerPingsInSpectate, true);
 }
 
 void CNEOHud_PlayerPing::Paint()
@@ -300,32 +328,37 @@ int CNEOHud_PlayerPing::GetStringPixelWidth(wchar_t* pString, vgui::HFont hFont)
 
 void CNEOHud_PlayerPing::HideAllPings()
 {
-	for (int i = 0; i < ARRAYSIZE(m_iPlayerPings); i++)
+	for (int i = 0; i < gpGlobals->maxClients; i++)
 	{
 		m_iPlayerPings[i].deathTime = 0;
+		m_iEnemyHitPings[i].deathTime = 0;
 	}
 }
 
-void CNEOHud_PlayerPing::UpdateDistanceToPlayer(C_BasePlayer* player, const int playerSlot)
+void CNEOHud_PlayerPing::UpdateDistanceToPlayer(C_BasePlayer* player, const int playerSlot, bool isShotPing)
 {
-	m_iPlayerPings[playerSlot].distance = METERS_PER_INCH * player->GetAbsOrigin().DistTo(m_iPlayerPings[playerSlot].worldPos);
+	playerPing* pings = isShotPing ? m_iEnemyHitPings : m_iPlayerPings;
+
+	pings[playerSlot].distance = METERS_PER_INCH * player->GetAbsOrigin().DistTo(pings[playerSlot].worldPos);
 
 	trace_t tr;
-	UTIL_TraceLine(player->EyePosition(), m_iPlayerPings[playerSlot].worldPos, MASK_VISIBLE_AND_NPCS, player, COLLISION_GROUP_NONE, &tr);
-	m_iPlayerPings[playerSlot].noLineOfSight = tr.fraction < 0.999;
+	UTIL_TraceLine(player->EyePosition(), pings[playerSlot].worldPos, MASK_VISIBLE_AND_NPCS, player, COLLISION_GROUP_NONE, &tr);
+	pings[playerSlot].noLineOfSight = tr.fraction < 0.999;
 }
 
-void CNEOHud_PlayerPing::SetPos(const int playerSlot, const int playerTeam, const Vector& pos, bool ghosterPing) {
+void CNEOHud_PlayerPing::SetPos(const int playerSlot, const int playerTeam, const Vector& pos, bool ghosterPing, bool isShotPing) {
 	constexpr float PLAYER_PING_LIFETIME = 8;
 	auto localPlayer = C_NEO_Player::GetLocalNEOPlayer();
 	if (!localPlayer) { return; }
 
-	m_iPlayerPings[playerSlot].worldPos = pos;
-	m_iPlayerPings[playerSlot].deathTime = gpGlobals->curtime + PLAYER_PING_LIFETIME;
-	m_iPlayerPings[playerSlot].team = playerTeam;
-	m_iPlayerPings[playerSlot].ghosterPing = ghosterPing;
+	playerPing* pings = isShotPing ? m_iEnemyHitPings : m_iPlayerPings;
 
-	UpdateDistanceToPlayer(localPlayer, playerSlot);
+	pings[playerSlot].worldPos = pos;
+	pings[playerSlot].deathTime = gpGlobals->curtime + PLAYER_PING_LIFETIME;
+	pings[playerSlot].team = playerTeam;
+	pings[playerSlot].ghosterPing = ghosterPing;
+
+	UpdateDistanceToPlayer(localPlayer, playerSlot, isShotPing);
 	const int playerPingsInSpectate = cl_neo_player_pings_in_spectate.GetInt();
 	if (GetLocalPlayerTeam() == TEAM_SPECTATOR && playerPingsInSpectate != NEO_SPECTATE_PINGS_ALL)
 	{
@@ -348,13 +381,13 @@ void CNEOHud_PlayerPing::SetPos(const int playerSlot, const int playerTeam, cons
 			return;
 		}
 	}
-	NotifyPing(playerSlot);
+	NotifyPing(playerSlot, isShotPing);
 }
 
 ConVar snd_ping_volume("snd_ping_volume", "0.33", FCVAR_ARCHIVE, "Player ping volume", true, 0.f, true, 1.f);
 ConVar cl_neo_player_pings_chat_message("cl_neo_player_pings_chat_message", "1", FCVAR_ARCHIVE, "Show message in chat for player pings.", true, 0, true, 1); // NEO TODO (Adam) custom chat filter instead?
 ConVar cl_neo_player_pings_time_between_sounds("cl_neo_player_pings_time_between_sounds", "0", FCVAR_ARCHIVE, "Minimum time between two ping sounds", true, 0, false, 0);
-void CNEOHud_PlayerPing::NotifyPing(const int playerSlot)
+void CNEOHud_PlayerPing::NotifyPing(const int playerSlot, bool isShotPing)
 {
 	C_NEO_Player* pPlayer = static_cast<C_NEO_Player*>(UTIL_PlayerByIndex(playerSlot + 1));
 	if (!pPlayer || pPlayer->IsLocalPlayer())
@@ -362,7 +395,7 @@ void CNEOHud_PlayerPing::NotifyPing(const int playerSlot)
 		return;
 	}
 
-	if (cl_neo_player_pings_chat_message.GetBool())
+	if (!isShotPing && cl_neo_player_pings_chat_message.GetBool())
 	{
 		CBaseHudChat* hudChat = (CBaseHudChat*)GET_HUDELEMENT(CHudChat);
 		if (hudChat)
@@ -400,7 +433,8 @@ void CNEOHud_PlayerPing::NotifyPing(const int playerSlot)
 	et.m_flVolume = snd_ping_volume.GetFloat();
 	et.m_pOrigin = const_cast<Vector *>(&m_iPlayerPings[playerSlot].worldPos);*/
 
-	const Vector* origin = const_cast<Vector *>(&m_iPlayerPings[playerSlot].worldPos);
+	playerPing* pings = isShotPing ? m_iEnemyHitPings : m_iPlayerPings;
+	const Vector* origin = const_cast<Vector *>(&pings[playerSlot].worldPos);
 
 	CLocalPlayerFilter filter;
 	//CBaseEntity::EmitSound(filter, SOUND_FROM_WORLD, et);

--- a/src/game/client/neo/ui/neo_hud_player_ping.h
+++ b/src/game/client/neo/ui/neo_hud_player_ping.h
@@ -34,13 +34,15 @@ protected:
 	virtual void FireGameEvent(IGameEvent* event) override;
 
 private:
+	void DrawPings(playerPing* pings, int localPlayerTeam, int spectateTargetTeam, int playerPingsInSpectate, bool isEnemyPings);
 	int GetStringPixelWidth(wchar_t* pString, vgui::HFont hFont);
-	void UpdateDistanceToPlayer(C_BasePlayer* player, const int pingIndex);
-	void SetPos(const int index, const int playerTeam, const Vector& pos, bool ghosterPing);
-	void NotifyPing(const int playerSlot);
+	void UpdateDistanceToPlayer(C_BasePlayer* player, const int pingIndex, bool isShotPing);
+	void SetPos(const int index, const int playerTeam, const Vector& pos, bool ghosterPing, bool isShotPing);
+	void NotifyPing(const int playerSlot, bool isShotPing);
 
 private:
 	playerPing m_iPlayerPings[MAX_PLAYERS] = {};
+	playerPing m_iEnemyHitPings[MAX_PLAYERS] = {};
 
 	int m_iPosX, m_iPosY;
 

--- a/src/game/client/neo/ui/neo_hud_player_ping.h
+++ b/src/game/client/neo/ui/neo_hud_player_ping.h
@@ -12,6 +12,7 @@ struct playerPing
 	int team;
 	bool noLineOfSight;
 	bool ghosterPing;
+	int victimUserID;
 };
 
 class CNEOHud_PlayerPing : public CNEOHud_ChildElement, public CHudElement, public vgui::Panel
@@ -34,15 +35,16 @@ protected:
 	virtual void FireGameEvent(IGameEvent* event) override;
 
 private:
-	void DrawPings(playerPing* pings, int localPlayerTeam, int spectateTargetTeam, int playerPingsInSpectate, bool isEnemyPings);
+	void DrawPings(playerPing* pings, int localPlayerTeam, int spectateTargetTeam, int playerPingsInSpectate, bool isEnemyPings, bool isDeathPing);
 	int GetStringPixelWidth(wchar_t* pString, vgui::HFont hFont);
-	void UpdateDistanceToPlayer(C_BasePlayer* player, const int pingIndex, bool isShotPing);
-	void SetPos(const int index, const int playerTeam, const Vector& pos, bool ghosterPing, bool isShotPing);
-	void NotifyPing(const int playerSlot, bool isShotPing);
+	void UpdateDistanceToPlayer(C_BasePlayer* player, const int pingIndex, bool isShotPing, bool isDeathPing);
+	void SetPos(const int index, const int playerTeam, const Vector& pos, bool ghosterPing, bool isShotPing, bool isDeathPing, int shotUserID);
+	void NotifyPing(const int playerSlot, bool isShotPing, bool isDeathPing);
 
 private:
 	playerPing m_iPlayerPings[MAX_PLAYERS] = {};
 	playerPing m_iEnemyHitPings[MAX_PLAYERS] = {};
+	playerPing m_iDeathPings[MAX_PLAYERS] = {};
 
 	int m_iPosX, m_iPosY;
 
@@ -54,6 +56,7 @@ private:
 	int m_iFontTall;
 
 	vgui::HTexture m_hTexture = 0UL;
+	vgui::HTexture m_hDeathPingTexture = 0UL;
 	int m_iTexWidth, m_iTexHeight;
 	int m_iTexTall;
 };

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1994,6 +1994,21 @@ void CNEO_Player::Event_Killed( const CTakeDamageInfo &info )
 		StartShowDmgStats(&info);
 	}
 
+	IGameEvent* event = gameeventmanager->CreateEvent("player_ping");
+	if (event)
+	{
+		const Vector& pos = info.GetDamagePosition();
+		event->SetInt("userid", GetUserID());
+		event->SetInt("playerteam", GetTeamNumber());
+		event->SetInt("pingx", pos.x);
+		event->SetInt("pingy", pos.y);
+		event->SetInt("pingz", pos.z);
+		event->SetBool("ghosterping", false);
+		event->SetInt("shotuserid", 0);
+		event->SetBool("deathping", true);
+		gameeventmanager->FireEvent(event);
+	}
+
 	if (NEORules()->GetGameType() == NEO_GAME_TYPE_TDM)
 	{
 		GetGlobalTeam(NEORules()->GetOpposingTeam(this))->AddScore(1);
@@ -2951,7 +2966,8 @@ int	CNEO_Player::OnTakeDamage_Alive(const CTakeDamageInfo& info)
 							evt->SetInt("pingy", pos.y);
 							evt->SetInt("pingz", pos.z);
 							evt->SetBool("ghosterping", false);
-							evt->SetBool("shotping", true);
+							evt->SetInt("shotuserid", GetUserID());
+							evt->SetBool("deathping", false);
 
 							gameeventmanager->FireEvent(evt);
 						}

--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -158,6 +158,7 @@ void CheckPingButton(CNEO_Player* player)
 		event->SetInt("pingy", tr.endpos.y);
 		event->SetInt("pingz", tr.endpos.z);
 		event->SetBool("ghosterping", player->IsCarryingGhost() || player->m_iNeoClass == NEO_CLASS_VIP);
+		event->SetInt("shotuserid", 0);
 #ifdef GAME_DLL
 		gameeventmanager->FireEvent(event);
 #else


### PR DESCRIPTION
## Description
This system automatically generates a `player_ping` event, marking the enemy's position, whenever an attacker damages them with a bullet or buckshot, provided both players have mutual clear line of sight (checked with smoke occlusion).

## Toolchain
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0
