### PR TITLE
Improve release assets compression

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -337,7 +337,7 @@ jobs:
       uses: actions/download-artifact@v4
 
     - name: Packing artifacts
-      run: 'parallel 7z a -tzip -mx=9 "{}.zip" "./{}/*" ::: neo-*'
+      run: 'parallel 7z a -t7z -m0=lzma -mx=9 "{}.7z" "./{}/*" ::: neo-*'
 
     - name: Create & upload latest build
       env:
@@ -347,7 +347,7 @@ jobs:
         # Delete old "latest" (delete step always returns true so that even if there's no release, it still uploads)
         gh release delete latest --cleanup-tag --yes --repo "$REPO_INFO" || true
         # Create new "latest"
-        gh release create latest neo-*.zip --prerelease --title "Latest Master Build" --repo "$REPO_INFO"
+        gh release create latest neo-*.7z --prerelease --title "Latest Master Build" --repo "$REPO_INFO"
 
   upload-release:
     name: Upload Release
@@ -366,10 +366,10 @@ jobs:
       run: 'rm -r *-Debug'
 
     - name: Packing artifacts
-      run: 'parallel 7z a -tzip -mx=9 "{= s/neo-(.*)/neo-$GITHUB_REF_NAME-\1.zip/ =}" "./{}/*" ::: neo-*'
+      run: 'parallel 7z a -t7z -m0=lzma -mx=9 "{= s/neo-(.*)/neo-$GITHUB_REF_NAME-\1.7z/ =}" "./{}/*" ::: neo-*'
 
     - name: Upload assets to a release
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_INFO: ${{ github.repository }}
-      run: 'gh release upload "$GITHUB_REF_NAME" neo-*.zip --clobber --repo "$REPO_INFO"'
+      run: 'gh release upload "$GITHUB_REF_NAME" neo-*.7z --clobber --repo "$REPO_INFO"'


### PR DESCRIPTION
## Description

### Summary

* Change the GitHub release assets' archive format from ZIP to 7-Zip
* Change the archive compression algorithm from DEFLATE to LZMA

Optimize release assets for file size, because the compress/decompress performance difference between these settings is negligible for our data.

At time of this commit, the total (release + debug) assets size before this patch is about 946 MB. After this patch, the total size is about 638 MB. So this change results in about 33% size (and download time) reduction for the release assets.

## Compatibility

### Users

Because the Windows file explorer GUI natively supports 7-Zip decompression since Windows 11 22H2 (released late 2022), this change should not affect the regular user experience for people with an up-to-date Windows machine. And since 7z is a fairly well-known format, I doubt it should cause confusion even for those whose OS doesn't have native extraction capability.

### Steam release script

This is a breaking change for the Steam release script, because both the archive format (ZIP -> 7-Zip) and the file extension (`<filename>.zip` -> `<filename>.7z`) have changed. As such, this PR should not be merged before confirming compatibility with the Steam release script.

The actual file name patterns aside from the file extension remain unchanged.

## Alternatives considered

### The asset format

Alternatively, we could've changed the ZIP algorithm used to LZMA, as support for it was [added to the ZIP spec](https://pkwaredownloads.blob.core.windows.net/pkware-general/Documentation/APPNOTE-6.3.0.TXT) already in 2006, but as of this PR date, Windows file explorer still does not natively handle LZMA-compressed ZIP archives extraction. Therefore, to avoid users confusing LZMA-compressed ZIPs as being corrupted, I chose to instead change the entire archive format to 7-Zip (which is fully compatible for native .7z extraction with modern Windows 11).

### Compressing intermediate build artifacts

I also experimented with changing the upload-artifact action's [compression config](https://github.com/actions/upload-artifact?tab=readme-ov-file#altering-compressions-level-speed-v-size) between 1 (best speed) and 9 (best compression) from the default value of 6, but this made no meaningful difference in the CI job speeds (+/- a couple seconds, which could've been random load variance). So I decided to not change that from the default.

## Toolchain
N/A

## Linked Issues

