### PR TITLE
Don't make the damage dealt text red if a player was killed by the localplayer on a previous round but not the current round

### DIFF
--- a/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
+++ b/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
@@ -143,6 +143,12 @@ void CNEOHud_KillerDamageInfo::resetHUDState()
 			}
 		}
 	}
+	
+	C_NEO_Player *localPlayer = C_NEO_Player::GetLocalNEOPlayer();
+	if (localPlayer)
+	{
+		V_memset(localPlayer->m_rfNeoPlayerIdxsKilledByLocal, false, sizeof(localPlayer->m_rfNeoPlayerIdxsKilledByLocal));
+	}
 	ResetDisplayInfos();
 }
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Recommend using "neo_bot_quota 2" and the default bot fill mode, and either "neo_bot_ignore_real_players 1" or "nb_player_stop 1".

Kill a bot in a round, and then hit them at least once but dont kill them on the second round and then let them kill you. Your damage dealt to the bot in round 2 should be white, not red

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1515

