### PR TITLE
Fix bot CTG navigation stuttering during breakaway run

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_carrier.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_carrier.cpp
@@ -507,18 +507,14 @@ void CNEOBotCtgCarrier::UpdateFollowPath( CNEOBot *me, const CUtlVector<CNEO_Pla
 			if ( !bAnyEnemyCloser )
 			{
 				m_chasePath.Invalidate();
-				m_path.Invalidate();
 
-				if ( !m_repathTimer.HasStarted() || m_repathTimer.IsElapsed() )
+				if ( !m_path.IsValid() || !m_repathTimer.HasStarted() || m_repathTimer.IsElapsed() )
 				{
 					CNEOBotPathCompute( me, m_path, vecGoalPos, FASTEST_ROUTE );
-					m_path.Update( me );
 					m_repathTimer.Start( RandomFloat( 0.3f, 0.5f ) );
 				}
-				else
-				{
-					m_path.Update( me );
-				}
+				
+				m_path.Update( me );
 				return;
 			}
 		}

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_escort.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_escort.cpp
@@ -201,7 +201,6 @@ ActionResult< CNEOBot >	CNEOBotCtgEscort::Update( CNEOBot *me, float interval )
 		if ( m_repathTimer.IsElapsed() )
 		{
 			m_chasePath.Invalidate();
-			m_path.Invalidate();
 
 			CNEOBotPathCompute( me, m_path, vecMoveTarget, SAFEST_ROUTE );
 			m_repathTimer.Start( RandomFloat( 1.0f, 2.0f ) );


### PR DESCRIPTION
## Description
The movements of the ghost carrier and their escorts would stutter if they were closer to the capture point than any enemy.  The root cause was identified as a thrashing invalidation of a valid path, resulted in stuttering between repath timer cycles.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1600

