### PR TITLE
Players shouldnt be able to carry over weapons from warmup / over game restart

### DIFF
--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -2643,6 +2643,14 @@ void CNEORules::StartNextRound()
 			continue;
 		}
 
+		if (bFromStarting)
+		{
+			pPlayer->Reset();
+			pPlayer->m_iXP.Set(0);
+			pPlayer->m_iTeamDamageInflicted = 0;
+			pPlayer->m_iTeamKillsInflicted = 0;
+		}
+
 		pPlayer->SpectatorTakeoverPlayerRevert(); // hard reset: round restart
 
 		if (pPlayer->GetTeamNumber() == TEAM_SPECTATOR)
@@ -2664,13 +2672,6 @@ void CNEORules::StartNextRound()
 		pPlayer->m_bInVision = false;
 		pPlayer->m_bIneligibleForLoadoutPick = false;
 
-		if (bFromStarting)
-		{
-			pPlayer->Reset();
-			pPlayer->m_iXP.Set(0);
-			pPlayer->m_iTeamDamageInflicted = 0;
-			pPlayer->m_iTeamKillsInflicted = 0;
-		}
 		pPlayer->m_bIsPendingTKKick = false;
 
 		pPlayer->SetTestMessageVisible(false);
@@ -3125,6 +3126,8 @@ void CNEORules::RestartGame()
 		if (!pPlayer)
 			continue;
 
+		pPlayer->m_iXP.GetForModify() = 0;
+
 		pPlayer->SpectatorTakeoverPlayerRevert(); // hard reset: restart game
 
 		if (pPlayer->GetActiveWeapon())
@@ -3134,8 +3137,6 @@ void CNEORules::RestartGame()
 		pPlayer->RemoveAllItems(true);
 		pPlayer->Spawn();
 		pPlayer->Reset();
-
-		pPlayer->m_iXP.GetForModify() = 0;
 
 		pPlayer->SetTestMessageVisible(false);
 	}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->
## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1635
