### PR TITLE
Cherry-pick from upstream: Always lowercase filenames in CUtlFilenameSymbolTable to fix loading packed files on Linux (fixes upstream 865)

### DIFF
--- a/src/tier1/utlsymbol.cpp
+++ b/src/tier1/utlsymbol.cpp
@@ -331,9 +331,7 @@ FileNameHandle_t CUtlFilenameSymbolTable::FindOrAddFileName( const char *pFileNa
 	char fn[ MAX_PATH ];
 	Q_strncpy( fn, pFileName, sizeof( fn ) );
 	Q_RemoveDotSlashes( fn );
-#ifdef _WIN32
 	Q_strlower( fn );
-#endif
 
 	// Split the filename into constituent parts
 	char basepath[ MAX_PATH ];
@@ -378,9 +376,7 @@ FileNameHandle_t CUtlFilenameSymbolTable::FindFileName( const char *pFileName )
 	char fn[ MAX_PATH ];
 	Q_strncpy( fn, pFileName, sizeof( fn ) );
 	Q_RemoveDotSlashes( fn );
-#ifdef _WIN32
 	Q_strlower( fn );
-#endif
 
 	// Split the filename into constituent parts
 	char basepath[ MAX_PATH ];


### PR DESCRIPTION
Upstream: Always lowercase filenames in CUtlFilenameSymbolTable to fix loading packed files on Linux (fixes https://github.com/ValveSoftware/source-sdk-2013/issues/865)
Upstream commit hash: fd413c5fc7d0b005747b05d8d6a31e7cc56ad294

