### PR TITLE
Fix crosshair not centered when changing resolution again and make slider and ringbox values change faster when clicking them with the mouse

### DIFF
--- a/src/game/client/neo/ui/neo_ui.cpp
+++ b/src/game/client/neo/ui/neo_ui.cpp
@@ -1384,6 +1384,7 @@ void RingBox(const wchar_t **wszLabelsList, const int iLabelsSize, int *iIndex)
 		}
 		break;
 		case MODE_MOUSEPRESSED:
+		case MODE_MOUSEDOUBLEPRESSED:
 		{
 			if (wdgState.bHot)
 			{
@@ -1448,8 +1449,6 @@ void Tabs(const wchar_t **wszLabelsList, const int iLabelsSize, int *iIndex, con
 	{
 	case MODE_PAINT:
 	{
-		int oldX = 0, oldY = 0, oldW, oldH;
-		vgui::surface()->GetScreenSize(oldW, oldH);
 		vgui::surface()->SetFullscreenViewport(c->rWidgetArea.x0, c->rWidgetArea.y0, c->irWidgetWide, c->irWidgetTall);
 		vgui::surface()->PushFullscreenViewport();
 
@@ -1490,7 +1489,7 @@ void Tabs(const wchar_t **wszLabelsList, const int iLabelsSize, int *iIndex, con
 		}
 
 		vgui::surface()->PopFullscreenViewport();
-		vgui::surface()->SetFullscreenViewport(oldX, oldY, oldW, oldH);
+		vgui::surface()->SetFullscreenViewport(0, 0, 0, 0);
 
 		// Draw the side-hints text
 		// NEO NOTE (nullsystem): F# as 1 is thinner than 3/not monospaced font
@@ -1680,6 +1679,7 @@ void Slider(const wchar_t *wszLeftLabel, float *flValue, const float flMin, cons
 		}
 		break;
 		case MODE_MOUSEPRESSED:
+		case MODE_MOUSEDOUBLEPRESSED:
 		{
 			if (wdgState.bHot)
 			{


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

I would appreciate if some linux person could test this one, just play in windowed and change the resolution from a small resolution to a large resolution, making sure not to open either the options or the find server menu after confirming the settings change as that fixes the crosshair offset on master currently. Not sure how this works but from testing setting the size of the fullscreen viewport to 0 0 seems to reset it to how it was behaving before the size was changed initially by the neoui tabs.

Also if there are any other ui input elements that are behaving sluggishly that I missed let me know. I didn't know if moving the position of the cursor in the text input should be faster or whether we should instead have double click select all text in the input, probably the latter, or maybe double click selects the word and triple click instead selects all text in the input.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0
