### PR TITLE
Github workflow: Release trigger website update

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -358,7 +358,7 @@ jobs:
         gh release create latest neo-*.7z --prerelease --title "Latest Master Build" --repo "$REPO_INFO"
 
   upload-release:
-    name: Upload Release
+    name: Upload Release and update website
 
     needs: [linux-build, windows-build, pack-resources]
     runs-on: ubuntu-24.04
@@ -381,3 +381,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_INFO: ${{ github.repository }}
       run: 'gh release upload "$GITHUB_REF_NAME" neo-*.7z --clobber --repo "$REPO_INFO"'
+
+    - name: Trigger NeotokyoRebuild.github.io to update
+      env:
+          NTRE_GH_SITE_PAT: ${{ secrets.NTRE_GH_SITE_PAT }}
+      run: |
+        curl -qs --fail-with-body -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $NTRE_GH_SITE_PAT" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/NeotokyoRebuild/NeotokyoRebuild.github.io/dispatches \
+            -d '{"event_type":"new-release"}'
+


### PR DESCRIPTION
Just an extra step to cause a site rebuild when there's a new release pushed out

Leads to be able to drop JS requirement in website: https://github.com/NeotokyoRebuild/NeotokyoRebuild.github.io/pull/27
