### PR TITLE
Fix neo_restart_this resetting game mode to CTG

### DIFF
--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -3168,7 +3168,17 @@ void CNEORules::RestartGame()
 
 	ResetMapSessionCommon();
 
-	GatherGameTypeVotes();
+	// NEO FIXME (Rain): this GatherGameTypeVotes business seems a bit wonky,
+	// since it'll just gather the clients' "neo_vote_game_mode" cvar values
+	// without prompting for some kind of a vote. So the most likely result
+	// is the map just switching to the "neo_vote_game_mode" default value (CTG),
+	// which may not be appropriate for the map.
+	const bool bFromStarting = (m_nRoundStatus == NeoRoundStatus::Warmup
+		|| m_nRoundStatus == NeoRoundStatus::Countdown);
+	if (sv_neo_gamemode_enforcement.GetInt() == GAMEMODE_ENFORCEMENT_VOTE && bFromStarting)
+	{
+		GatherGameTypeVotes();
+	}
 
 	SetGameRelatedVars();
 


### PR DESCRIPTION
## Description
Stop unconditionally calling `GatherGameTypeVotes` from `CNEORules::RestartGame`, because it was determining the game mode based on the players' "neo_vote_game_mode" userinfo cvar values, but this is inappropriate when the corresponding `sv_neo_gamemode_enforcement` mode is not set.

The mechanism itself also seems a bit obscure if the players are required to manually adjust their "neo_vote_game_mode" cvar values by console, but that stuff is out of scope for this PR.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1670 

