### PR TITLE
Apply godmode when comp match is paused

### DIFF
--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -2979,12 +2979,18 @@ int	CNEO_Player::OnTakeDamage_Alive(const CTakeDamageInfo& info)
 {
 	if (m_takedamage != DAMAGE_EVENTS_ONLY)
 	{
-		if (sv_neo_warmup_godmode.GetBool() &&
-				(NEORules()->GetRoundStatus() == NeoRoundStatus::Idle ||
-				 NEORules()->GetRoundStatus() == NeoRoundStatus::Warmup ||
-				 NEORules()->GetRoundStatus() == NeoRoundStatus::Countdown))
+		if (sv_neo_warmup_godmode.GetBool())
 		{
-			return 0;
+			switch (NEORules()->GetRoundStatus())
+			{
+			case NeoRoundStatus::Idle:
+			case NeoRoundStatus::Warmup:
+			case NeoRoundStatus::Countdown:
+			case NeoRoundStatus::Pause:
+				return 0;
+			default:
+				break;
+			}
 		}
 
 		// Checking because attacker might be prop or world


### PR DESCRIPTION
## Description
Make `sv_neo_warmup_godmode 1` apply also for the comp pause mode.

## Toolchain
- Windows MSVC VS2022
- Linux GCC 10 Sniper 3.0

## Linked Issues
- fixes #1645 
