### PR TITLE
Update VS 2022 docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ To be safe and avoid problems with VAC, it's recommended to add a [-insecure](ht
 #### VS2022 + CMake (Windows)
 In the CMake Target View, right-click "client (shared library)" and click on "Add Debug Configuration". This should generate the `src/.vs/launch.vs.json` config file.
 
-Modify the config to your liking; example is provided below:
+Modify the config to fix the directory paths; an example is provided below:
 
 ```
 {


### PR DESCRIPTION
## Description
This is a follow-up to #1184 

The bug with the CMake Target view debug configurations generation was patched in version Visual Studio 2022 v17.14.22: https://developercommunity.visualstudio.com/t/Cant-create-launchvsjson-for-CMake-ex/10913931#T-N11014006

Now, the feature should work for an up-to-date IDE without needing any workarounds.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1184 

