### PR TITLE
Fix Steam release script compatibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -557,12 +557,9 @@ endif()
 
 if(NEO_INSTALL_RESOURCES)
     install(
-        DIRECTORY ${CMAKE_SOURCE_DIR}/../game/neo
-        DESTINATION "${INSTALL_PATH_PREFIX}-resources"
-    )
-    install(
         DIRECTORY
         ${CMAKE_SOURCE_DIR}/../game/bin
+        ${CMAKE_SOURCE_DIR}/../game/neo
         DESTINATION "${INSTALL_PATH_PREFIX}-resources"
     )
 endif()


### PR DESCRIPTION
## Description
Undo the resources artifact's base dir change to avoid breakage in the Steam release scripts, and instead manually install the `/../game/bin/` configs.

### Expected file layout of resources.zip
```
APP ROOT
¦
+---bin
¦   ¦   GameConfig.txt (the 32bit Hammer one)
¦   ¦   rebuild.fgd
¦   ¦   
¦   +---x64
¦           GameConfig.txt (the 64bit Hammer one)
¦           
+---neo
```

## Toolchain
N/A

## Linked Issues


