### PR TITLE
Make it possible to fire the supa immediately after loading a shell

### DIFF
--- a/src/game/shared/neo/weapons/weapon_supa7.cpp
+++ b/src/game/shared/neo/weapons/weapon_supa7.cpp
@@ -11,11 +11,13 @@ BEGIN_NETWORK_TABLE(CWeaponSupa7, DT_WeaponSupa7)
 	RecvPropBool(RECVINFO(m_bSlugLoaded)),
 	RecvPropBool(RECVINFO(m_bWeaponRaised)),
 	RecvPropBool(RECVINFO(m_bShellInChamber)),
+	RecvPropFloat(RECVINFO(m_flNextReload)),
 #else
 	SendPropBool(SENDINFO(m_bSlugDelayed)),
 	SendPropBool(SENDINFO(m_bSlugLoaded)),
 	SendPropBool(SENDINFO(m_bWeaponRaised)),
 	SendPropBool(SENDINFO(m_bShellInChamber)),
+	SendPropFloat(SENDINFO(m_flNextReload)),
 #endif
 END_NETWORK_TABLE()
 
@@ -25,6 +27,7 @@ BEGIN_PREDICTION_DATA(CWeaponSupa7)
 	DEFINE_PRED_FIELD(m_bSlugLoaded, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE),
 	DEFINE_PRED_FIELD(m_bWeaponRaised, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE),
 	DEFINE_PRED_FIELD(m_bShellInChamber, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE),
+	DEFINE_PRED_FIELD(m_flNextReload, FIELD_FLOAT, FTYPEDESC_INSENDTABLE),
 END_PREDICTION_DATA()
 #endif
 
@@ -38,6 +41,7 @@ BEGIN_DATADESC(CWeaponSupa7)
 	DEFINE_FIELD(m_bSlugLoaded, FIELD_BOOLEAN),
 	DEFINE_FIELD(m_bWeaponRaised, FIELD_BOOLEAN),
 	DEFINE_FIELD(m_bShellInChamber, FIELD_BOOLEAN),
+	DEFINE_FIELD(m_flNextReload, FIELD_FLOAT),
 END_DATADESC()
 #endif
 
@@ -68,6 +72,7 @@ CWeaponSupa7::CWeaponSupa7(void)
 	m_bSlugLoaded = false;
 	m_bWeaponRaised = false;
 	m_bShellInChamber = true;
+	m_flNextReload = 0.0f;
 
 	m_fMinRange1 = 0.0;
 	m_fMaxRange1 = 500;
@@ -117,6 +122,7 @@ bool CWeaponSupa7::StartReload(void)
 
 	pOwner->m_flNextAttack = gpGlobals->curtime;
 	ProposeNextAttack(gpGlobals->curtime + SequenceDuration());
+	m_flNextReload = gpGlobals->curtime + SequenceDuration();
 
 	m_bInReload = true;
 	return true;
@@ -153,6 +159,7 @@ bool CWeaponSupa7::StartReloadSlug(void)
 
 	pOwner->m_flNextAttack = gpGlobals->curtime;
 	ProposeNextAttack(gpGlobals->curtime + SequenceDuration());
+	m_flNextReload = gpGlobals->curtime + SequenceDuration();
 
 	return true;
 }
@@ -185,7 +192,8 @@ bool CWeaponSupa7::Reload(void)
 
 	pOwner->m_flNextAttack = gpGlobals->curtime;
 	constexpr float TIME_BETWEEN_SHELLS_LOADED = 0.5f;
-	ProposeNextAttack(gpGlobals->curtime + TIME_BETWEEN_SHELLS_LOADED);
+	// ProposeNextAttack(gpGlobals->curtime + TIME_BETWEEN_SHELLS_LOADED);
+	m_flNextReload = gpGlobals->curtime + TIME_BETWEEN_SHELLS_LOADED;
 
 	return true;
 }
@@ -223,7 +231,9 @@ bool CWeaponSupa7::ReloadSlug(void)
 	pOwner->DoAnimationEvent(PLAYERANIMEVENT_RELOAD);
 
 	pOwner->m_flNextAttack = gpGlobals->curtime;
-	ProposeNextAttack(gpGlobals->curtime + SequenceDuration());
+	// ProposeNextAttack(gpGlobals->curtime + SequenceDuration());
+	m_flNextReload = gpGlobals->curtime + SequenceDuration();
+
 	return true;
 }
 
@@ -252,7 +262,7 @@ void CWeaponSupa7::FinishReload(void)
 	}
 
 	pOwner->m_flNextAttack = gpGlobals->curtime;
-	ProposeNextAttack(gpGlobals->curtime + SequenceDuration());
+	// ProposeNextAttack(gpGlobals->curtime + SequenceDuration());
 }
 
 // Purpose: Play finish reload anim and fill clip
@@ -414,7 +424,7 @@ void CWeaponSupa7::ItemPostFrame(void)
 			// This is a slight nerf to the supa where the gun has to be racked before it is fired
 			FinishReload();
 		}
-		else if (m_flNextPrimaryAttack <= gpGlobals->curtime)
+		else if (m_flNextReload <= gpGlobals->curtime)
 		{
 			// If we're supposed to have a slug loaded, load it
 			if (m_bSlugDelayed)

--- a/src/game/shared/neo/weapons/weapon_supa7.h
+++ b/src/game/shared/neo/weapons/weapon_supa7.h
@@ -88,6 +88,7 @@ private:
 	CNetworkVar(bool, m_bSlugLoaded); // Slug currently loaded in chamber
 	CNetworkVar(bool, m_bWeaponRaised); // Slug currently loaded in chamber
 	CNetworkVar(bool, m_bShellInChamber); // Slug currently loaded in chamber
+	CNetworkVar(float, m_flNextReload); // Time to load the next shell
 
 private:
 	CWeaponSupa7(const CWeaponSupa7 &other);


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
I didn't actually time this to make sure it's parity but it feels a lot closer. Basically, I only bump nextAttack when starting the reload and not for all the sequences after. A new member m_flNextReload was added to handle the delay between each shell because it was using nextAttack before.

I left the attack delay code commented out in case we want to revisit it later.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1678

