### PR TITLE
Fix screen size change breaking brightness

### DIFF
--- a/src/game/client/game_controls/baseviewport.cpp
+++ b/src/game/client/game_controls/baseviewport.cpp
@@ -223,12 +223,7 @@ void CBaseViewport::OnScreenSizeChanged(int iOldWide, int iOldTall)
 #ifndef _XBOX
 	m_pBackGround = new CBackGroundPanel( NULL );
 	m_pBackGround->SetZPos( -20 ); // send it to the back 
-#ifdef NEO
-	// The software cursor requires a visible background surface to draw against, even if it's empty.
-	m_pBackGround->SetVisible( true );
-#else
 	m_pBackGround->SetVisible( false );
-#endif
 #endif
 	CreateDefaultPanels();
 #ifndef _XBOX


### PR DESCRIPTION
## Description
Remove the unneeded line making the background panel visible upon screen change, because it was causing screen brightness settings to seemingly break.

Regression from 04de06a9f5d

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- Fixes #1722