### PR TITLE
Use `voice_modenable` instead of `voice_enable`, fix voicerecord state

### DIFF
--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -1481,6 +1481,17 @@ void CHLClient::PostInit()
 				}
 			}
 
+			if (iCfgVerMajor < 26)
+			{
+				// voice_modenable is used now instead of voice_enable as
+				// that's how the valve settings menu does it now and
+				// force voice_enable back on
+				ConVarRef cvr_voice_enable("voice_enable");
+				ConVarRef cvr_voice_modenable("voice_modenable");
+				cvr_voice_modenable.SetValue(cvr_voice_enable.GetBool());
+				cvr_voice_enable.SetValue(true);
+			}
+
 			cvr_cl_neo_cfg_version_major.SetValue(NEO_VERSION_MAJOR);
 			cvr_cl_neo_cfg_version_minor.SetValue(NEO_VERSION_MINOR);
 		}

--- a/src/game/client/neo/ui/neo_root.cpp
+++ b/src/game/client/neo/ui/neo_root.cpp
@@ -1084,7 +1084,7 @@ void CNeoRoot::MainLoopSettings(const MainLoopParam param)
 					NeoUI::Bind(BTNCODES_DEFAULT, ARRAYSIZE(BTNCODES_DEFAULT)))
 			{
 				m_state = STATE_SETTINGSRESETDEFAULT;
-				engine->GetVoiceTweakAPI()->EndVoiceTweakMode();
+				NeoSettingsEndVoiceTweakMode();
 			}
 			if (m_ns.bModified)
 			{
@@ -1125,7 +1125,7 @@ void CNeoRoot::MainLoopSettings(const MainLoopParam param)
 	{
 		m_ns.bBack = false;
 		m_state = (m_ns.bModified) ? STATE_CONFIRMSETTINGS : STATE_ROOT;
-		engine->GetVoiceTweakAPI()->EndVoiceTweakMode();
+		NeoSettingsEndVoiceTweakMode();
 	}
 	else if (m_ns.iNextBinding >= 0)
 	{

--- a/src/game/client/neo/ui/neo_root_settings.h
+++ b/src/game/client/neo/ui/neo_root_settings.h
@@ -290,7 +290,7 @@ struct NeoSettings
 		CONVARREF_DEFNOGLOBALPTR(snd_victory_volume);
 		CONVARREF_DEFNOGLOBALPTR(snd_ping_volume);
 		CONVARREF_DEF(snd_surround_speakers);
-		CONVARREF_DEF(voice_enable);
+		CONVARREF_DEF(voice_modenable);
 		CONVARREF_DEF(voice_scale);
 		CONVARREF_DEF(snd_mute_losefocus);
 		CONVARREF_DEF(snd_pitchquality);
@@ -347,6 +347,7 @@ void NeoSettingsDeinit(NeoSettings *ns);
 void NeoSettingsRestore(NeoSettings *ns, const NeoSettings::Keys::Flags flagsKeys = NeoSettings::Keys::NONE);
 void NeoSettingsSave(const NeoSettings *ns);
 void NeoSettingsResetToDefault(NeoSettings *ns);
+void NeoSettingsEndVoiceTweakMode();
 
 void NeoSettings_General(NeoSettings *ns);
 void NeoSettings_Keys(NeoSettings *ns);


### PR DESCRIPTION

<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
`voice_enable` have issues when toggling it on/off and using the tweak in the settings menu, seems to be an Source SDK bug. However, I've noticed checked in HL2:DM, while it also have the same issue (through testing in console), the settings doesn't use `voice_enable` and now uses `voice_modenable` when it toggles that setting instead.

Also added migration for v26 from voice_enable to voice_modenable setting.

Then there's a second bug where after you fiddle around with tweaking, load up a local server and the voice recording HUD indicator in the bottom left show's it's recording even though it's actually not determining by voice_loopback 1. This can be worked around by setting UpdateSpeakerStatus and ending tweaking unified under the NeoSettingsEndVoiceTweakMode function.

Extra note: When pressing the voice keybind, this will always re-enable `voice_modenable` to 1 and this is also the behavior on HL2:DM. So changing to this setting and this behavior is just in-parity with upstream's voice enable/disable behavior.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native GCC 15

<!--
## Linked Issues

Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

- fixes #
- related #
-->

