### PR TITLE
Gamma corrected HUD background color

### DIFF
--- a/game/neo/scripts/HudLayout.res
+++ b/game/neo/scripts/HudLayout.res
@@ -398,7 +398,7 @@
 		"MaxDeathNotices" 	"8"
 		"RightJustify"		"1"
 		"BackgroundColour"	"20 20 20 220"
-		"BackgroundColourInvolved"	"200 200 200 40"
+		"BackgroundColourInvolved"	"150 150 150 60"
 	}
 
 	HudVehicle
@@ -828,7 +828,7 @@
 		"objective_visible"	"1"
 		"text_fade_exp"	"1"
 		"text_color"	"255 255 255 150"
-		"box_color"		"200 200 200 40"
+		"box_color"		"150 150 150 60"
 	}
 	NHudWeapon
 	{
@@ -839,7 +839,7 @@
 		"ypos"			"446"
 		"wide"			"203"
 		"tall"			"32"
-		"box_color"		"200 200 200 40"
+		"box_color"		"150 150 150 60"
 		"top_left_corner"	"1"
 		"top_right_corner"	"0"
 		"bottom_left_corner"	"1"
@@ -872,7 +872,7 @@
 		"ypos"			"446"
 		"wide"			"203"
 		"tall"			"32"
-		"box_color"		"200 200 200 40"
+		"box_color"		"150 150 150 60"
 		"top_left_corner"	"0"
 		"top_right_corner"	"1"
 		"bottom_left_corner"	"0"
@@ -917,7 +917,7 @@
 	NRoundState
 	{
 		"fieldName"		"NRoundState"
-		"box_color"		"200 200 200 40"
+		"box_color"		"150 150 150 60"
 		"health_monochrome"	"1"
 	}
 	NHudPlayerPing
@@ -988,7 +988,7 @@
 		"ypos"	"440"
 		"wide"	"640"
 	}
-	
+
 	neo_message
 	{
 		"fieldName"		"neo_message"
@@ -1005,7 +1005,7 @@
 		"ypos"	"150"
 		"wide"	"640"
 		"tall"	"480"
-		"box_color"		"200 200 200 40"
+		"box_color"		"150 150 150 60"
 	}
 
 	neo_context_hint


### PR DESCRIPTION
## Description
The OGNT HUD background color is `200 200 200`. Using the formula to convert to sRGB (`255*(x/255)^1/2.2`) gives `150 150 150`, and with those numbers the color looks a lot closer to OGNT. 

However, at 40 alpha it's too transparent. Using the same formula as for rbg gives 110, which is too opaque. With trial and error I (very unscientifically) arrived at 60, which seems close enough. See comparison screenshots below (taken with HDR disabled).

<img width="2050" height="1238" alt="Screenshot_20260223_205248" src="https://github.com/user-attachments/assets/6e14d77b-8bd8-48b3-921a-53f0d26f152a" />
<img width="2050" height="1238" alt="Screenshot_20260223_205956" src="https://github.com/user-attachments/assets/49a1a381-7737-4645-8b55-2593e949a592" />
<img width="2050" height="1238" alt="Screenshot_20260223_210428" src="https://github.com/user-attachments/assets/6b484a72-cff0-4a60-a61e-5384330fcf32" />
<img width="2050" height="1238" alt="Screenshot_20260223_210512" src="https://github.com/user-attachments/assets/c6a01f93-59b3-472b-881b-bc92ee0160f1" />

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

