### PR TITLE
Don't pvs cull entities for roaming spectators

### DIFF
--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -2507,8 +2507,8 @@ inline void CServerNetworkProperty::CheckTransmit( CCheckTransmitInfo *pInfo )
 	}
 } */
 
-#ifdef NEO // NEO NOTE (Adam) probably don't need to check observer mode now that we are checking if the camera is out of bounds, but maybe its better to leave the check in case players somehow get out of bounds when playing
-ConVar sv_neo_pvs_cull_roaming_observers("sv_neo_pvs_cull_roaming_observers", "0", FCVAR_NONE, "Cull entities against PVS for players who are out of bounds in the roaming observer mode");
+#ifdef NEO
+ConVar cl_neo_pvs_cull_roaming_observer("cl_neo_pvs_cull_roaming_observer", "0", FCVAR_CLIENTDLL | FCVAR_USERINFO | FCVAR_ARCHIVE, "Cull entities against PVS when out of bounds in the roaming observer mode");
 #endif // NEO
 void CServerGameEnts::CheckTransmit( CCheckTransmitInfo *pInfo, const unsigned short *pEdictIndices, int nEdicts )
 {
@@ -2533,7 +2533,9 @@ void CServerGameEnts::CheckTransmit( CCheckTransmitInfo *pInfo, const unsigned s
 	const bool bIsHLTV = pRecipientPlayer->IsHLTV();
 	const bool bIsReplay = pRecipientPlayer->IsReplay();
 #ifdef NEO
-	const bool bIsRoamingOOBObserver = !sv_neo_pvs_cull_roaming_observers.GetBool() && pRecipientPlayer->GetObserverMode() == OBS_MODE_ROAMING && engine->GetArea( pRecipientPlayer->GetAbsOrigin()) == 0;
+	const char* recipientPlayerWantsPVSCull = engine->GetClientConVarValue(pRecipientPlayer->entindex(), "cl_neo_pvs_cull_roaming_observer");
+	const bool bRecipientPlayerWantsPVSCull = recipientPlayerWantsPVSCull && *recipientPlayerWantsPVSCull && (V_atoi(recipientPlayerWantsPVSCull) != 0) ? true : false;
+	const bool bIsRoamingOOBObserver = !bRecipientPlayerWantsPVSCull && pRecipientPlayer->GetObserverMode() == OBS_MODE_ROAMING && engine->GetArea( pRecipientPlayer->GetAbsOrigin()) == 0;
 #endif // NEO
 
 	// m_pTransmitAlways must be set if HLTV client


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

No idea how much extra network strain this will cause, but it does improve the viewing experience from a birds eye view so I would like to test it. While the cost of this feature isn't yet known I've added a convar sv_neo_pvs_cull_roaming_observers for toggling it, but I think it would be better if this was either permanently on or removed down the line.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1594
