### PR TITLE
Stop bots from retreating from ghost carrier

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
@@ -176,6 +176,15 @@ ActionResult< CNEOBot >	CNEOBotRetreatToCover::Update( CNEOBot *me, float interv
 {
 	const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat( true );
 
+	if ( threat && threat->GetEntity() && threat->GetEntity()->IsPlayer() )
+	{
+		CNEO_Player *pThreatPlayer = ToNEOPlayer( threat->GetEntity() );
+		if ( pThreatPlayer && pThreatPlayer->IsCarryingGhost() )
+		{
+			return Done( "Stopping retreat because my threat is the ghost carrier" );
+		}
+	}
+
 	if ( ShouldRetreat( me ) == ANSWER_NO )
 		return Done( "No longer need to retreat" );
 


### PR DESCRIPTION
## Description
There was an edge case related to #1534 where retreating bots will retreat forever from a ghost carrier, because the ghost carrier is always visible to enemies, so the threat never goes away for a retreating bot. This PR causes bots to not consider ghost carriers as a threat that needs retreating from.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1534

