### PR TITLE
Fix incorrect ChapterBackgrounds.txt ignore

### DIFF
--- a/game/neo/scripts/ChapterBackgrounds.txt
+++ b/game/neo/scripts/ChapterBackgrounds.txt
@@ -1,5 +1,0 @@
-// Auto Generated on game launch. Set background in game through the options menu from those available in scripts/neo_backgrounds.txt
-"chapters"
-{
-  1 "background01"
-}


### PR DESCRIPTION
Breakin' 2: Electric Boogaloo

## Description

Use `git rm --cached` to fix the previous cache conflicting with the gitignore

This should hopefully finally get rid of the ChapterBackgrounds.txt popping up in working tree.

See previous attempt: #1458

## Toolchain
N/A

## Linked Issues

