### PR TITLE
Only reset XP down to sergeant inbetween JGR rounds

### DIFF
--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -3094,9 +3094,9 @@ void CNEORules::ResetJGR()
 	for (int i = 1; i <= gpGlobals->maxClients; ++i)
 	{
 		auto pPlayer = static_cast<CNEO_Player *>(UTIL_PlayerByIndex(i));
-		if (pPlayer)
+		if (pPlayer && pPlayer->m_iXP.Get() > 10)
 		{
-			pPlayer->m_iXP.GetForModify() = 0;
+			pPlayer->m_iXP.GetForModify() = 10;
 		}
 	}
 }


### PR DESCRIPTION
## Description
Rather than resetting all XP only rank players down to sergeant if they had higher than 10 xp, otherwise players keep the xp they had

## Toolchain
- Windows MSVC VS2022

