### PR TITLE
Remove redundant teammate check from player list

### DIFF
--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -778,7 +778,7 @@ void CNEOHud_RoundState::DrawPlayerList_BotCmdr()
 		{
 			continue;
 		}
-		if (i == localPlayerIndex || localPlayerSpec || hideDueToScoreboard || !ArePlayersOnSameTeam(i, localPlayerIndex))
+		if (i == localPlayerIndex || localPlayerSpec || hideDueToScoreboard)
 		{
 			continue;
 		}


### PR DESCRIPTION
## Description
In the feature flagged bot command aware player list, removed a redundant teammate check.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1345

