### PR TITLE
Fix neo_restart_this leaking edicts

### DIFF
--- a/src/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -1241,6 +1241,11 @@ void CHL2MPRules::CheckRestartGame( void )
 
 	if ( iRestartDelay > 0 )
 	{
+#ifdef NEO
+		if (iRestartDelay != MAGIC_NEO_RESTART_THIS)
+		{
+#endif
+
 		if ( iRestartDelay > 60 )
 			iRestartDelay = 60;
 
@@ -1250,6 +1255,11 @@ void CHL2MPRules::CheckRestartGame( void )
 		Q_snprintf( strRestartDelay, sizeof( strRestartDelay ), "%d", iRestartDelay );
 		UTIL_ClientPrintAll( HUD_PRINTCENTER, "Game will restart in %s1 %s2", strRestartDelay, iRestartDelay == 1 ? "SECOND" : "SECONDS" );
 		UTIL_ClientPrintAll( HUD_PRINTCONSOLE, "Game will restart in %s1 %s2", strRestartDelay, iRestartDelay == 1 ? "SECOND" : "SECONDS" );
+
+#ifdef NEO
+		}
+		else iRestartDelay = 0;
+#endif
 
 		m_flRestartGameTime = gpGlobals->curtime + iRestartDelay;
 		m_bCompleteReset = true;

--- a/src/game/shared/multiplay_gamerules.cpp
+++ b/src/game/shared/multiplay_gamerules.cpp
@@ -108,7 +108,7 @@ ConVar neo_restart_this("neo_restart_this", "0", FCVAR_GAMEDLL, "If non-zero, ga
 	[](IConVar* var, const char* pOldValue, float flOldValue)->void {
 		if (ConVarRef(var).GetBool())
 		{
-			if (NEORules()) NEORules()->RestartGame();
+			mp_restartgame.SetValue(MAGIC_NEO_RESTART_THIS);
 		}
 		var->SetValue("0");
 	});

--- a/src/game/shared/neo/neo_gamerules.h
+++ b/src/game/shared/neo/neo_gamerules.h
@@ -30,6 +30,11 @@
 	#define CNEOGameRulesProxy C_NEOGameRulesProxy
 #endif
 
+// NEO JANK (Rain): magic value for signaling a mp_restart originated from "neo_restart_this".
+// This is a hack around neo_restart_this leaking edicts for some reason; for now, it just
+// repurposes the mp_restartgame logic but without the HL2DM-style center print.
+constexpr float MAGIC_NEO_RESTART_THIS = 0xdaff;
+
 class CNEOGameRulesProxy : public CHL2MPGameRulesProxy
 {
 public:


### PR DESCRIPTION
## Description
For some reason, calling RestartGame directly from the neo_restart_this change callback does not clean up edicts correctly, which leads to an edict starvation and a subsequent game crash when using `neo_restart_this 1` repeatedly in a sufficiently complex map.

Because we don't have support for the SDK native `mp_restartgame_immediate`, and we don't want `neo_restart_this` to mimic the SDK native `mp_restartgame` center of screen printout, this commit works around those limitations by calling `mp_restartgame` with a magic value that we intercept from `CHL2MPRules::CheckRestartGame`, and then monkey with the values to achieve parity-ish map reset behaviour while sidestepping the edict leak problem.

This is a complete hack and should be revisited, but since the command is essentially broken currently, this is better than nothing for the time being.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1580 
