### PR TITLE
OnStuck location sharing for NavArea avoidance

### DIFF
--- a/src/game/server/neo/bot/neo_bot_path_cost.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_cost.cpp
@@ -114,6 +114,7 @@ float CNEOBotPathCost::operator()(CNavArea* baseArea, CNavArea* fromArea, const 
 			&& (m_routeType != FASTEST_ROUTE) )
 		{
 			cost += CNEOBotPathReservations()->GetPredictedFriendlyPathCount(area->GetID(), m_me->GetTeamNumber()) * neo_bot_path_reservation_penalty.GetFloat();
+			cost += CNEOBotPathReservations()->GetAreaStuckPenalty(area->GetID());
 		}
 		// ------------------------------------------------------------------------------------------------
 

--- a/src/game/server/neo/bot/neo_bot_path_reservation.h
+++ b/src/game/server/neo/bot/neo_bot_path_reservation.h
@@ -42,7 +42,7 @@ public:
         return lhs.GetSerialNumber() < rhs.GetSerialNumber();
     }
 
-    CNEOBotPathReservationSystem() : m_BotReservedAreas(EHandleLessFunc)
+    CNEOBotPathReservationSystem() : m_BotReservedAreas(EHandleLessFunc), m_AreaOnStuckPenalties(DefLessFunc(unsigned int))
     {
         for (int i = 0; i < MAX_TEAMS; ++i)
         {
@@ -61,6 +61,9 @@ public:
     void DecrementPredictedFriendlyPathCount( int areaID, int teamID );
     int GetPredictedFriendlyPathCount( int areaID, int teamID ) const;
 
+    void IncrementAreaStuckPenalty(unsigned int navAreaID);
+    float GetAreaStuckPenalty(unsigned int navAreaID) const;
+
     // Allow the global accessor to access private members if needed, though constructor handles init now.
     friend CNEOBotPathReservationSystem* CNEOBotPathReservations();
 
@@ -68,6 +71,7 @@ private:
     CUtlMap<int, ReservationInfo> m_Reservations[MAX_TEAMS];
     CUtlMap<EHANDLE, BotReservedAreas_t> m_BotReservedAreas;
     CUtlMap<int, int> m_AreaPathCounts[MAX_TEAMS];
+    CUtlMap<unsigned int, float> m_AreaOnStuckPenalties;
 };
 
 


### PR DESCRIPTION
## Description
When bots are in the OnStuck behavior, bots record where they got stuck and which adjacent NavArea node they were going to in the path reservation system, so that other bots can avoid those trouble areas. This is intended to help smooth out bot behaviors in maps where the navmesh generation has not been cleaned up.

## Toolchain
- Windows MSVC VS2022
