### PR TITLE
Stop health bars in new squad list overlapping onto adjacent squad mates / the central timer element

### DIFF
--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -800,19 +800,20 @@ void CNEOHud_RoundState::DrawPlayer(int playerIndex, int teamIndex, const TeamLo
 	if (!g_PR->IsAlive(playerIndex))
 		return;
 
+	const int health = g_PR->GetDisplayedHealth(playerIndex, 0);
 	if (health_monochrome) {
-		const int greenBlueValue = (g_PR->GetDisplayedHealth(playerIndex, 0) / 100.0f) * 255;
+		const int greenBlueValue = (health / 100.0f) * 255;
 		surface()->DrawSetColor(Color(255, greenBlueValue, greenBlueValue, 255));
 	}
 	else {
-		if (g_PR->GetHealth(playerIndex) <= 20)
+		if (health <= 20)
 			surface()->DrawSetColor(COLOR_RED);
-		else if (g_PR->GetHealth(playerIndex) <= 80)
+		else if (health <= 80)
 			surface()->DrawSetColor(COLOR_YELLOW);
 		else
 			surface()->DrawSetColor(COLOR_WHITE);
 	}
-	surface()->DrawFilledRect(xOffset, Y_POS + m_ilogoSize + 2, xOffset + (g_PR->GetHealth(playerIndex) / 100.0f * m_ilogoSize), Y_POS + m_ilogoSize + 6);
+	surface()->DrawFilledRect(xOffset, Y_POS + m_ilogoSize + 2, xOffset + (health / 100.0f * m_ilogoSize), Y_POS + m_ilogoSize + 6);
 }
 
 void CNEOHud_RoundState::CheckActiveStar()


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

fixes this 
<img width="671" height="119" alt="image" src="https://github.com/user-attachments/assets/eec7d6df-dc4f-45f1-88df-47f3cdce372e" />


## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

