### PR TITLE
update alive player count when spectator

### DIFF
--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -711,7 +711,6 @@ void CNEOHud_RoundState::DrawPlayerList()
 
 int CNEOHud_RoundState::DrawPlayerRow(int playerIndex, const int yOffset, bool small)
 {
-
 	// Draw player
 	static constexpr int SQUAD_MATE_TEXT_LENGTH = 62; // 31 characters in name without end character max plus 3 in short rank name plus 7 max in class name plus 3 max in health plus other characters
 	char squadMateText[SQUAD_MATE_TEXT_LENGTH];


### PR DESCRIPTION
## Description
Alive player count should update when the scoreboard is open #1505


## Toolchain
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
- fixes #1505


