### PR TITLE
Fix projectiles colliding with dropped weapons

### DIFF
--- a/src/game/server/neo/neo_detpack.cpp
+++ b/src/game/server/neo/neo_detpack.cpp
@@ -41,7 +41,7 @@ void CNEODeployedDetpack::Spawn(void)
 	constexpr float NEO_DETPACK_GRAVITY = 1.f;
 	SetGravity(NEO_DETPACK_GRAVITY);
 	SetFriction(sv_neo_grenade_friction.GetFloat());
-	SetCollisionGroup(COLLISION_GROUP_WEAPON);
+	SetCollisionGroup(COLLISION_GROUP_PROJECTILE);
 
 	m_flDamage = NEO_DETPACK_DAMAGE;
 	m_DmgRadius = NEO_DETPACK_DAMAGE_RADIUS;

--- a/src/game/server/neo/neo_grenade.cpp
+++ b/src/game/server/neo/neo_grenade.cpp
@@ -44,7 +44,7 @@ void CNEOGrenadeFrag::Spawn(void)
 	SetElasticity(sv_neo_grenade_cor.GetFloat());
 	SetGravity(sv_neo_grenade_gravity.GetFloat());
 	SetFriction(sv_neo_grenade_friction.GetFloat());
-	SetCollisionGroup(COLLISION_GROUP_WEAPON);
+	SetCollisionGroup(COLLISION_GROUP_PROJECTILE);
 	SetDetonateTimerLength(FLT_MAX);
 
 	SetThink(&CNEOGrenadeFrag::DelayThink);

--- a/src/game/server/neo/neo_smokegrenade.cpp
+++ b/src/game/server/neo/neo_smokegrenade.cpp
@@ -53,7 +53,7 @@ void CNEOGrenadeSmoke::Spawn(void)
 	SetElasticity(sv_neo_grenade_cor.GetFloat());
 	SetGravity(sv_neo_grenade_gravity.GetFloat());
 	SetFriction(sv_neo_grenade_friction.GetFloat());
-	SetCollisionGroup(COLLISION_GROUP_WEAPON);
+	SetCollisionGroup(COLLISION_GROUP_PROJECTILE);
 	SetDetonateTimerLength(FLT_MAX);
 
 	SetThink(&CNEOGrenadeSmoke::DelayThink);


### PR DESCRIPTION
## Description
In #915 and #891 projectiles were set to use `COLLISION_GROUP_WEAPON` which is probably incorrect as they collide with dropped weapons which is not parity. Changing them to `COLLISION_GROUP_PROJECTILE` does not appear to bring back the colliding with players issue nor have I found any side effects of this change...

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1567 

