### PR TITLE
Remove bone merge from default items

### DIFF
--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -2957,12 +2957,17 @@ CBaseEntity* CNEO_Player::GiveNamedItem(const char* szName, int iSubType)
 {
 	auto* item = BaseClass::GiveNamedItem(szName, iSubType);
 
-	if (item && szName && FStrEq(szName, "weapon_tachi"))
+	if (item)
 	{
-		const char* tachiPref = engine->GetClientConVarValue(entindex(), "cl_neo_tachi_prefer_auto");
-		if (tachiPref && *tachiPref && (V_atoi(tachiPref) != 0))
+		item->RemoveEffects( EF_BONEMERGE );
+
+		if (szName && FStrEq(szName, "weapon_tachi"))
 		{
-			assert_cast<CWeaponTachi*>(item)->ForceSetFireMode(Tachi::Firemode::Auto);
+			const char* tachiPref = engine->GetClientConVarValue(entindex(), "cl_neo_tachi_prefer_auto");
+			if (tachiPref && *tachiPref && (V_atoi(tachiPref) != 0))
+			{
+				assert_cast<CWeaponTachi*>(item)->ForceSetFireMode(Tachi::Firemode::Auto);
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Items given through GiveNamedItem do not get switched to even when the player has no other items, so this should be fine. Fixes an issue where players have their utility in their hands when they first spawn, instead of attached to their body
<img width="1663" height="1292" alt="image" src="https://github.com/user-attachments/assets/66375f25-4f2e-497b-87eb-6eafc2310bb1" />

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

