### PR TITLE
Show bot ghost carrier callouts to teammates

### DIFF
--- a/src/game/client/neo/ui/neo_hud_ghost_beacons.h
+++ b/src/game/client/neo/ui/neo_hud_ghost_beacons.h
@@ -21,6 +21,7 @@ public:
 
 private:
 	void DrawPlayer(float distance, const Vector& playerPos) const;
+	void DrawBotGhostCallout();
 
 protected:
 	virtual void UpdateStateForNeoHudElementDraw() override;
@@ -30,6 +31,9 @@ protected:
 private:
 	vgui::HFont m_hFont;
 	vgui::HTexture m_hTex;
+
+	CHandle<C_NEO_Player> m_hCachedGhostCarrier;
+	float m_flNextGhostSearchTime;
 
 private:
 	CNEOHud_GhostBeacons(const CNEOHud_GhostBeacons &other);

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_carrier.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_carrier.cpp
@@ -89,6 +89,14 @@ void CNEOBotGhostEquipmentHandler::Update( CNEOBot *me )
 	}
 
 	CBaseEntity *pFocus = m_hCurrentFocusEnemy.Get();
+
+	// Store target of bot ghost callout in ghost weapon for retrieval from neo_hud_ghost_beacons
+	CWeaponGhost *pGhost = dynamic_cast<CWeaponGhost*>( me->Weapon_GetSlot( 0 ) );
+	if ( pGhost )
+	{
+		pGhost->SetBotDesignatedTarget( pFocus );
+	}
+
 	if ( pFocus && pFocus->IsAlive() )
 	{
 		// Notify teammates to look at the enemy

--- a/src/game/shared/neo/weapons/weapon_ghost.h
+++ b/src/game/shared/neo/weapons/weapon_ghost.h
@@ -97,6 +97,12 @@ public:
 		BaseClass::UpdateOnRemove();
 	};
 
+	CBaseEntity* GetDesignatedTarget() const { return m_hDesignatedTarget.Get(); }
+
+#ifdef GAME_DLL
+	void SetBotDesignatedTarget(CBaseEntity* pTarget);
+#endif
+
 private:
 	void PlayGhostSound(float volume = 1.0f);
 #ifdef CLIENT_DLL
@@ -110,6 +116,7 @@ private:
 	CNetworkVar(float, m_flDeployTime); // The timestamp when the ghost was last equipped as the active weapon.
 	CNetworkVar(float, m_flNearestEnemyDist);
 	CNetworkVar(float, m_flPickupTime); // The timestamp when the ghost was last picked up by a player into their inventory.
+	CNetworkHandle(CBaseEntity, m_hDesignatedTarget);
 
 	CWeaponGhost(const CWeaponGhost &other);
 };


### PR DESCRIPTION
## Description
Visualize bot callouts to other teammates as a single ghost beacon.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1600

