### PR TITLE
Dynamic bot jump path penalty based on class max

### DIFF
--- a/src/game/server/neo/bot/neo_bot_path_cost.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_cost.cpp
@@ -12,7 +12,7 @@ ConVar neo_bot_path_friendly_reservation_enable("neo_bot_path_friendly_reservati
 ConVar neo_bot_path_around_friendly_cooldown("neo_bot_path_around_friendly_cooldown", "2.0", FCVAR_CHEAT,
 	"How often to check for friendly path dispersion", false, 0, false, 60);
 
-ConVar neo_bot_path_jump_penalty_multiplier("neo_bot_path_jump_penalty_multiplier", "100.0", FCVAR_CHEAT,
+ConVar neo_bot_path_penalty_jump_multiplier("neo_bot_path_penalty_jump_multiplier", "100.0", FCVAR_CHEAT,
 	"Maximum penalty multiplier for jump height changes in pathfinding", false, 0.01f, false, 1000.0f);
 
 //-------------------------------------------------------------------------------------------------
@@ -74,7 +74,7 @@ float CNEOBotPathCost::operator()(CNavArea* baseArea, CNavArea* fromArea, const 
 			}
 
 			// jumping is slower than flat ground
-			const float jumpPenalty = neo_bot_path_jump_penalty_multiplier.GetFloat() * Square( deltaZ / m_maxJumpHeight );
+			const float jumpPenalty = neo_bot_path_penalty_jump_multiplier.GetFloat() * Square( deltaZ / m_maxJumpHeight );
 			dist *= jumpPenalty;
 		}
 		else if (deltaZ < -m_maxDropHeight)


### PR DESCRIPTION
## Description
Penalizes bot path NavArea candidates that involve jumping, scaled to the max jump height for the class of that bot.

## Toolchain
- Windows MSVC VS2022


