### PR TITLE
Fix competitive idle map rotation

### DIFF
--- a/src/game/shared/multiplay_gamerules.cpp
+++ b/src/game/shared/multiplay_gamerules.cpp
@@ -469,6 +469,9 @@ ConVarRef suitcharger( "sk_suitcharger" );
 			int iIdleSeconds = (int)( flNow - m_flTimeLastMapChangeOrPlayerWasConnected );
 			if ( iIdleSeconds >= mp_mapcycle_empty_timeout_seconds.GetInt() )
 			{
+#ifdef NEO
+				assert_cast<CNEORules*>(this)->m_bRotatingMapRightNow = true;
+#endif
 
 				Log( "Server has been empty for %d seconds on this map, cycling map as per mp_mapcycle_empty_timeout_seconds\n", iIdleSeconds );
 				ChangeLevel();
@@ -1564,6 +1567,9 @@ ConVarRef suitcharger( "sk_suitcharger" );
 		m_flTimeLastMapChangeOrPlayerWasConnected = 0.0f;
 		Msg( "CHANGE LEVEL: %s\n", pszMap );
 		engine->ChangeLevel( pszMap, NULL );
+#ifdef NEO
+		assert_cast<CNEORules*>(this)->m_bRotatingMapRightNow = false;
+#endif
 	}
 
 

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -784,7 +784,7 @@ void CNEORules::ResetMapSessionCommon()
 void CNEORules::ChangeLevel(void)
 {
 	ResetMapSessionCommon();
-	if (sv_neo_readyup_lobby.GetBool() && !sv_neo_readyup_autointermission.GetBool())
+	if (!m_bRotatingMapRightNow && sv_neo_readyup_lobby.GetBool() && !sv_neo_readyup_autointermission.GetBool())
 	{
 		m_bChangelevelDone = false;
 	}

--- a/src/game/shared/neo/neo_gamerules.h
+++ b/src/game/shared/neo/neo_gamerules.h
@@ -418,6 +418,7 @@ public:
 	bool m_bPausedByPreRoundFreeze = false;
 	bool m_bPausingTeamRequestedUnpause = false;
 	bool m_bThinkCheckClantags = false;
+	bool m_bRotatingMapRightNow = false;
 #endif
 	CNetworkVar(float, m_flPauseEnd);
 


### PR DESCRIPTION
## Description
Fix a bug with the idle map cycle cvar `mp_mapcycle_empty_timeout_seconds` combined with cvar value `sv_neo_comp 1` causing an infinitely failing map change loop, where the idle mapchange logic and the `sv_neo_readyup_...` logic are fighting each other, and endlessly flipping the `m_bChangelevelDone` gamerules value back and forth.

This commit simply introduces a new `m_bRotatingMapRightNow` gamerules state flag for the idle rotation special case to sidestep the problem, instead of refactoring the logic. But it should be good enough to get this problem fixed for now. Could be cleaned up in some future refactor...

Steps to reproduce the bug:

* Start a SRCDS server
* Use commands:

```
sv_neo_comp 1; // Necessary to trigger the bug!

// How many seconds must the server be empty until attempting to change maps,
// set to a low value to trigger the bug fast.
mp_mapcycle_empty_timeout_seconds 10;
```

## Toolchain
- Windows MSVC VS2022
- Linux GCC 10 Sniper 3.0

## Linked Issues
- fixes #1330
