### PR TITLE
Add cvars for controlling XP rewards.

### DIFF
--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -724,16 +724,16 @@ void C_NEO_Player::AddEntity( void )
 
 void C_NEO_Player::AddPoints(int score, bool bAllowNegativeScore, bool bIgnorePlayerTakeover)
 {
-    if (!bIgnorePlayerTakeover && m_hSpectatorTakeoverPlayerTarget.Get())
-    {
-        if (score >= 0)
-        {
-            // Reward possessed/bot for takeover player's actions
-            m_hSpectatorTakeoverPlayerTarget->AddPoints(score, false);
-            return;
-        }
-        // If a player made a mistake while taking over another player, continue to penalize them
-    }
+	if (!bIgnorePlayerTakeover && m_hSpectatorTakeoverPlayerTarget.Get())
+	{
+		if (score >= 0)
+		{
+			// Reward possessed/bot for takeover player's actions
+			m_hSpectatorTakeoverPlayerTarget->AddPoints(score, false);
+			return;
+		}
+		// If a player made a mistake while taking over another player, continue to penalize them
+	}
 
 	// Positive score always adds
 	if (score < 0)

--- a/src/game/client/neo/c_neo_player.h
+++ b/src/game/client/neo/c_neo_player.h
@@ -40,7 +40,7 @@ public:
 
 	virtual int DrawModel( int flags );
 	virtual void AddEntity( void );
-    virtual void AddPoints(int score, bool bAllowNegativeScore, bool bIgnorePlayerTakeover = false);
+	virtual void AddPoints(int score, bool bAllowNegativeScore, bool bIgnorePlayerTakeover = false);
 
 	virtual void PreDataUpdate(DataUpdateType_t updateType) OVERRIDE;
 

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -1619,13 +1619,13 @@ void CNEORules::AwardRankUp(CNEO_Player *pClient)
 	{
 		if (pClient->m_iXP.Get() < ranks[i])
 		{
-            pClient->AddPoints(ranks[i] - pClient->m_iXP, false, true);
+			pClient->AddPoints(ranks[i] - pClient->m_iXP, false, true);
 			return;
 		}
 	}
 
 	// If we're beyond max rank, just award +1 point.
-    pClient->AddPoints(1, false, true);
+	pClient->AddPoints(1, false, true);
 }
 
 // Return remaining time in seconds. Zero means there is no time limit.
@@ -3555,59 +3555,59 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 				player->EmitSound(soundFilter, i, soundParams);
 			}
 
