### PR TITLE
Fix DM bot crashes with death/respawn and team enforcement tweaks

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -71,6 +71,16 @@ ActionResult< CNEOBot >	CNEOBotMainAction::Update( CNEOBot *me, float interval )
 {
 	VPROF_BUDGET( "CNEOBotMainAction::Update", "NextBot" );
 
+	// If bot is already dead at this point, make sure it's dead.
+	// This check prevents the main behavior loop from executing on dead bots, which can happen
+	// if a bot dies during a frame or enters an invalid state like Observer mode.
+	// Executing main behavior (like looking for enemies or navigating) on a dead/observer bot
+	// can lead to crashes due to invalid entity state or accessing components that shouldn't be accessed.
+	if ( !me->IsAlive() )
+	{
+		return ChangeTo( new CNEOBotDead, "I'm actually dead" );
+	}
+
 	// TEAM_UNASSIGNED -> deathmatch
 	if ( me->GetTeamNumber() != TEAM_JINRAI && me->GetTeamNumber() != TEAM_NSF && me->GetTeamNumber() != TEAM_UNASSIGNED )
 	{

--- a/src/game/server/neo/bot/behavior/neo_bot_dead.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_dead.cpp
@@ -47,7 +47,12 @@ ActionResult< CNEOBot >	CNEOBotDead::Update( CNEOBot *me, float interval )
 	{
 		if ( g_pGameRules->FPlayerCanRespawn( me ) )
 		{
-			respawn( me, !me->IsObserver() );
+			// Defer respawn to outside of the behavior update loop.
+			// Calling respawn() here triggers CNEOBot::Spawn -> INextBot::Reset -> delete m_behavior.
+			// If we delete the behavior while we are executing a method of an action belonging to it,
+			// we cause a use-after-free when the stack unwinds back to Behavior::Update.
+			me->m_bWantsRespawn = true;
+			me->m_bRespawnCopyCorpse = !me->IsObserver();
 		}
 	}
 

--- a/src/game/server/neo/bot/neo_bot.h
+++ b/src/game/server/neo/bot/neo_bot.h
@@ -436,6 +436,9 @@ public:
 	int m_iIntendTeam = 0;
 	int m_iProfileIdx = -1;
 
+	bool m_bWantsRespawn = false;
+	bool m_bRespawnCopyCorpse = false;
+
 private:
 	CNEOBotLocomotion *m_locomotor;
 	CNEOBotBody *m_body;

--- a/src/game/server/neo/bot/neo_bot_manager.cpp
+++ b/src/game/server/neo/bot/neo_bot_manager.cpp
@@ -346,7 +346,10 @@ void CNEOBotManager::MaintainBotQuota()
 	{
 		int iTeam = TEAM_UNASSIGNED;
 
-		if ( NEORules()->IsTeamplay() && iTeam == TEAM_UNASSIGNED )
+		// In DeathMatch (DM), bots must still be assigned to valid teams (JINRAI/NSF) instead of TEAM_UNASSIGNED.
+		// TEAM_UNASSIGNED forces bots into a limbo/Observer state that the bot logic isn't designed to handle, leading to crashes.
+		// By forcing them onto teams, we ensure they have a valid state and can participate in the DM logic (treating everyone as enemy).
+		if ( iTeam == TEAM_UNASSIGNED )
 		{
 			CTeam* pJinrai = GetGlobalTeam(TEAM_JINRAI);
 			CTeam* pNSF = GetGlobalTeam(TEAM_NSF);


### PR DESCRIPTION
## Description
Addresses #1418's crash on round startup when bots are added.  Other DM mode related bugs are considered out of scope for this PR.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1418

