### PR TITLE
Disable xray in maps with friendly markers disabled

### DIFF
--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -1461,7 +1461,7 @@ void C_NEO_Player::TeamChange(int iNewTeam)
 #ifdef GLOWS_ENABLE
 void C_NEO_Player::UpdateGlowEffects(int iNewTeam)
 {
-	if (!glow_outline_effect_enable.GetBool() || (!NEORules()->IsTeamplay() && GetLocalPlayerTeam() != TEAM_SPECTATOR) || NEORules()->GetHiddenHudElements() & NEO_HUD_ELEMENT_FRIENDLY_MARKER)
+	if (!glow_outline_effect_enable.GetBool() || NEORules()->GetHiddenHudElements() & NEO_HUD_ELEMENT_FRIENDLY_MARKER)
 	{
 		return;
 	}


### PR DESCRIPTION
## Description
Title

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1565

