### PR TITLE
Forbid implicit bools for cvar ctor args

### DIFF
--- a/src/game/client/c_baseentity.cpp
+++ b/src/game/client/c_baseentity.cpp
@@ -79,7 +79,11 @@ void cc_cl_interp_all_changed( IConVar *pConVar, const char *pOldString, float f
 
 static ConVar  cl_extrapolate( "cl_extrapolate", "1", FCVAR_CHEAT, "Enable/disable extrapolation if interpolation history runs out." );
 static ConVar  cl_interp_npcs( "cl_interp_npcs", "0.0", FCVAR_USERINFO, "Interpolate NPC positions starting this many seconds in past (or cl_interp, if greater)" );  
+#ifdef NEO
+static ConVar  cl_interp_all( "cl_interp_all", "0", 0, "Disable interpolation list optimizations.", false, 0, false, 0, cc_cl_interp_all_changed );
+#else
 static ConVar  cl_interp_all( "cl_interp_all", "0", 0, "Disable interpolation list optimizations.", 0, 0, 0, 0, cc_cl_interp_all_changed );
+#endif
 ConVar  r_drawmodeldecals( "r_drawmodeldecals", "1", FCVAR_ALLOWED_IN_COMPETITIVE );
 extern ConVar	cl_showerror;
 int C_BaseEntity::m_nPredictionRandomSeed = -1;

--- a/src/public/tier1/convar.h
+++ b/src/public/tier1/convar.h
@@ -30,6 +30,13 @@
 #error "implement me"
 #endif
 
+#ifdef NEO
+#include <concepts>
+#include <type_traits>
+
+template <typename T>
+concept NotBoolean = !std::is_same_v<bool, T>;
+#endif
 
 //-----------------------------------------------------------------------------
 // Forward declarations
@@ -339,7 +346,54 @@ public:
 									bool bCompMin, float fCompMin, bool bCompMax, float fCompMax,
 									FnChangeCallback_t callback );
 
+#ifdef NEO
+								// You may have a typo in your constructor argument order if the compiler is
+								// attempting to invoke one or more of the deleted constructors below.
+								// If you really meant to evaluate bMin/bMax or bCompMin/bCompMax from a non-boolean type,
+								// please cast them to bool to silence the error.
 
+								template <NotBoolean T>
+								ConVar( const char *pName, const char *pDefaultValue, int flags,
+									const char *pHelpString, T bMin, float fMin, bool bMax, float fMax ) = delete;
+
+								template <NotBoolean T>
+								ConVar( const char *pName, const char *pDefaultValue, int flags,
+									const char *pHelpString, bool bMin, float fMin, T bMax, float fMax ) = delete;
+
+								template <NotBoolean T>
+								ConVar( const char *pName, const char *pDefaultValue, int flags,
+									const char *pHelpString, T bMin, float fMin, bool bMax, float fMax,
+									FnChangeCallback_t callback ) = delete;
+
+								template <NotBoolean T>
+								ConVar( const char *pName, const char *pDefaultValue, int flags,
+									const char *pHelpString, bool bMin, float fMin, T bMax, float fMax,
+									FnChangeCallback_t callback ) = delete;
+
+								template <NotBoolean T>
+								ConVar( const char *pName, const char *pDefaultValue, int flags,
+									const char *pHelpString, T bMin, float fMin, bool bMax, float fMax,
+									bool bCompMin, float fCompMin, bool bCompMax, float fCompMax,
+									FnChangeCallback_t callback ) = delete;
+
+								template <NotBoolean T>
+								ConVar( const char *pName, const char *pDefaultValue, int flags,
+									const char *pHelpString, bool bMin, float fMin, T bMax, float fMax,
+									bool bCompMin, float fCompMin, bool bCompMax, float fCompMax,
+									FnChangeCallback_t callback ) = delete;
+
+								template <NotBoolean T>
+								ConVar( const char *pName, const char *pDefaultValue, int flags,
+									const char *pHelpString, bool bMin, float fMin, bool bMax, float fMax,
+									T bCompMin, float fCompMin, bool bCompMax, float fCompMax,
+									FnChangeCallback_t callback ) = delete;
+
+								template <NotBoolean T>
+								ConVar( const char *pName, const char *pDefaultValue, int flags,
+									const char *pHelpString, bool bMin, float fMin, bool bMax, float fMax,
+									bool bCompMin, float fCompMin, T bCompMax, float fCompMax,
+									FnChangeCallback_t callback ) = delete;
+#endif
 
 	virtual						~ConVar( void );
 


### PR DESCRIPTION
## Description
Require the `bMin` and `bMax` values of `ConVar` constructors be evaluated from boolean types, to prevent bugs with typo'd argument order where an incorrect argument would silently get evaluated as the boolean value, and/or be swapped with the intended float min/max bound, without raising a compiler error.

For example, for the `ConVar` ctor arguments:

`bool bMin, float fMin, bool bMax, float fMax`

one could accidentally write:

`100, true, 2000, true`

which would implictly get converted to:

`bMin=bool(100)=true, fMin=float(true)=1, bMax=bool(2000)=true, fMax=float(true)=1`

instead of the intended:

`bMin=true, fMin=100, bMax=true, fMax=2000`.

By introducing specialized deleted constructors for non-boolean inputs to the `bMin`/`bMax` and `bCompMin`/`bCompMax` args, we can cause the compiler to error in such cases to catch these bugs.

In the rare case where the programmer really meant to evaluate a non-boolean type for these args, they can still explicitly cast it to bool to express that intent, and make it work.

## Toolchain
- Windows MSVC VS2022

## Linked Issues


