### PR TITLE
Fix array bounds underflow

### DIFF
--- a/src/game/client/neo/ui/neo_ui.cpp
+++ b/src/game/client/neo/ui/neo_ui.cpp
@@ -1981,6 +1981,11 @@ void SliderU8(const wchar_t *wszLeftLabel, uint8 *ucValue, const uint8 iMin, con
 
 static int TextEditChIdxFromMouse(const int iWszTextSize)
 {
+	if (iWszTextSize <= 0)
+	{
+		return 0;
+	}
+
 	const int iMouseOnXWidth = c->iMouseAbsX - (c->rWidgetArea.x0 + c->iMarginX);
 	int iChIdx = -1;
 	for (int i = 0; i < iWszTextSize; ++i)


### PR DESCRIPTION
## Description
Fix a case of potential array bounds underflow by `NeoUI::TextEditChIdxFromMouse` for empty inputs.

## Steps to reproduce

* checkout current master 04569ec0
* Build & launch the game
* Click "Create Server"
* Empty the "Password" field's value
* Press escape to return to main menu
* Click "Create Server" again
* Now the Password field's value should be empty
* Add a breakpoint to line: https://github.com/NeotokyoRebuild/neo/blob/04569ec0d99f5725c31ab54b3bf30112b03c8bf7/src/game/client/neo/ui/neo_ui.cpp#L2008
* Click the empty "Password" field with your mouse
* The breakpoint should be hit

## What happens

* Value of `iWszTextSize` is 0
* Therefore, at https://github.com/NeotokyoRebuild/neo/blob/04569ec0d99f5725c31ab54b3bf30112b03c8bf7/src/game/client/neo/ui/neo_ui.cpp#L2008 the `irTextWidths` is indexed at `-1` which is out array bounds.

## What should happen

* `irTextWidths` access stays in bounds

## Toolchain
- Windows MSVC VS2022

## Linked Issues

