### PR TITLE
Simplify dynamic crosshair calculation

### DIFF
--- a/src/game/client/neo/ui/neo_hud_crosshair.cpp
+++ b/src/game/client/neo/ui/neo_hud_crosshair.cpp
@@ -312,8 +312,8 @@ int HalfInaccuracyConeInScreenPixels(C_NEOBaseCombatWeapon* pWeapon, int halfScr
 	{
 		return 0;
 	}
-	Vector pointInWorldSpaceOnSpreadCone = MainViewOrigin() + MainViewForward() + (MainViewRight() * spread);
-	Vector pointInScreenSpaceOnSpreadCone = vec3_origin;
-	ScreenTransform(pointInWorldSpaceOnSpreadCone, pointInScreenSpaceOnSpreadCone);
-	return pointInScreenSpaceOnSpreadCone.x * halfScreenWidth;
+	float scaledFov = DEG2RAD(ScaleFOVByWidthRatio(
+		C_BasePlayer::GetLocalPlayer()->GetFOV(),
+		engine->GetScreenAspectRatio() * 0.75f )) / 2;
+	return halfScreenWidth * spread / tan(scaledFov);
 };


### PR DESCRIPTION
## Description
Calculate dynamic crosshair size without involving view position and angle. Probably won't fix the jitter when spectating, but won't hurt either.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

