### PR TITLE
Go into overtime if Juggernaut is being activated, allow teammates to score in JGR

### DIFF
--- a/src/game/shared/neo/neo_juggernaut.h
+++ b/src/game/shared/neo/neo_juggernaut.h
@@ -33,6 +33,8 @@ public:
 	virtual int	ObjectCaps(void) { return BaseClass::ObjectCaps() | FCAP_ONOFF_USE; }
 	virtual int UpdateTransmitState() override;
 
+	const bool IsBeingActivatedByLosingTeam();
+
 	bool	m_bPostDeath = false;
 #endif
 
@@ -56,7 +58,7 @@ private:
 #endif
 
 #ifdef GAME_DLL
-	CHandle<CNEO_Player>	m_hPlayer;
+	CHandle<CNEO_Player> m_hHoldingPlayer;
 	EHANDLE m_hPush;
 	float m_flWarpedPlaybackRate;
 	float m_flHoldStartTime = 0.0f;


### PR DESCRIPTION
## Description
Title and also reverts round timelimit to 4 minutes and max score to win to 20
The scoring change is experimental.
Currently there is no way of setting per gamemount max rounds / score limit and that will be done seperately

## Toolchain
- Windows MSVC VS2022


