### PR TITLE
Cull smoke particles inside walls

### DIFF
--- a/src/game/client/c_particle_smokegrenade.cpp
+++ b/src/game/client/c_particle_smokegrenade.cpp
@@ -854,13 +854,17 @@ void C_ParticleSmokeGrenade::FillVolume()
 				vPos.z = m_SmokeBasePos.z + ((float)z * invNumPerDimZ) * m_SpacingRadius * 2 - m_SpacingRadius;
 
 				// Don't spawn and simulate particles that are inside a wall
-//				int contents = enginetrace->GetPointContents( vPos );
+#ifdef NEO
+				int contents = enginetrace->GetPointContents( vPos );
 
 				// Culling out particles in solid makes smoke not fill up small passageways.
-				//if( contents & CONTENTS_SOLID )
-				//{
-				//	continue;
-				//}
+				// NEO NOTE DG: ^^^ Maybe this is true, but this was performed
+				// in OGNT as far as I am aware and caused no issue.
+				if( contents & CONTENTS_SOLID )
+				{
+					continue;
+				}
+#endif
 
 				if(SmokeParticleInfo *pInfo = GetSmokeParticleInfo(x,y,z))
 				{

--- a/src/game/client/particlemgr.cpp
+++ b/src/game/client/particlemgr.cpp
@@ -1206,7 +1206,14 @@ Particle *CParticleMgr::AllocParticle( int size )
 {
 	// Enforce max particle limit.
 	if ( m_nCurrentParticlesAllocated >= MAX_TOTAL_PARTICLES )
+#ifdef NEO
+	{
+		DevWarning("CParticleMgr::AllocParticle: Too many particles!\n");
 		return NULL;
+	}
+#else
+		return NULL;
+#endif
 		
 	Particle *pRet = (Particle *)malloc( size );
 	if ( pRet )


### PR DESCRIPTION
## Description
Parity. Removes unnecessary smoke particles to stay under the particle limit. Also adds a warning when hitting the limit so we know what might be happening...

## Toolchain
- Windows MSVC VS2022



