### PR TITLE
Fix GetSpreadInfo assertion for bot behaviors

### DIFF
--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -824,7 +824,7 @@ const Vector &CNEOBaseCombatWeapon::GetBulletSpread(void)
 
 	// We lerp from very accurate to inaccurate over time
 	static Vector cone;
-	auto weaponSpread = GetSpreadInfo();
+	const auto& weaponSpread = GetSpreadInfo();
 	if (pOwner && pOwner->IsInAim())
 	{
 		VectorLerp(


### PR DESCRIPTION
## Description
The bot logic in some of the upcoming behavior PRs can cause the bots to request spread information for unusual weapons, like the ghost, knife, grenades, etc. This triggers the assertion at https://github.com/NeotokyoRebuild/neo/blob/f0906262e63ae28bbe20062e7479591f8afbe61c/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp#L789
because as per https://github.com/NeotokyoRebuild/neo/blob/f0906262e63ae28bbe20062e7479591f8afbe61c/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp#L249-L257 the weapons not defined in the handling table will use the zeroth entry, which happens to be the AA13. And since a knife is not an AA13, that will cause the above assert to fire.

While we could address this in the bot logic, I felt it's lower maintenance to reserve the lowest (zeroth) entry in the weapons handling table for this exact purpose, so those weapons just return a zeroed dummy value for things like spread. This avoids us having to do the "if not knife, if not ghost, if not grenade" dance in the bot logic whenever the handling info is needed. And this was firing from several bot PRs in different locations, so I think we want to handle this base case to avoid needing changes in many places.

## Steps to reproduce the bug
* git checkout #1600
* load `map ntre_oilstain_ctg`
* go to spectator, spawn 10 bots
* set `host_timescale 10` and let the bots play a full map

### What happens
The assert triggers sooner or later during the map

### What should happen
The assert doesn't trigger

## To test the fix
* git checkout this PR
* rebase it on top of #1600
* try the above steps again
* no more assert failure

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1600

