### PR TITLE
Replace `neo_aim_hold` with keybind hold/toggle

### DIFF
--- a/game/neo/cfg/user_default.scr
+++ b/game/neo/cfg/user_default.scr
@@ -63,12 +63,6 @@ DESCRIPTION INFO_OPTIONS
 		{ NUMBER -20 40 } // Alternatively SLIDER, but can't have both?
 		{ "0" }
 	}
-	"neo_aim_hold"
-	{
-		"Hold To Aim"
-		{ BOOL }
-		{ "0" }
-	}
 	"cl_autoreload_when_empty"
 	{
 		"Reload When Empty"

--- a/game/neo/scripts/kb_act.lst
+++ b/game/neo/scripts/kb_act.lst
@@ -20,6 +20,7 @@
 "+attack"				"#Valve_Primary_Attack"
 "+attack2"				"Special"
 "+aim"	 	            "Aim"
+"toggle_aim"	 	    "Aim (toggle)"
 "+reload"				"#Valve_Reload_Weapon"
 "+use"					"#Valve_Use_Items"
 "slot1"					"Primary Weapon"

--- a/game/neo/scripts/kb_def.lst
+++ b/game/neo/scripts/kb_def.lst
@@ -50,7 +50,7 @@
 "MWHEELDOWN" "invprev"
 "MWHEELUP" "invnext"
 "MOUSE1" "+attack"
-"MOUSE2" "+aim"
+"MOUSE2" "toggle_aim"
 "MOUSE3" "+attack3"
 "PAUSE" "pause"
 "`" "neo_toggleconsole"

--- a/src/game/client/in_main.cpp
+++ b/src/game/client/in_main.cpp
@@ -551,6 +551,18 @@ void IN_SpecNextDown(const CCommand &args) { KeyDown(&in_spec_next, args[1]); }
 void IN_SpecPrevUp(const CCommand &args) { KeyUp(&in_spec_prev, args[1]); }
 void IN_SpecPrevDown(const CCommand &args) { KeyDown(&in_spec_prev, args[1]); }
 
+void IN_AimToggle(const CCommand& args)
+{
+	if (::input->KeyState(&in_aim))
+	{
+		KeyUp(&in_aim, args[1]);
+	}
+	else
+	{
+		KeyDown(&in_aim, args[1]);
+	}
+}
+
 void IN_LeanLeftToggle(const CCommand& args)
 {
 	if (::input->KeyState(&in_lean_left))
@@ -1760,6 +1772,8 @@ static ConCommand enddrop("-toss", IN_DropUp);
 
 static ConCommand startaim("+aim", IN_AimDown);
 static ConCommand endaim("-aim", IN_AimUp);
+
+static ConCommand toggle_aim("toggle_aim", IN_AimToggle);
 
 static ConCommand startleanleft("+leanl", IN_LeanLeftDown);
 static ConCommand endleanleft("-leanl", IN_LeanLeftUp);

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -1333,7 +1333,6 @@ void C_NEO_Player::PostThink(void)
 
 	if (auto *pNeoWep = static_cast<C_NEOBaseCombatWeapon *>(GetActiveWeapon()))
 	{
-		const bool clientAimHold = ClientWantsAimHold(this);
 		if (pNeoWep->m_bInReload && !m_bPreviouslyReloading)
 		{
 			Weapon_SetZoom(false);
@@ -1342,14 +1341,14 @@ void C_NEO_Player::PostThink(void)
 		{
 			Weapon_SetZoom(false);
 		}
-		else if (clientAimHold ? (m_nButtons & IN_AIM && !IsInAim()) : m_afButtonPressed & IN_AIM)
+		else if (m_nButtons & IN_AIM && !IsInAim())
 		{
 			if (!CanSprint() || !(m_nButtons & IN_SPEED))
 			{
-				Weapon_AimToggle(pNeoWep, clientAimHold ? NEO_TOGGLE_FORCE_AIM : NEO_TOGGLE_DEFAULT);
+				Weapon_AimToggle(pNeoWep, NEO_TOGGLE_FORCE_AIM);
 			}
 		}
-		else if (clientAimHold && (m_afButtonReleased & IN_AIM))
+		else if (m_afButtonReleased & IN_AIM)
 		{
 			Weapon_AimToggle(pNeoWep, NEO_TOGGLE_FORCE_UN_AIM);
 		}

--- a/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/src/game/client/neo/ui/neo_root_settings.cpp
@@ -388,7 +388,6 @@ void NeoSettingsRestore(NeoSettings *ns, const NeoSettings::Keys::Flags flagsKey
 		pGeneral->bMarkerSpecOnlyClantag = cvr->cl_neo_clantag_friendly_marker_spec_only.GetBool();
 		pGeneral->iFov = cvr->neo_fov.GetInt();
 		pGeneral->iViewmodelFov = cvr->neo_viewmodel_fov_offset.GetInt();
-		pGeneral->bAimHold = cvr->neo_aim_hold.GetBool();
 		pGeneral->bReloadEmpty = cvr->cl_autoreload_when_empty.GetBool();
 		pGeneral->bViewmodelRighthand = cvr->cl_righthand.GetBool();
 		pGeneral->bLeanViewmodelOnly = cvr->cl_neo_lean_viewmodel_only.GetBool();
@@ -686,7 +685,6 @@ void NeoSettingsSave(const NeoSettings *ns)
 		cvr->cl_neo_clantag_friendly_marker_spec_only.SetValue(pGeneral->bMarkerSpecOnlyClantag);
 		cvr->neo_fov.SetValue(pGeneral->iFov);
 		cvr->neo_viewmodel_fov_offset.SetValue(pGeneral->iViewmodelFov);
-		cvr->neo_aim_hold.SetValue(pGeneral->bAimHold);
 		cvr->cl_autoreload_when_empty.SetValue(pGeneral->bReloadEmpty);
 		cvr->cl_righthand.SetValue(pGeneral->bViewmodelRighthand);
 		cvr->cl_neo_lean_viewmodel_only.SetValue(pGeneral->bLeanViewmodelOnly);
@@ -942,7 +940,6 @@ void NeoSettings_General(NeoSettings *ns)
 
 	NeoUI::SliderInt(L"FOV", &pGeneral->iFov, 75, 110);
 	NeoUI::SliderInt(L"Viewmodel FOV Offset", &pGeneral->iViewmodelFov, -20, 40);
-	NeoUI::RingBoxBool(L"Aim hold", &pGeneral->bAimHold);
 	NeoUI::RingBoxBool(L"Reload empty", &pGeneral->bReloadEmpty);
 	NeoUI::RingBoxBool(L"Right hand viewmodel", &pGeneral->bViewmodelRighthand);
 	NeoUI::RingBoxBool(L"Lean viewmodel only", &pGeneral->bLeanViewmodelOnly);

--- a/src/game/client/neo/ui/neo_root_settings.h
+++ b/src/game/client/neo/ui/neo_root_settings.h
@@ -46,7 +46,6 @@ struct NeoSettings
 		bool bMarkerSpecOnlyClantag;
 		int iFov;
 		int iViewmodelFov;
-		bool bAimHold;
 		bool bReloadEmpty;
 		bool bViewmodelRighthand;
 		bool bLeanViewmodelOnly;
@@ -208,7 +207,6 @@ struct NeoSettings
 		CONVARREF_DEF(cl_neo_clantag_friendly_marker_spec_only);
 		CONVARREF_DEF(neo_fov);
 		CONVARREF_DEF(neo_viewmodel_fov_offset);
-		CONVARREF_DEF(neo_aim_hold);
 		CONVARREF_DEF(cl_autoreload_when_empty);
 		CONVARREF_DEF(cl_righthand);
 		CONVARREF_DEF(cl_neo_lean_viewmodel_only);

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1504,7 +1504,6 @@ void CNEO_Player::PostThink(void)
 
 	if (auto *pNeoWep = static_cast<CNEOBaseCombatWeapon *>(GetActiveWeapon()))
 	{
-		const bool clientAimHold = ClientWantsAimHold(this);
 		if (pNeoWep->m_bInReload && !m_bPreviouslyReloading)
 		{
 			Weapon_SetZoom(false);
@@ -1513,14 +1512,14 @@ void CNEO_Player::PostThink(void)
 		{
 			Weapon_SetZoom(false);
 		}
-		else if (clientAimHold ? (m_nButtons & IN_AIM && !IsInAim()) : m_afButtonPressed & IN_AIM)
+		else if (m_nButtons & IN_AIM && !IsInAim())
 		{
 			if (!CanSprint() || !(m_nButtons & IN_SPEED))
 			{
-				Weapon_AimToggle(pNeoWep, clientAimHold ? NEO_TOGGLE_FORCE_AIM : NEO_TOGGLE_DEFAULT);
+				Weapon_AimToggle(pNeoWep, NEO_TOGGLE_FORCE_AIM);
 			}
 		}
-		else if (clientAimHold && (m_afButtonReleased & IN_AIM))
+		else if (m_afButtonReleased & IN_AIM)
 		{
 			Weapon_AimToggle(pNeoWep, NEO_TOGGLE_FORCE_UN_AIM);
 		}

--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -32,7 +32,6 @@
 ConVar cl_autoreload_when_empty("cl_autoreload_when_empty", "1", FCVAR_USERINFO | FCVAR_ARCHIVE,
 	"Automatically start reloading when the active weapon becomes empty.",
 	true, 0.0f, true, 1.0f);
-ConVar neo_aim_hold("neo_aim_hold", "0", FCVAR_USERINFO | FCVAR_ARCHIVE, "Hold to aim as opposed to toggle aim.", true, 0.0f, true, 1.0f);
 #endif
 
 ConVar sv_neo_dev_loadout("sv_neo_dev_loadout", "0", FCVAR_CHEAT | FCVAR_REPLICATED | FCVAR_HIDDEN | FCVAR_DONTRECORD, "", true, 0.0f, true, 1.0f);
@@ -99,20 +98,6 @@ CBaseCombatWeapon* GetNeoWepWithBits(const CNEO_Player* player, const NEO_WEP_BI
 	}
 
 	return NULL;
-}
-
-bool ClientWantsAimHold(const CNEO_Player* player)
-{
-#ifdef CLIENT_DLL
-	return neo_aim_hold.GetBool();
-#else
-	if (!player || player->IsBot())
-	{
-		return false;
-	}
-
-	return 1 == atoi(engine->GetClientConVarValue(engine->IndexOfEdict(player->edict()), "neo_aim_hold"));
-#endif
 }
 
 #ifdef CLIENT_DLL

--- a/src/game/shared/neo/neo_player_shared.h
+++ b/src/game/shared/neo/neo_player_shared.h
@@ -247,12 +247,10 @@ enum NeoLeanDirectionE {
 };
 
 enum NeoWeponAimToggleE {
-	NEO_TOGGLE_DEFAULT = 0,
+	NEO_TOGGLE_NIL = 0,
 	NEO_TOGGLE_FORCE_AIM,
 	NEO_TOGGLE_FORCE_UN_AIM,
 };
-
-bool ClientWantsAimHold(const CNEO_Player* player);
 
 void CheckPingButton(CNEO_Player* player);
 


### PR DESCRIPTION

<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
* Convar `neo_aim_hold` will no longer exists and instead replaced by keybind versions
* Also could be an opportunity to add binding on NT;RE updates, but this to be dealt with as a separate PR. Otherwise this could interfere with players on the next update.
* Default keybind changed from `+aim` to `toggle_aim`
* TODO: Double-check on dedicated servers
* If #1487 gets in first, update within this PR to deal with keybind update, otherwise another PR

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
- Windows MSVC VS2022
-->
- Linux GCC Distro Native Arch/GCC 15

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1481
* related #1332

