### PR TITLE
Don't force crouch for bots when reloading

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -607,8 +607,6 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 
 			if ( m_isWaitingForFullReload )
 			{
-				me->PressCrouchButton(0.3f);
-
 				if ( myWeapon->Clip1() < myWeapon->GetMaxClip1() )
 				{
 					return;
@@ -817,7 +815,6 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 			}
 			else if (myWeapon->m_iClip1 <= 0)
 			{
-				me->PressCrouchButton(0.3f);
 				if (m_isWaitingForFullReload)
 				{
 					// passthrough: don't introduce decision jitter

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -1616,7 +1616,6 @@ void CNEOBot::ReloadIfLowClip(void)
 		{
 			ReleaseFireButton();
 			PressReloadButton();
-			PressCrouchButton(0.3f);
 		}
 	}
 }


### PR DESCRIPTION
## Description
Don't force crouch anymore when reloading because:
- The Juggernaut was always crouching, because their weapon uses 0/low Clip1() ammo to indicate a cooler state for the heat based weapon.
- When retreating, it may be more important to be fast than than to be small, so crouching is now disabled in favor of walking/sprinting which are faster than crouch walking.

## Toolchain
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0
