### PR TITLE
Improve warning for bad capzone m_iOwningTeam

### DIFF
--- a/src/game/shared/neo/neo_ghost_cap_point.cpp
+++ b/src/game/shared/neo/neo_ghost_cap_point.cpp
@@ -167,8 +167,10 @@ void CNEOGhostCapturePoint::Spawn(void)
 	{
 		// We could recover, but it's probably better to break the capzone
 		// and throw a nag message in console so the mapper can fix their error.
-		Warning("Capzone had an invalid owning team: %i. Expected %i (Jinrai), or %i (NSF).\n",
-			m_iOwningTeam.Get(), NEO_FGD_TEAMNUM_ATTACKER, NEO_FGD_TEAMNUM_DEFENDER);
+		Warning("Capzone at position %.1f %.1f %.1f had an invalid owning team: %i. "
+			"Expected %i (Jinrai), %i (NSF), or %i (neutral).\n",
+			GetAbsOrigin().x, GetAbsOrigin().y, GetAbsOrigin().z,
+			m_iOwningTeam.Get(), NEO_FGD_TEAMNUM_ATTACKER, NEO_FGD_TEAMNUM_DEFENDER, NEO_FGD_TEAMNUM_NEUTRAL);
 
 		// Nobody will be able to cap here.
 		m_iOwningTeam = TEAM_INVALID;


### PR DESCRIPTION
## Description
Since #1555, we support neutral cap zones. Update the warning message for bad `CNEOGhostCapturePoint::m_iOwningTeam` value to take this change into account.

Also print the position of the bad capzone to make it easier for the mapper to pinpoint the offending entity.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1555 
