### PR TITLE
 Silenced Mosok should unlock at Corporal for Assaults

### DIFF
--- a/src/game/shared/neo/neo_weapon_loadout.cpp
+++ b/src/game/shared/neo/neo_weapon_loadout.cpp
@@ -35,7 +35,7 @@ inline const CLoadoutWeapon s_LoadoutWeapons[NEO_LOADOUT__COUNT][MAX_WEAPON_LOAD
 	{
 		{XP_ANY, WEAPON(mpn)},			{XP_PRIVATE, WEAPON(srm)},		{XP_PRIVATE, WEAPON(jitte)},
 		{XP_PRIVATE, WEAPON(zr68c)},	{XP_PRIVATE, WEAPON(zr68s)},	{XP_CORPORAL, WEAPON(supa7)},
-		{XP_CORPORAL, WEAPON(mosok)},	{XP_SERGEANT, WEAPON(mosokl)},	{XP_SERGEANT, WEAPON(mx)},
+		{XP_CORPORAL, WEAPON(mosok)},	{XP_CORPORAL, WEAPON(mosokl)},	{XP_SERGEANT, WEAPON(mx)},
 		{XP_SERGEANT, WEAPON(mxs)},		{XP_LIEUTENANT, WEAPON(aa13)},	{XP_LIEUTENANT, WEAPON(srs)},
 	},
 	// Support


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Unlock silenced Mosok at Corporal instead of Sergeant.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