-            if (winningTeamNum != TEAM_SPECTATOR && player->GetTeamNumber() == winningTeamNum)
+			if (winningTeamNum != TEAM_SPECTATOR && player->GetTeamNumber() == winningTeamNum)
 			{
-                int xpAward = 1;	// Base reward for being on winning team
-                if (iWinReason == NEO_VICTORY_GHOST_CAPTURE || iWinReason == NEO_VICTORY_VIP_ESCORT || m_bTeamBeenAwardedDueToCapPrevent)
-                {
-                    auto cap_reward = sv_neo_cap_reward.GetInt();
-                    if (!cap_reward) // Rank up
-                    {
-                        if (sv_neo_cap_reward_dead.GetBool() || player->IsAlive())
-                        {
-                            // Swap controller and controlee for the purposes of rankup
-                            auto playerPossessedByMe = player->m_hSpectatorTakeoverPlayerTarget.Get();
-                            auto playerControllingMe = player->m_hSpectatorTakeoverPlayerImpersonatingMe.Get();
-                            auto playerToRankUp = player;
-                            if (playerPossessedByMe)
-                                playerToRankUp = playerPossessedByMe;
-                            if (playerControllingMe)
-                                playerToRankUp = playerControllingMe;
-                            AwardRankUp(playerToRankUp);
-                            xpAward = 0;
-                        }
-                    }
-                    else
-                    {
-                        if (sv_neo_cap_reward_dead.GetBool() || player->IsAlive())
-                        {
-                            xpAward = cap_reward;
-                        }
-                    }
-                }
-                else if (GetGameType() == NEO_GAME_TYPE_CTG || GetGameType() == NEO_GAME_TYPE_VIP)
-                {
-                    if (sv_neo_survivor_bonus.GetBool() && player->IsAlive())
-                    {
-                        ++xpAward;
-                    }
-                    if (sv_neo_ghost_carrier_bonus.GetBool() && player->IsCarryingGhost())
-                    {
-                        ++xpAward;
-                    }
-                }
+				int xpAward = 1;	// Base reward for being on winning team
+				if (iWinReason == NEO_VICTORY_GHOST_CAPTURE || iWinReason == NEO_VICTORY_VIP_ESCORT || m_bTeamBeenAwardedDueToCapPrevent)
+				{
+					auto cap_reward = sv_neo_cap_reward.GetInt();
+					if (!cap_reward) // Rank up
+					{
+						if (sv_neo_cap_reward_dead.GetBool() || player->IsAlive())
+						{
+							// Swap controller and controlee for the purposes of rankup
+							auto playerPossessedByMe = player->m_hSpectatorTakeoverPlayerTarget.Get();
+							auto playerControllingMe = player->m_hSpectatorTakeoverPlayerImpersonatingMe.Get();
+							auto playerToRankUp = player;
+							if (playerPossessedByMe)
+								playerToRankUp = playerPossessedByMe;
+							if (playerControllingMe)
+								playerToRankUp = playerControllingMe;
+							AwardRankUp(playerToRankUp);
+							xpAward = 0;
+						}
+					}
+					else
+					{
+						if (sv_neo_cap_reward_dead.GetBool() || player->IsAlive())
+						{
+							xpAward = cap_reward;
+						}
+					}
+				}
+				else if (GetGameType() == NEO_GAME_TYPE_CTG || GetGameType() == NEO_GAME_TYPE_VIP)
+				{
+					if (sv_neo_survivor_bonus.GetBool() && player->IsAlive())
+					{
+						++xpAward;
+					}
+					if (sv_neo_ghost_carrier_bonus.GetBool() && player->IsCarryingGhost())
+					{
+						++xpAward;
+					}
+				}
 
-                auto playerControllingMe = player->m_hSpectatorTakeoverPlayerImpersonatingMe.Get();
-                if (playerControllingMe)
-                {
-                    // Controlling player will be awarded as if they were dead
-                    playerControllingMe->AddPoints(xpAward, false, true);
-                }
-                else
-                {
-                    // This will award the controlled player, if any
-                    player->AddPoints(xpAward, false);
-                }
+				auto playerControllingMe = player->m_hSpectatorTakeoverPlayerImpersonatingMe.Get();
+				if (playerControllingMe)
+				{
+					// Controlling player will be awarded as if they were dead
+					playerControllingMe->AddPoints(xpAward, false, true);
+				}
+				else
+				{
+					// This will award the controlled player, if any
+					player->AddPoints(xpAward, false);
+				}
 			}
 
 			// Any human player still alive, show them damage stats in round end


### PR DESCRIPTION
## Description
Add cvars from WinCond plugin for controlling XP rewards.

*sv_neo_cap_reward* - How much XP to reward for capturing the ghost. 0 = Rank up. (Default: 0)
*sv_neo_cap_reward_dead* - Whether dead players should receive the ghost capture reward. (Default: 0)
*sv_neo_survivor_bonus* - Whether surviving players on the winning team should receive extra XP. (Default: 1)
*sv_neo_ghost_carrier_bonus* - Whether the ghost carrier on the winning team should receive extra XP. (Default: 1)

Some liberal refactoring was made to reduce code duplication. The bot takeover logic was a bit confusing but I think I got it right.

Tested with and without possessing a bot:

|                                                    | sv_neo_cap_reward_dead 0 | sv_neo_cap_reward_dead 1 |
|------------------------------------------|---------------------------------------------------|--------------------------------------------------|
| sv_neo_cap_reward 0 | ✅ | ✅ |
|sv_neo_cap_reward 3  | ✅ | ✅ |

## Toolchain
- CachyOS, gcc v15.2.1

## Linked Issues
- fixes #1462 

