### PR TITLE
Let inaccuracy decay while gun is holstered

### DIFF
--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -534,13 +534,6 @@ bool CNEOBaseCombatWeapon::Holster(CBaseCombatWeapon* pSwitchingTo)
 	return BaseClass::Holster(pSwitchingTo);
 }
 
-#ifdef CLIENT_DLL
-void CNEOBaseCombatWeapon::ItemHolsterFrame(void)
-{ // Overrides the base class behaviour of reloading the weapon after its been holstered for 3 seconds
-	return;
-}
-#endif
-
 void CNEOBaseCombatWeapon::CheckReload(void)
 {
 	if (!m_bInReload && UsesClipsForAmmo1() && m_iClip1 == 0 && GetOwner() && !ClientWantsAutoReload(GetOwner()))
@@ -584,6 +577,19 @@ void CNEOBaseCombatWeapon::UpdateInaccuracy()
 
 void CNEOBaseCombatWeapon::ItemPreFrame(void)
 {
+	BaseClass::ItemPreFrame();
+	UpdateInaccuracy();
+}
+
+void CNEOBaseCombatWeapon::ItemBusyFrame(void)
+{
+	BaseClass::ItemBusyFrame();
+	UpdateInaccuracy();
+}
+
+void CNEOBaseCombatWeapon::ItemHolsterFrame(void)
+{
+	BaseClass::ItemHolsterFrame();
 	UpdateInaccuracy();
 }
 

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -147,6 +147,7 @@ public:
 
 	virtual void ItemPreFrame(void) override;
 	virtual void ItemPostFrame(void) override;
+	virtual void ItemBusyFrame(void) override;
 
 	virtual void PrimaryAttack(void) override;
 	virtual void SecondaryAttack(void) override;
@@ -210,8 +211,8 @@ public:
 	virtual void SetPickupTouch(void) override;
 
 	virtual bool Holster(CBaseCombatWeapon* pSwitchingTo) override;
-#ifdef CLIENT_DLL
 	virtual void ItemHolsterFrame() override;
+#ifdef CLIENT_DLL
 	virtual bool ShouldDraw(void) override;
 	virtual void ThirdPersonSwitch(bool bThirdPerson) override;
 	virtual int RestoreData(const char* context, int slot, int type) override;


### PR DESCRIPTION
## Description
Turns out ItemPreFrame isn't called while the gun is holstered, which should've been obvious. Less obvious is that it also isn't called while the gun is playing the deploy animation.

The first issue is solved by calling UpdateInaccuracy in ItemHolsterFrame.
The second by calling it in ItemBusyFrame.

I also realized that ItemPreFrame wasn't calling the base class method, which meant that MaintainIdealActivity wasn't being called. I'm not sure if this has been causing any issues previously, but I figure it can't hurt to fix while at it.

ItemHolsterFrame was previously overriden to not call the base class method to avoid automatically reloading holstered guns, but there's already an if-statement in the base class to handle that. I decided to call the base class method for consistency.

As an aside, it would probably make more sense to store the inaccuracy on the player, but I don't feel like doing a larger refactor right now.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native CachyOS

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1665 

