### PR TITLE
Fix: Bot didn't have plan when repathing

### DIFF
--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -1915,6 +1915,12 @@ void CNEOBot::RepathIfFriendlyBlockingLineOfFire()
 		return;
 	}
 
+	const PathFollower* pPath = GetCurrentPath();
+	if (!pPath)
+	{
+		return;
+	}
+
 	if (!m_repathAroundFriendlyTimer.IsElapsed())
 	{
 		return;
@@ -1932,7 +1938,6 @@ void CNEOBot::RepathIfFriendlyBlockingLineOfFire()
 
 	if (!IsLineOfFireClearOfFriendlies(eyePos, targetPos))
 	{
-		const PathFollower* pPath = GetCurrentPath();
 		Vector goal = pPath->GetEndPosition();
 
 		CNEOBotPathCost cost(this, SAFEST_ROUTE);


### PR DESCRIPTION
## Description
Sometimes a bot doesn't have a path plan when the repathing code triggers around a friendly which leads to an access error.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1535

