### PR TITLE
NeoUI - Fix first-used force active textedit not properly set cursor

### DIFF
--- a/src/game/client/neo/ui/neo_ui.cpp
+++ b/src/game/client/neo/ui/neo_ui.cpp
@@ -296,6 +296,7 @@ void BeginContext(NeoUI::Context *pNextCtx, const NeoUI::Mode eMode, const wchar
 		c->colorEditInfo.a = nullptr;
 		c->iPrePopupActive = c->iPrePopupHot = FOCUSOFF_NUM;
 		c->iPrePopupActiveSection = c->iPrePopupHotSection = -1;
+		c->iTextSelStart = c->iTextSelCur = -1;
 	}
 
 	switch (c->eMode)
@@ -2198,6 +2199,12 @@ void TextEdit(wchar_t *wszText, const int iMaxWszTextSize, const TextEditFlags f
 		// changing it. Otherwise use V_wcslen directly after changing wszText
 		// contents.
 		const int iWszTextSize = V_wcslen(wszText);
+
+		// Caused by forced input, set it to the end of the text
+		if (bHasTextSel && c->iTextSelStart == -1 && c->iTextSelCur == -1)
+		{
+			c->iTextSelStart = c->iTextSelCur = iWszTextSize;
+		}
 
 		const int iTextSelMin = bCurRightStart ? c->iTextSelStart : c->iTextSelCur;
 		const int iTextSelMax = bCurRightStart ? c->iTextSelCur : c->iTextSelStart;


### PR DESCRIPTION

<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Password input textedit have forced active and if that textedit is used first, the cursor are not set properly and when the player enters a character the cursor goes left of the character, not right. Just add an if-statement to check if selection variables set to -1 and widget is active, set it to the size of the current text.

Test it with local server, make sure no other text edits are touched, create a local server then go to server list, enter that local server, see that password section, and start typing. The cursor should stay on the most-right side/end of the password text input.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native GCC 15

<!--
## Linked Issues

Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

- fixes #
- related #
-->

