### PR TITLE
Support both hold/toggle aim to see previous player in spectator mode

### DIFF
--- a/src/game/client/clientmode_shared.cpp
+++ b/src/game/client/clientmode_shared.cpp
@@ -815,7 +815,7 @@ int ClientModeShared::HandleSpectatorKeyInput( int down, ButtonCode_t keynum, co
 	}
 #ifdef NEO
 	else if (down && pszCurrentBinding &&
-			 (Q_strcmp(pszCurrentBinding, "+specprevplayer") == 0 || Q_strcmp(pszCurrentBinding, "+aim") == 0))
+			 (Q_strcmp(pszCurrentBinding, "+specprevplayer") == 0 || Q_strcmp(pszCurrentBinding, "+aim") == 0 || Q_strcmp(pszCurrentBinding, "toggle_aim") == 0))
 #else
 	else if ( down && pszCurrentBinding && Q_strcmp( pszCurrentBinding, "+attack2" ) == 0 )
 #endif


### PR DESCRIPTION
## Description
Support both hold/toggle aim to see previous player in spectator mode.  (Previously only hold aim would toggle to previous spectate player.)

## Toolchain
- Windows MSVC VS2022

