### PR TITLE
Bots slow down if far ahead of teammates

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "Path/NextBotChasePath.h"
-
+#include "bot/neo_bot_contextual_query_interface.h"
 
 //
 // Roam around the map attacking enemies
 //
-class CNEOBotSeekAndDestroy : public Action< CNEOBot >
+class CNEOBotSeekAndDestroy : public Action< CNEOBot >, public CNEOBotContextualQueryInterface
 {
 public:
 	CNEOBotSeekAndDestroy( float duration = -1.0f );
@@ -22,6 +22,8 @@ public:
 
 	virtual QueryResultType	ShouldRetreat( const INextBot *me ) const;					// is it time to retreat?
 	virtual QueryResultType ShouldHurry( const INextBot *me ) const;					// are we in a hurry?
+	virtual QueryResultType ShouldWalk( const CNEOBot *me, const QueryResultType qShouldAimQuery ) const override;					// are we to walk?
+	virtual QueryResultType ShouldAim(const CNEOBot *me, const bool bWepHasClip) const override;
 
 	virtual EventDesiredResult< CNEOBot > OnTerritoryCaptured( CNEOBot *me, int territoryID );
 	virtual EventDesiredResult< CNEOBot > OnTerritoryLost( CNEOBot *me, int territoryID );

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -2657,24 +2657,29 @@ QueryResultType CNEOBotBehavior::ShouldWalk(const CNEOBot *me, const QueryResult
 {
 	QueryResultType result = ANSWER_UNDEFINED;
 
-	auto *neoAction = static_cast<CNEOBotMainAction *>(m_action);
-	if ( neoAction )
+	Action<CNEOBot> *action = m_action;
+	if ( action )
 	{
 		// find innermost child action
-		CNEOBotMainAction *action;
-		for( action = neoAction; action->m_child; action = static_cast<CNEOBotMainAction *>(action->m_child) )
-			;
+		while( action->GetActiveChildAction() )
+        {
+			action = action->GetActiveChildAction();
+        }
 
 		// work our way through our containers
 		while( action && result == ANSWER_UNDEFINED )
 		{
-			CNEOBotMainAction *containingAction = static_cast<CNEOBotMainAction *>(action->m_parent);
+			Action<CNEOBot> *containingAction = action->GetParentAction();
 
 			// work our way up the stack
 			while( action && result == ANSWER_UNDEFINED )
 			{
-				result = action->ShouldWalk(me, qShouldAimQuery);
-				action = static_cast<CNEOBotMainAction *>(action->GetActionBuriedUnderMe());
+                auto *query = dynamic_cast<const CNEOBotContextualQueryInterface *>(action);
+                if (query)
+                {
+				    result = query->ShouldWalk(me, qShouldAimQuery);
+                }
+				action = action->GetActionBuriedUnderMe();
 			}
 
 			action = containingAction;
@@ -2693,24 +2698,29 @@ QueryResultType CNEOBotBehavior::ShouldAim(const CNEOBot *me, const bool bWepHas
 {
 	QueryResultType result = ANSWER_UNDEFINED;
 
-	auto *neoAction = static_cast<CNEOBotMainAction *>(m_action);
-	if ( neoAction )
+	Action<CNEOBot> *action = m_action;
+	if ( action )
 	{
 		// find innermost child action
-		CNEOBotMainAction *action;
-		for( action = neoAction; action->m_child; action = static_cast<CNEOBotMainAction *>(action->m_child) )
-			;
+		while( action->GetActiveChildAction() )
+        {
+			action = action->GetActiveChildAction();
+        }
 
 		// work our way through our containers
 		while( action && result == ANSWER_UNDEFINED )
 		{
-			CNEOBotMainAction *containingAction = static_cast<CNEOBotMainAction *>(action->m_parent);
+			Action<CNEOBot> *containingAction = action->GetParentAction();
 
 			// work our way up the stack
 			while( action && result == ANSWER_UNDEFINED )
 			{
-				result = action->ShouldAim(me, bWepHasClip);
-				action = static_cast<CNEOBotMainAction *>(action->GetActionBuriedUnderMe());
+                auto *query = dynamic_cast<const CNEOBotContextualQueryInterface *>(action);
+                if (query)
+                {
+				    result = query->ShouldAim(me, bWepHasClip);
+                }
+				action = action->GetActionBuriedUnderMe();
 			}
 
 			action = containingAction;


### PR DESCRIPTION
## Description
Leverages the walk intention interface to slow down the travel speed of bots to allow their teammates to catch up when approaching the CTG objective.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1534 
- related #1535 

(Requires the above PRs to be accepted before, as currently bots in a team will clump together which presents a friendly fire and splash damage risk.)

