### PR TITLE
Fix sound pool starvation for very rapid gunfire

### DIFF
--- a/src/game/shared/baseentity_shared.cpp
+++ b/src/game/shared/baseentity_shared.cpp
@@ -1951,8 +1951,14 @@ void CBaseEntity::FireBullets( const FireBulletsInfo_t &info )
 #ifdef GAME_DLL
 			UpdateShotStatistics( tr );
 
+#ifdef NEO
+			const int soundEntChannel = (info.m_nFlags & FIRE_BULLETS_TEMPORARY_DANGER_SOUND)
+				? SOUNDENT_CHANNEL_BULLET_IMPACT
+				: (neoWeapon->IsAutomatic() ? SOUNDENT_CHANNEL_REPEATING : SOUNDENT_CHANNEL_WEAPON);
+#else
 			// For shots that don't need persistance
 			int soundEntChannel = ( info.m_nFlags&FIRE_BULLETS_TEMPORARY_DANGER_SOUND ) ? SOUNDENT_CHANNEL_BULLET_IMPACT : SOUNDENT_CHANNEL_UNSPECIFIED;
+#endif
 
 			CSoundEnt::InsertSound( SOUND_BULLET_IMPACT, tr.endpos, 200, 0.5, this, soundEntChannel );
 #endif

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -181,7 +181,7 @@ public:
 	int GetNumShotsFired(void) const { return m_nNumShotsFired; }
 
 	// Whether this weapon should fire automatically when holding down the attack.
-	virtual bool IsAutomatic(void) const
+	inline virtual bool IsAutomatic(void) const
 	{
 		return ((GetNeoWepBits() & (NEO_WEP_AA13 | NEO_WEP_JITTE | NEO_WEP_JITTE_S |
 			NEO_WEP_KNIFE | NEO_WEP_MPN | NEO_WEP_MPN_S | NEO_WEP_MX | NEO_WEP_MX_S |
@@ -193,7 +193,7 @@ public:
 	}
 
 	// Whether this weapon should fire only once per each attack command, even if held down.
-	bool IsSemiAuto(void) const { return !IsAutomatic(); }
+	inline bool IsSemiAuto(void) const { return !IsAutomatic(); }
 
 	virtual const Vector& GetBulletSpread(void) override;
 	virtual const WeaponSpreadInfo_t& GetSpreadInfo(void);

--- a/src/game/shared/neo/weapons/weapon_tachi.h
+++ b/src/game/shared/neo/weapons/weapon_tachi.h
@@ -55,7 +55,7 @@ public:
 	virtual int	GetMinBurst() OVERRIDE { return 1; }
 	virtual int	GetMaxBurst() OVERRIDE { return 3; }
 
-	virtual bool IsAutomatic(void) const OVERRIDE
+	inline virtual bool IsAutomatic(void) const override final
 	{
 		return (m_bIsPrimaryFireMode == Tachi::Firemode::Auto);
 	}


### PR DESCRIPTION
## Description
Fix the sound pool running out of free allocations when very many weapons are firing rapidly simultaneously.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1523

