### PR TITLE
Fix some comp countdown issues.

### DIFF
--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -223,7 +223,6 @@ public:
 
 		panel->SetMouseInputEnabled(true);
 		//panel->SetKeyBoardInputEnabled(true);
-		panel->SetCursorAlwaysVisible(true);
 
 		panel->SetControlEnabled("Button1", true);
 		panel->SetControlEnabled("Button2", true);
@@ -330,7 +329,6 @@ public:
 
 		panel->SetMouseInputEnabled(true);
 		//panel->SetKeyBoardInputEnabled(true);
-		panel->SetCursorAlwaysVisible(true);
 
 		panel->SetControlEnabled("Scout_Button", true);
 		panel->SetControlEnabled("Assault_Button", true);
@@ -402,7 +400,6 @@ public:
 
 		panel->SetMouseInputEnabled(true);
 		//panel->SetKeyBoardInputEnabled(true);
-		panel->SetCursorAlwaysVisible(true);
 
 		panel->SetControlEnabled("jinraibutton", true);
 		panel->SetControlEnabled("nsfbutton", true);
@@ -1646,20 +1643,6 @@ void C_NEO_Player::Spawn( void )
 
 	if (localPlayer == nullptr || localPlayer == this)
 	{
-		// NEO NOTE (nullsystem): Reset Vis/Enabled/MouseInput/Cursor state here, otherwise it can get stuck at situations
-		for (const auto pname : {PANEL_CLASS, PANEL_TEAM, PANEL_NEO_LOADOUT})
-		{
-			if (auto *panel = static_cast<vgui::EditablePanel*>
-					(GetClientModeNormal()->GetViewport()->FindChildByName(pname)))
-			{
-				panel->SetVisible(false);
-				panel->SetEnabled(false);
-				panel->SetMouseInputEnabled(false);
-				panel->SetCursorAlwaysVisible(false);
-				//panel->SetKeyBoardInputEnabled(false);
-			}
-		}
-
 		for (auto *hud : gHUD.m_HudList)
 		{
 			if (auto *neoHud = dynamic_cast<CNEOHud_ChildElement *>(hud))

--- a/src/game/client/neo/game_controls/neo_classmenu.cpp
+++ b/src/game/client/neo/game_controls/neo_classmenu.cpp
@@ -179,7 +179,6 @@ void CNeoClassMenu::CommandCompletion()
 
 	SetMouseInputEnabled(false);
 	//SetKeyBoardInputEnabled(false);
-	SetCursorAlwaysVisible(false);
 }
 
 void CNeoClassMenu::OnClose()

--- a/src/game/client/neo/game_controls/neo_loadoutmenu.cpp
+++ b/src/game/client/neo/game_controls/neo_loadoutmenu.cpp
@@ -154,7 +154,6 @@ void CNeoLoadoutMenu::CommandCompletion()
 	SetEnabled(false);
 
 	SetMouseInputEnabled(false);
-	SetCursorAlwaysVisible(false);
 }
 
 void CNeoLoadoutMenu::ShowPanel(bool bShow)

--- a/src/game/client/neo/game_controls/neo_teammenu.cpp
+++ b/src/game/client/neo/game_controls/neo_teammenu.cpp
@@ -214,7 +214,6 @@ void CNeoTeamMenu::CommandCompletion()
 	SetEnabled(false);
 
 	SetMouseInputEnabled(false);
-	SetCursorAlwaysVisible(false);
 }
 
 void CNeoTeamMenu::OnCommand(const char *command)

--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -38,7 +38,6 @@ ConVar cl_neo_squad_hud_original("cl_neo_squad_hud_original", "1", FCVAR_ARCHIVE
 ConVar cl_neo_squad_hud_star_scale("cl_neo_squad_hud_star_scale", "0", FCVAR_ARCHIVE, "Scaling to apply from 1080p, 0 disables scaling");
 extern ConVar sv_neo_dm_win_xp;
 extern ConVar cl_neo_streamermode;
-extern ConVar snd_victory_volume;
 extern ConVar sv_neo_readyup_countdown;
 extern ConVar cl_neo_hud_scoreboard_hide_others;
 extern ConVar sv_neo_ctg_ghost_overtime_grace;
@@ -417,8 +416,9 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 
 			if (m_iBeepSecsTotal != secsTotal)
 			{
+				DevMsg("beepsTotal: %i, secsTotal: %i\n", m_iBeepSecsTotal, secsTotal);
 				const bool bEndBeep = secsTotal == 0;
-				const float flVol = (bEndBeep) ? (1.3f * snd_victory_volume.GetFloat()) : snd_victory_volume.GetFloat();
+				const float flVol = bEndBeep ? 1.0f : 0.7f;
 				static constexpr int PITCH_END = 165;
 				enginesound->EmitAmbientSound("tutorial/hitsound.wav", flVol, bEndBeep ? PITCH_END : PITCH_NORM);
 				m_iBeepSecsTotal = secsTotal;

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -1768,8 +1768,10 @@ void CNEORules::FireGameEvent(IGameEvent* event)
 			StartAutoClientRecording();
 		}
 #endif
+#ifdef GAME_DLL
 		m_flNeoRoundStartTime = gpGlobals->curtime;
 		m_flNeoNextRoundStartTime = 0;
+#endif
 	}
 
 #ifdef CLIENT_DLL


### PR DESCRIPTION
## Description
* Remove extra tick/beep after 0.
* Beep volume isn't tied to victory jingle volume anymore.
* Loadout menu doesn't go away when demo recording starts.

The latter was due to the panels being closed on Spawn. Introduced in #412. I more or less reverted all of that, and instead removed all occurrences of `SetCursorAlwaysVisible(true)` which don't seem to be needed.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1646
- related #1435
