### PR TITLE
Reduce bot ammo waste from spraying

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.h
@@ -51,6 +51,7 @@ private:
 	bool m_isWaitingForFullReload;
 
 	void FireWeaponAtEnemy( CNEOBot *me );
+	float GetFireDurationByDifficulty( CNEOBot *me ) const;
 
 	CHandle< CBaseEntity > m_lastTouch;
 	float m_lastTouchTime;


### PR DESCRIPTION
## Description
Reduces bot ammo waste from spraying, by reducing the minimum time spraying based on difficulty, while also interrupting sprays when the line of fire checks fail when firing at an enemy.

Also incidentally fixes bots being able to shoot as the Juggernaut, as the player weapon relied on a novel weapon cooling mechanic that led to the refusal to fire for bots.

## Toolchain
- Windows MSVC VS2022
