### PR TITLE
Fix CMake for forked repos' CI runners

### DIFF
--- a/src/cmake/build_info.cmake
+++ b/src/cmake/build_info.cmake
@@ -9,6 +9,19 @@ execute_process(
 )
 string(SUBSTRING "${GIT_LONGHASH}" 0 7 GIT_HASH)
 
+set(UPSTREAM_URL "https://github.com/NeotokyoRebuild/neo")
+execute_process(
+    COMMAND git remote get-url origin
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE THIS_REMOTE_URL
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+# Must fetch tags from upstream in forked repos to guarantee the "git describe --tags (...)" command works
+if (NOT "${THIS_REMOTE_URL}" STREQUAL "${UPSTREAM_URL}")
+execute_process(
+    COMMAND git fetch ${UPSTREAM_URL} --force --tags
+)
+endif()
 execute_process(
     COMMAND git describe --tags --abbrev=0 --match v*
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
## Description
Fix the build_info.cmake for forked repos' CI to ensure that tags from upstream are fetched before attempting to read them.

This seems to be a bug from #1487 since the commit previous to that merge works fine.

## Error logs
From a failed GH runner in a fork:
```
 fatal: No names found, cannot describe anything.
-- GIT_LATESTTAG: 
CMake Error at cmake/build_info.cmake:23 (message):
  Failed to get git tag
Call Stack (most recent call first):
  CMakeLists.txt:19 (include)


-- Configuring incomplete, errors occurred!
```

## Toolchain
N/A

## Linked Issues
