### PR TITLE
Set m_bJuggernautItemExists with certainty, always transmit the juggernaut to clients

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_jgr_capture.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_jgr_capture.cpp
@@ -93,10 +93,12 @@ ActionResult<CNEOBot> CNEOBotJgrCapture::Update( CNEOBot *me, float interval )
 
 	if ( me->GetAbsOrigin().DistToSqr( m_hObjective->GetAbsOrigin() ) < CNEO_Juggernaut::GetUseDistanceSquared() )
 	{
-		CNEO_Juggernaut *pJuggernaut = m_hObjective.Get();
-		if ( NEORules()->IsJuggernautLocked() || (pJuggernaut && pJuggernaut->m_bLocked) )
+		if ( NEORules()->IsJuggernautLocked() )
 		{
+#ifdef DEBUG
+			auto pJuggernaut = m_hObjective.Get();
 			Assert( NEORules()->IsJuggernautLocked() == (pJuggernaut && pJuggernaut->m_bLocked) );
+#endif
 			me->ReleaseUseButton();
 			return SuspendFor( new CNEOBotRetreatToCover( 2.0f ), "Juggernaut is locked, taking cover to wait for it to unlock" );
 		}

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -3397,6 +3397,12 @@ int CNEO_Player::ShouldTransmit(const CCheckTransmitInfo* pInfo)
 	if (IsCarryingGhost())
 		return FL_EDICT_ALWAYS;
 
+	// The Juggernaut position is always displayed on the compass
+	// Don't just check the player class here. We need THE juggernaut
+	// or else we could end up networking JGR players when we dont need to
+	if (NEORules()->GetJuggernautPlayer() == entindex())
+		return FL_EDICT_ALWAYS;
+
 	const auto* otherNeoPlayer = assert_cast<CNEO_Player*>(Instance(pInfo->m_pClientEnt));
 
 	if (otherNeoPlayer->GetTeamNumber() == TEAM_SPECTATOR ||

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -1182,6 +1182,7 @@ void CNEORules::Think(void)
 			m_iGhosterTeam = TEAM_UNASSIGNED;
 			m_iGhosterPlayer = 0;
 			m_pJuggernautItem = nullptr;
+			m_bJuggernautItemExists = false;
 			m_pJuggernautPlayer = nullptr;
 			m_iJuggernautPlayerIndex = 0;
 		}
@@ -1408,12 +1409,6 @@ void CNEORules::Think(void)
 
 			m_pJuggernautItem->m_bLocked = false;
 		}
-
-		m_bJuggernautItemExists = true;
-	}
-	else
-	{
-		m_bJuggernautItemExists = false;
 	}
 
 	if (GetGameType() == NEO_GAME_TYPE_JGR && IsRoundLive())
@@ -2091,6 +2086,7 @@ void CNEORules::JuggernautActivated(CNEO_Player *pPlayer)
 		m_pJuggernautPlayer = pPlayer;
 		m_iJuggernautPlayerIndex = pPlayer->entindex();
 		m_pJuggernautItem = nullptr;
+		m_bJuggernautItemExists = false;
 		m_iLastJuggernautTeam = pPlayer->GetTeamNumber();
 
 		for (int i = 1; i <= gpGlobals->maxClients; i++)
@@ -2112,7 +2108,19 @@ void CNEORules::JuggernautDeactivated(CNEO_Juggernaut *pJuggernaut)
 		m_pJuggernautPlayer = nullptr;
 		m_iJuggernautPlayerIndex = 0;
 		m_pJuggernautItem = pJuggernaut;
+		m_bJuggernautItemExists = true;
 		m_flJuggernautDeathTime = gpGlobals->curtime;
+	}
+}
+
+// This should only ever be used in cases where the Juggernaut item was removed unexpectedly
+void CNEORules::JuggernautTotalRemoval(CNEO_Juggernaut *pJuggernaut)
+{
+	if ((GetGameType() == NEO_GAME_TYPE_JGR) && (m_hJuggernaut.Get() == pJuggernaut))
+	{
+		m_hJuggernaut = nullptr;
+		m_pJuggernautItem = nullptr;
+		m_bJuggernautItemExists = false;
 	}
 }
 

--- a/src/game/shared/neo/neo_gamerules.h
+++ b/src/game/shared/neo/neo_gamerules.h
@@ -424,6 +424,7 @@ private:
 public:
 	void JuggernautActivated(CNEO_Player *pPlayer);
 	void JuggernautDeactivated(CNEO_Juggernaut *pJuggernaut);
+	void JuggernautTotalRemoval(CNEO_Juggernaut *pJuggernaut);
 private:
 	CNEO_Juggernaut *m_pJuggernautItem = nullptr;
 	CNEO_Player *m_pJuggernautPlayer = nullptr;

--- a/src/game/shared/neo/neo_juggernaut.cpp
+++ b/src/game/shared/neo/neo_juggernaut.cpp
@@ -1,4 +1,5 @@
 #include "neo_juggernaut.h"
+#include "neo_gamerules.h"
 #ifdef GAME_DLL
 #include "engine/IEngineSound.h"
 #include "explode.h"
@@ -66,6 +67,12 @@ CNEO_Juggernaut::~CNEO_Juggernaut()
 void CNEO_Juggernaut::UpdateOnRemove()
 {
 	StopSound("HUD.CPCharge");
+#ifdef GAME_DLL
+	if (!m_bActivationRemoval)
+	{
+		NEORules()->JuggernautTotalRemoval(this);
+	}
+#endif
 	BaseClass::UpdateOnRemove();
 }
 
@@ -215,11 +222,12 @@ void CNEO_Juggernaut::Think(void)
 		m_hPlayer->CreateRagdollEntity();
 		m_hPlayer->Weapon_DropAllOnDeath(CTakeDamageInfo(this, this, 0, DMG_GENERIC));
 		m_hPlayer->Teleport(&GetAbsOrigin(), &GetAbsAngles(), &vec3_origin);
-		m_hPlayer->SnapEyeAngles(GetAbsAngles());
 
 		m_hPlayer->BecomeJuggernaut();
 
 		m_OnPlayerActivate.FireOutput(m_hPlayer, this);
+
+		m_bActivationRemoval = true;
 		UTIL_Remove(this);
 
 		return;
@@ -321,6 +329,11 @@ void CNEO_Juggernaut::SetSoftCollision(bool soft)
 	{
 		SetCollisionGroup(HARD_COLLISION);
 	}
+}
+
+int CNEO_Juggernaut::UpdateTransmitState()
+{
+	return SetTransmitState(FL_EDICT_ALWAYS);
 }
 #endif
 

--- a/src/game/shared/neo/neo_juggernaut.h
+++ b/src/game/shared/neo/neo_juggernaut.h
@@ -31,6 +31,8 @@ public:
 	void	Spawn(void);
     void	Use(CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value);
 	virtual int	ObjectCaps(void) { return BaseClass::ObjectCaps() | FCAP_ONOFF_USE; }
+	virtual int UpdateTransmitState() override;
+
 	bool	m_bPostDeath = false;
 #endif
 
@@ -59,6 +61,7 @@ private:
 	float m_flWarpedPlaybackRate;
 	float m_flHoldStartTime = 0.0f;
 	bool m_bIsHolding = false;
+	bool m_bActivationRemoval = false;
 
 	hudtextparms_t	m_textParms;
 	COutputEvent m_OnPlayerActivate;


### PR DESCRIPTION
## Description
- Should prevent asserts caused by false information on the juggernaut from gamerules functions
- Stops the juggernaut marker / compass needle from vanishing

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1579 

