### PR TITLE
Fix pen handling for multiple func_breakable_surf skipping glass breaking effect

### DIFF
--- a/src/game/client/c_func_breakablesurf.cpp
+++ b/src/game/client/c_func_breakablesurf.cpp
@@ -1335,7 +1335,8 @@ IMaterial *CBreakableSurfaceProxy::GetMaterial()
 
 EXPOSE_INTERFACE( CBreakableSurfaceProxy, IMaterialProxy, "BreakableSurface" IMATERIAL_PROXY_INTERFACE_VERSION );
 
-int GetBreakableSurfaceType( C_BaseEntity *pC_BaseEntity )
+#ifdef NEO
+int GetBreakableSurfaceType( const C_BaseEntity *pC_BaseEntity )
 {
 	Assert(pC_BaseEntity);
 
@@ -1344,12 +1345,8 @@ int GetBreakableSurfaceType( C_BaseEntity *pC_BaseEntity )
 		return -1;
 	}
 
-	C_BreakableSurface *pBreakableEnt = assert_cast<C_BreakableSurface *>(pC_BaseEntity);
-
-	if (!pBreakableEnt)
-	{
-		return -1;
-	}
+	auto *pBreakableEnt = assert_cast<const C_BreakableSurface *>(pC_BaseEntity);
 
 	return pBreakableEnt->m_nSurfaceType;
 }
+#endif

--- a/src/game/shared/baseentity_shared.cpp
+++ b/src/game/shared/baseentity_shared.cpp
@@ -78,8 +78,10 @@ ConVar hl2_episodic( "hl2_episodic", "0", FCVAR_REPLICATED );
 	extern bool ExtractKeyvalue( void *pObject, typedescription_t *pFields, int iNumFields, const char *szKeyName, char *szValue, int iMaxLen );
 #endif
 
+#ifdef NEO
 #ifdef CLIENT_DLL
-	extern int GetBreakableSurfaceType(C_BaseEntity *pEnt);
+	extern int GetBreakableSurfaceType(const C_BaseEntity *pEnt);
+#endif
 #endif
 
 bool CBaseEntity::m_bAllowPrecache = false;
@@ -2304,7 +2306,7 @@ void CBaseEntity::HandleShotPenetration(const FireBulletsInfo_t& info,
 		// NEO HACK: Force a fake thickness for now non-solid breakable surfaces,
 		// this prevents stopping the function at the open air case (fraction == 1.0f).
 		// This is because there is in fact nothing solid to penetrate, but still we need to 
-		// invoke the effects for the breakable surface at DoImpactEffect.
+		// invoke the effects for the breakable surface.
 		constexpr float kBreakableSurfFakeThickness = 2.3f;
 		penetrationTrace.fraction = 1.0f - (kBreakableSurfFakeThickness / MAX_PENETRATION_DEPTH);
 	}
@@ -2331,7 +2333,8 @@ void CBaseEntity::HandleShotPenetration(const FireBulletsInfo_t& info,
 	//		 would do exactly the same anyway...
 
 	// Impact the other side (will look like an exit effect)
-	if (!bIsShatterGlassSurf) {
+	if (!bIsShatterGlassSurf)
+	{
 		DoImpactEffect(penetrationTrace, GetAmmoDef()->DamageType(info.m_iAmmoType));
 	}
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description

Fix bullet penetration through multiple `func_breakable_surf` panes.

Two fixes:
 - Proper penetration handling for glass on both sides (glass texture and nodraw texture)
 - Saves the function penetration handling function from stopping too soon and failing to apply shatter effects to glass

~~Plus I told the ai to not apply any damage reduction with these, but I am not sure what the behavior in the original is. (easily removable if incorrect)~~

The original fix had some crash happen, I went through the firing range and it didn't crash. I also tested the double shatter multiple times, nothing bad happened.

~~disclaimer: These changes were authored by AI. I reviewed it best I could, but it's the first time I look at Source(tm) code. The solution makes sense _I guess_.~~

AI assisted in finding cause of bug.

## Toolchain

- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1685
