### PR TITLE
Fix unable to jump after recrouching during uncrouch animation.

### DIFF
--- a/src/game/shared/gamemovement.cpp
+++ b/src/game/shared/gamemovement.cpp
@@ -4487,10 +4487,10 @@ void CGameMovement::FinishDuck( void )
 {
 #ifdef NEO
 	Assert(dynamic_cast<CNEO_Player*>(player));
-#endif
-
+#else
 	if ( player->GetFlags() & FL_DUCKING )
 		return;
+#endif
 
 	player->AddFlag( FL_DUCKING );
 	player->m_Local.m_bDucked = true;
@@ -5271,4 +5271,3 @@ void  CGameMovement::TryTouchGround( const Vector& start, const Vector& end, con
 	ray.Init( start, end, mins, maxs );
 	UTIL_TraceRay( ray, fMask, mv->m_nPlayerHandle.Get(), collisionGroup, &pm );
 }
-


### PR DESCRIPTION
## Description
Source 2013 has an early return in FinishDuck that didn't exist in 2006. This causes us to get stuck in the ducking state. Fix is to simply ifdef out the if-statement. Hard to say why it was added in the first place since the method is only called once when the animation finishes so it's not really a performance save.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1661 
