### PR TITLE
Fix crash on "sv_specnoclip 0"

### DIFF
--- a/src/game/shared/hl2mp/hl2mp_player_shared.cpp
+++ b/src/game/shared/hl2mp/hl2mp_player_shared.cpp
@@ -70,6 +70,10 @@ Vector CHL2MP_Player::GetAttackSpread( CBaseCombatWeapon *pWeapon, CBaseEntity *
 //-----------------------------------------------------------------------------
 void CHL2MP_Player::PlayStepSound( Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force )
 {
+#ifdef NEO
+	if (!psurface) return;
+#endif
+
 	if ( gpGlobals->maxClients > 1 && !sv_footsteps.GetFloat() )
 		return;
 


### PR DESCRIPTION
## Description
Fix a nullptr dereference crash when attempting to play nonexistant footstep sounds for a spectator who is "walking"/gliding across a floor, when the `sv_specnoclip 0` cvar is preventing them from noclipping through the floor surface.

Callstack:

```
Exception thrown: read access violation.
**psurface** was nullptr.

>	server.dll!CHL2MP_Player::PlayStepSound(Vector & vecOrigin, surfacedata_t * psurface, float fvol, bool force) Line 112	C++
 	server.dll!CNEO_Player::PlayStepSound(Vector & vecOrigin, surfacedata_t * psurface, float fvol, bool force) Line 2469	C++
 	server.dll!CGameMovement::PlayerRoughLandingEffects(float fvol) Line 4165	C++
 	server.dll!CGameMovement::TryPlayerMove(Vector * pFirstDest, CGameTrace * pFirstTrace, float flSlideMultiplier) Line 2979	C++
 	server.dll!CGameMovement::FullObserverMove() Line 2366	C++
 	server.dll!CGameMovement::PlayerMove() Line 4978	C++
 	server.dll!CGameMovement::ProcessMovement(CBasePlayer * pPlayer, CMoveData * pMove) Line 1201	C++
 	server.dll!CHL2GameMovement::ProcessMovement(CBasePlayer * pPlayer, CMoveData * pMove) Line 538	C++
 	server.dll!CPlayerMove::RunCommand(CBasePlayer * player, CUserCmd * ucmd, IMoveHelper * moveHelper) Line 428	C++
 	server.dll!CBasePlayer::PlayerRunCommand(CUserCmd * ucmd, IMoveHelper * moveHelper) Line 4000	C++
 	server.dll!CHL2_Player::PlayerRunCommand(CUserCmd * ucmd, IMoveHelper * moveHelper) Line 1306	C++
 	server.dll!CBasePlayer::PhysicsSimulate() Line 3490	C++
 	server.dll!Physics_SimulateEntity(CBaseEntity * pEntity) Line 2019	C++
 	server.dll!Physics_RunThinkFunctions(bool simulating) Line 2075	C++
 	server.dll!CServerGameDLL::GameFrame(bool simulating) Line 1281	C++
 	[External Code]	
```

## Toolchain
- Windows MSVC VS2022

## Linked Issues

- fixes #1584 