### PR TITLE
Fix and guard against marker zero-length string showing random data

### DIFF
--- a/src/game/client/neo/ui/neo_hud_friendly_marker.cpp
+++ b/src/game/client/neo/ui/neo_hud_friendly_marker.cpp
@@ -230,10 +230,23 @@ void CNEOHud_FriendlyMarker::DrawPlayer(Color teamColor, C_NEO_Player *player, c
 	char textASCII[MAX_MARKER_STRSIZE];
 	int textSize = 0;
 
-	auto DisplayText = [this, &textSize, x](const char *textASCII, int y, int maxLength) {
+	auto DisplayText = [this, &textSize, x](const char *textASCII, const int y, const int maxLength) {
+			if (maxLength <= 0)
+			{
+				textSize = 0;
+				return;
+			}
+
 			wchar_t textUTF[MAX_MARKER_STRSIZE];
 			COMPILE_TIME_ASSERT(sizeof(textUTF) == sizeof(wchar_t) * MAX_MARKER_STRSIZE);
+			textUTF[0] = L'\0';
 			const int numChars = g_pVGuiLocalize->ConvertANSIToUnicode(textASCII, textUTF, narrow_cast<int>(Min(sizeof(textUTF), sizeof(wchar_t) * maxLength)));
+			if (numChars <= 0)
+			{
+				textSize = 0;
+				return;
+			}
+
 			int textWidth, textHeight;
 			vgui::surface()->GetTextSize(m_hFont, textUTF, textWidth, textHeight);
 			vgui::surface()->DrawSetTextPos(x - (textWidth / 2), y - textHeight);


### PR DESCRIPTION

<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
The string wasn't zero-initalized, max length set 0 means it copies nothing and then it shows random data. Only an issue on Windows it seems but nevertheless need to have more checks to guard against this. Don't need to print text anyway if it's zero-length.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
 [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0
-->
- Linux GCC Distro Native Arch/GCC 15 (Although this issue not affecting Linux)


