### PR TITLE
Allow reload immediately after firing.

### DIFF
--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -631,7 +631,7 @@ void CNEOBaseCombatWeapon::ItemPostFrame(void)
 
 	UpdateAutoFire();
 
-	if (IsSemiAuto() && (pOwner->m_afButtonLast & IN_ATTACK) && !(pOwner->m_nButtons & IN_ATTACK))
+	if (IsSemiAuto() && !(pOwner->m_nButtons & IN_ATTACK))
 	{
 		m_bTriggerReset = true;
 	}
@@ -760,7 +760,7 @@ void CNEOBaseCombatWeapon::ItemPostFrame(void)
 	// -----------------------
 	//  Reload pressed / Clip Empty
 	//  Can only start the Reload Cycle after the firing cycle
-	if ((pOwner->m_nButtons & IN_RELOAD) && m_flNextPrimaryAttack <= gpGlobals->curtime && UsesClipsForAmmo1() && !m_bInReload)
+	if ((pOwner->m_nButtons & IN_RELOAD) && UsesClipsForAmmo1() && !m_bInReload)
 	{
 		// reload when reload is pressed, or if no buttons are down and weapon is empty.
 		Reload();

--- a/src/game/shared/neo/weapons/weapon_srs.cpp
+++ b/src/game/shared/neo/weapons/weapon_srs.cpp
@@ -46,7 +46,7 @@ CWeaponSRS::CWeaponSRS()
 
 void CWeaponSRS::PrimaryAttack()
 {
-	if (ShootingIsPrevented() || !m_iClip1)
+	if (ShootingIsPrevented() || !m_iClip1 || !m_bTriggerReset)
 	{
 		Assert(!(m_iClip1 < 0));
 		return BaseClass::PrimaryAttack();
@@ -70,7 +70,7 @@ void CWeaponSRS::ItemPreFrame()
 		return BaseClass::ItemPreFrame();
 	}
 
-	if (m_flLastAttackTime + 0.08f <= gpGlobals->curtime && m_iClip1 > 0)
+	if (m_flLastAttackTime + 0.08f <= gpGlobals->curtime)
 	{ // Primary attack animation finished, begin chambering a round
 		if (auto* pOwner = ToNEOPlayer(GetOwner())) {
 			if (pOwner->m_nButtons & IN_ATTACK)
@@ -104,15 +104,7 @@ bool CWeaponSRS::Reload()
 	// we don't want to bolt twice.
 	m_bNeedsBolting = false;
 
-	if (auto owner = ToBasePlayer(GetOwner()))
-	{
-		if (!(owner->m_nButtons & IN_ATTACK))
-		{
-			return BaseClass::Reload();
-		}
-		return false;
-	}
-	return false;
+	return BaseClass::Reload();
 }
 
 bool CWeaponSRS::CanBePickedUpByClass(int classId)


### PR DESCRIPTION
## Description
* Remove mandatory delay after firing by just removing the nextPrimaryAttack check.
* Fix issue with semi-auto guns where the first shot after reload would be a dud if the fire button was held when starting the reload.
* Pull SRS bolt after firing last round. This is parity and it was annoying that it didn't unzoom immediately (when using toggle aim). The bolt animation can always be cancelled into a reload.
* Allow reloading the SRS while the fire button is still held.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1698 

