### PR TITLE
Recon bots use superjump to travel quickly

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.cpp
@@ -232,9 +232,9 @@ void CNEOBotTacticalMonitor::ReconConsiderSuperJump( CNEOBot *me )
 		}
 
 		// Get the bot motion to know which direction the jump will be boosted
-		Vector vecForward = me->GetLocomotionInterface()->GetGroundMotionVector();
-		vecForward.z = 0.0f;
-		vecForward.NormalizeInPlace();
+		Vector vecMovement = me->GetLocomotionInterface()->GetGroundMotionVector();
+		vecMovement.z = 0.0f;
+		vecMovement.NormalizeInPlace();
 
 		// Get the bot's facing direction
 		Vector vecFacing;
@@ -242,22 +242,27 @@ void CNEOBotTacticalMonitor::ReconConsiderSuperJump( CNEOBot *me )
 		vecFacing.z = 0.0f;
 		vecFacing.NormalizeInPlace();
 
+		if (vecMovement.Dot(vecFacing) < neo_bot_recon_superjump_min_accuracy.GetFloat())
+		{
+			return;
+		}
+
 		// Check that upcoming path is in line of a jump
 		bool bCanJump = false;
 		while (seg)
 		{
 			constexpr int maskAttributesToStopPathEval = (
-				NAV_MESH_AVOID			|	
-				NAV_MESH_CLIFF			|	
-				NAV_MESH_CROUCH			|	
-				NAV_MESH_HAS_ELEVATOR	|	
-				NAV_MESH_JUMP			| // likely to interrupt superjump trajectory
-				NAV_MESH_NAV_BLOCKER	|
-				NAV_MESH_NO_JUMP		|
-				NAV_MESH_OBSTACLE_TOP	|	
-				NAV_MESH_PRECISE		|	
-				NAV_MESH_STAIRS			|	
-				NAV_MESH_STOP			|	
+				NAV_MESH_AVOID |
+				NAV_MESH_CLIFF |
+				NAV_MESH_CROUCH |
+				NAV_MESH_HAS_ELEVATOR |
+				NAV_MESH_JUMP | // likely to interrupt superjump trajectory
+				NAV_MESH_NAV_BLOCKER |
+				NAV_MESH_NO_JUMP |
+				NAV_MESH_OBSTACLE_TOP |
+				NAV_MESH_PRECISE |
+				NAV_MESH_STAIRS |
+				NAV_MESH_STOP |
 				NAV_MESH_TRANSIENT
 			);
 
@@ -274,11 +279,9 @@ void CNEOBotTacticalMonitor::ReconConsiderSuperJump( CNEOBot *me )
 
 			if (flDist > 1.0f)
 			{
-				// Predictability of jump is too erratic when bot isn't both facing and moving toward waypoint
-				if (vecForward.Dot(vecToWaypoint) < neo_bot_recon_superjump_min_accuracy.GetFloat() ||
-					vecFacing.Dot(vecToWaypoint) < neo_bot_recon_superjump_min_accuracy.GetFloat())
+				if (vecMovement.Dot(vecToWaypoint) < neo_bot_recon_superjump_min_accuracy.GetFloat())
 				{
-					break;
+					return; // Diverges too much from trajectory
 				}
 			}
 

--- a/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.cpp
@@ -277,18 +277,19 @@ void CNEOBotTacticalMonitor::ReconConsiderSuperJump( CNEOBot *me )
 			
 			float flDist = vecToWaypoint.NormalizeInPlace();
 
-			if (flDist > 1.0f)
+			if (vecMovement.Dot(vecToWaypoint) < neo_bot_recon_superjump_min_accuracy.GetFloat())
 			{
-				if (vecMovement.Dot(vecToWaypoint) < neo_bot_recon_superjump_min_accuracy.GetFloat())
-				{
-					return; // Diverges too much from trajectory
-				}
+				return; // Diverges too much from trajectory
 			}
 
 			if (flDist >= neo_bot_recon_superjump_min_dist.GetFloat())
 			{
 				bCanJump = true;
 				break;
+			}
+			else if (flDist < 0)
+			{
+				return; // Just in case of a bad value
 			}
 
 			seg = path->NextSegment(seg);

--- a/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.h
@@ -21,6 +21,7 @@ public:
 
 private:
 	CountdownTimer m_maintainTimer;
+	CountdownTimer m_reconSuperJumpPathCheckTimer;
 
 	CountdownTimer m_acknowledgeAttentionTimer;
 	CountdownTimer m_acknowledgeRetryTimer;


### PR DESCRIPTION
## Description
Recon bots use superjump to travel quickly. Involves looking up the projected path of the bot and triggering a superjump if enough waypoints align in the path of an average superjump.

## Toolchain
- Windows MSVC VS2022

https://github.com/user-attachments/assets/b39dbe41-281f-42d3-a3ee-12d220602dbe
