### PR TITLE
Add custom core SourceMod gamedata

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -536,6 +536,11 @@ if(NEO_INSTALL_LIBRARIES)
     endif()
 
     if(OS_LINUX AND NEO_GENERATE_GAMEDATA)
+        install(
+            FILES "${CMAKE_SOURCE_DIR}/gamedata/core.games/custom/game.neo.txt"
+            DESTINATION "${INSTALL_PATH_PREFIX}-gamedata/neo/addons/sourcemod/gamedata/core.games/custom"
+        )
+
         get_target_property(SERVER_GAMEDATA_SDKHOOKS_OUTPUT_FILE server GAMEDATA_SDKHOOKS_OUTPUT_FILE)
         install(
             FILES ${SERVER_GAMEDATA_SDKHOOKS_OUTPUT_FILE}

--- a/src/gamedata/core.games/custom/game.neo.txt
+++ b/src/gamedata/core.games/custom/game.neo.txt
@@ -1,0 +1,29 @@
+"Games"
+{
+	"#default"
+	{
+		"Offsets"
+		{
+			"CSendPropExtra_UtlVector::m_Offset"
+			{
+				"windows64"	"28"
+				"linux64"	"28"
+			}
+		}
+	}
+	
+	"#default"
+	{
+		"#supported"
+		{
+			"game"	"neo"
+		}
+
+		"Keys"
+		{
+			"HudRadioMenuMsg"	"ShowMenu"
+			"RadioMenuTimeout"	"4"
+			"HudTextMsg"		"HudMsg"
+		}
+	}
+}


### PR DESCRIPTION
## Description
Add missing gamedata entries from core.games, which fixes non-working menu.

## Toolchain
- Linux GCC Native [Arch Linux, g++ (GCC) 15.2.1 20250813]

## Linked Issues
- related #1475
- related #1466
- related #842

