### PR TITLE
Prevent dereferencing NULL m_pWorldRenderList

### DIFF
--- a/src/game/client/viewrender.cpp
+++ b/src/game/client/viewrender.cpp
@@ -3872,6 +3872,14 @@ void CRendering3dView::DrawWorld( float waterZAdjust )
 		return;
 	}
 
+#ifdef NEO
+	if ( !m_pWorldRenderList )
+	{
+		DevWarning( "CRendering3dView::DrawWorld: m_pWorldRenderList is NULL\n" );
+		return;
+	}
+#endif
+
 	unsigned long engineFlags = BuildEngineDrawWorldListFlags( m_DrawFlags );
 
 	render->DrawWorldLists( m_pWorldRenderList, engineFlags, waterZAdjust );


### PR DESCRIPTION
## Description
Prevent dereferencing NULL m_pWorldRenderList

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1642
