### PR TITLE
Fix killer/damage HUD background

### DIFF
--- a/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
+++ b/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
@@ -76,6 +76,7 @@ CNEOHud_KillerDamageInfo::CNEOHud_KillerDamageInfo(const char *pszName, vgui::Pa
 {
 	SetAutoDelete(true);
 	SetupNTRETheme(&m_uiCtx);
+	m_uiCtx.colors.sectionBg = COLOR_TRANSPARENT;
 
 	if (parent)
 	{


### PR DESCRIPTION
Should be fully transparent on per-section as it does the bg itself.


