### PR TITLE
Add function for restricting external cvars/cmds

### DIFF
--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -906,6 +906,8 @@ static void RestrictNeoClientCheats()
 	// These cheat names can be either ConVars or ConCommands
 	constexpr const char* cheats[]{
 		"building_cubemaps",
+		"cl_showerror",
+		"net_showmsg",
 	};
 
 	constexpr auto flags = FCVAR_CHEAT;


### PR DESCRIPTION
## Description
Some ConVars and ConCommands are declared in external libraries beyond our control, so we can't set their cheat flags at their construction. But we can manually adjust the flags at client systems init to mark them as cheats, which is what this does.

This is not a conclusive list, but rather just implements the functionality.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1488 

