### PR TITLE
Fix multiple func_breakable_surf penetrations case

### DIFF
--- a/src/game/shared/baseentity_shared.cpp
+++ b/src/game/shared/baseentity_shared.cpp
@@ -2268,6 +2268,7 @@ void CBaseEntity::HandleShotPenetration(const FireBulletsInfo_t& info,
 	}
 
 	// See if we have enough pen to penetrate
+	Assert(penResistance != 0);
 	const float penUsed = ((1.0f - penetrationTrace.fraction) * MAX_PENETRATION_DEPTH) / penResistance;
 	Assert(info.m_flPenetration > 0);
 	if (penUsed && penUsed > info.m_flPenetration)


### PR DESCRIPTION
## Description
Fix bullet penetration through multiple `func_breakable_surf` panes.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1685 
