### PR TITLE
Fix chat and scoreboard text size on Linux

### DIFF
--- a/game/neo/resource/ClientScheme.res
+++ b/game/neo/resource/ClientScheme.res
@@ -246,7 +246,8 @@ Scheme
 			"1"
 			{
 				"name"		"Verdana"
-				"tall"		"12"
+				"tall"		"12" [!$LINUX]
+				"tall"      "15" [$LINUX]
 				"weight"	"900"
 				"antialias"	"1"
 				"yres"		"480 599"
@@ -254,7 +255,8 @@ Scheme
 			"2"
 			{
 				"name"		"Verdana"
-				"tall"		"13"
+				"tall"		"13" [!$LINUX]
+				"tall"		"16" [$LINUX]
 				"weight"	"900"
 				"antialias"	"1"
 				"yres"		"600 767"
@@ -262,7 +264,8 @@ Scheme
 			"3"
 			{
 				"name"		"Verdana"
-				"tall"		"14"
+				"tall"		"14" [!$LINUX]
+				"tall"		"18" [$LINUX]
 				"weight"	"900"
 				"antialias" "1"
 				"yres"	"768 1023"
@@ -270,7 +273,8 @@ Scheme
 			"4"
 			{
 				"name"		"Verdana"
-				"tall"		"16" // "20"
+				"tall"		"16" [!$LINUX] //"20"
+				"tall"		"20" [$LINUX]
 				"weight"	"900"
 				"antialias" "1"
 				"yres"	"1024 1199"
@@ -278,7 +282,8 @@ Scheme
 			"5"
 			{
 				"name"		"Verdana"
-				"tall"		"16" // "24"
+				"tall"		"16" [!$LINUX] //"24"
+				"tall"		"20" [$LINUX]
 				"weight"	"900"
 				"antialias" "1"
 				"yres"	"1200 10000"
@@ -286,7 +291,8 @@ Scheme
 			"6"
 			{
 				"name"		"Verdana"
-				"tall"		"12"
+				"tall"		"12" [!$LINUX]
+				"tall"      "15" [$LINUX]
 				"range"		"0x0000 0x00FF"
 				"weight"	"900"
 			}
@@ -321,7 +327,8 @@ Scheme
 			"1"
 			{
 				"name"		"Verdana"
-				"tall"		"12"
+				"tall"		"12" [!$LINUX]
+				"tall"      "13" [$LINUX]
 				"weight"	"0"
 				"range"		"0x0000 0x017F"
 				"yres"	"480 599"
@@ -329,7 +336,8 @@ Scheme
 			"2"
 			{
 				"name"		"Verdana"
-				"tall"		"13"
+				"tall"		"13" [!$LINUX]
+				"tall"		"14" [$LINUX]
 				"weight"	"0"
 				"range"		"0x0000 0x017F"
 				"yres"	"600 767"
@@ -337,7 +345,8 @@ Scheme
 			"3"
 			{
 				"name"		"Verdana"
-				"tall"		"14"
+				"tall"		"14" [!$LINUX]
+				"tall"		"16" [$LINUX]
 				"weight"	"0"
 				"range"		"0x0000 0x017F"
 				"yres"	"768 1023"
@@ -346,7 +355,8 @@ Scheme
 			"4"
 			{
 				"name"		"Verdana"
-				"tall"		"16" //"20"
+				"tall"		"16" [!$LINUX] //"20"
+				"tall"		"18" [$LINUX]
 				"weight"	"0"
 				"range"		"0x0000 0x017F"
 				"yres"	"1024 1199"
@@ -355,7 +365,8 @@ Scheme
 			"5"
 			{
 				"name"		"Verdana"
-				"tall"		""16" //24"
+				"tall"		"16" [!$LINUX] //"24"
+				"tall"		"18" [$LINUX]
 				"weight"	"0"
 				"range"		"0x0000 0x017F"
 				"yres"	"1200 6000"
@@ -374,7 +385,8 @@ Scheme
 			"1"
 			{
 				"name"		"Verdana"
-				"tall"		"12"
+				"tall"		"12" [!$LINUX]
+				"tall"      "13" [$LINUX]
 				"weight"	"0"
 				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
 				"yres"	"480 599"
@@ -382,7 +394,8 @@ Scheme
 			"2"
 			{
 				"name"		"Verdana"
-				"tall"		"13"
+				"tall"		"13" [!$LINUX]
+				"tall"		"14" [$LINUX]
 				"weight"	"0"
 				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
 				"yres"	"600 767"
@@ -390,7 +403,8 @@ Scheme
 			"3"
 			{
 				"name"		"Verdana"
-				"tall"		"14"
+				"tall"		"14" [!$LINUX]
+				"tall"		"16" [$LINUX]
 				"weight"	"0"
 				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
 				"yres"	"768 1023"
@@ -399,7 +413,8 @@ Scheme
 			"4"
 			{
 				"name"		"Verdana"
-				"tall"		"16" //"20"
+				"tall"		"16" [!$LINUX] //"20"
+				"tall"		"18" [$LINUX]
 				"weight"	"0"
 				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
 				"yres"	"1024 1199"
@@ -408,7 +423,8 @@ Scheme
 			"5"
 			{
 				"name"		"Verdana"
-				"tall"		"16" //"24"
+				"tall"		"16" [!$LINUX] //"24"
+				"tall"		"18" [$LINUX]
 				"weight"	"0"
 				"range"		"0x0000 0x017F" //	Basic Latin, Latin-1 Supplement, Latin Extended-A
 				"yres"	"1200 6000"
@@ -417,7 +433,8 @@ Scheme
 			"6"
 			{
 				"name"		"Verdana"
-				"tall"		"12"
+				"tall"		"12" [!$LINUX]
+				"tall"      "13" [$LINUX]
 				"range" 		"0x0000 0x00FF"
 				"weight"		"0"
 			}
@@ -434,35 +451,40 @@ Scheme
 			"1"
 			{
 				"name"		"Verdana"
-				"tall"		"12"
+				"tall"		"12" [!$LINUX]
+				"tall"      "15" [$LINUX]
 				"weight"	"700"
 				"yres"	"480 599"
 			}
 			"2"
 			{
 				"name"		"Verdana"
-				"tall"		"13"
+				"tall"		"13" [!$LINUX]
+				"tall"		"16" [$LINUX]
 				"weight"	"700"
 				"yres"	"600 767"
 			}
 			"3"
 			{
 				"name"		"Verdana"
-				"tall"		"14"
+				"tall"		"14" [!$LINUX]
+				"tall"		"18" [$LINUX]
 				"weight"	"700"
 				"yres"	"768 1023"
 			}
 			"4"
 			{
 				"name"		"Verdana"
-				"tall"		"20"
+				"tall"		"20" [!$LINUX]
+				"tall"		"26" [$LINUX]
 				"weight"	"700"
 				"yres"	"1024 1199"
 			}
 			"5"
 			{
 				"name"		"Verdana"
-				"tall"		"24"
+				"tall"		"24" [!$LINUX]
+				"tall"		"32" [$LINUX]
 				"weight"	"700"
 				"yres"	"1200 10000"
 			}
@@ -507,7 +529,8 @@ Scheme
 			"1"
 			{
 				"name"		"Verdana"
-				"tall"		"11"
+				"tall"		"11" [!$LINUX]
+				"tall"		"14" [$LINUX]
 				"weight"	"700"
 				"antialias" "1"
 				"additive"	"1"
@@ -520,7 +543,8 @@ Scheme
 			"1"
 			{
 				"name"		"Verdana"
-				"tall"		"8"
+				"tall"		"8" [!$LINUX]
+				"tall"		"10" [$LINUX]
 				"weight"	"700"
 				"antialias" "1"
 				"yres"	"1 599"
@@ -530,7 +554,8 @@ Scheme
 			"2"
 			{
 				"name"		"Verdana"
-				"tall"		"10"
+				"tall"		"10" [!$LINUX]
+				"tall"		"13" [$LINUX]
 				"weight"	"700"
 				"antialias" "1"
 				"yres"	"600 767"
@@ -540,7 +565,8 @@ Scheme
 			"3"
 			{
 				"name"		"Verdana"
-				"tall"		"12"
+				"tall"		"12" [!$LINUX]
+				"tall"		"15" [$LINUX]
 				"weight"	"900"
 				"antialias" "1"
 				"yres"	"768 1023"
@@ -549,7 +575,8 @@ Scheme
 			"4"
 			{
 				"name"		"Verdana"
-				"tall"		"16"
+				"tall"		"16" [!$LINUX]
+				"tall"		"20" [$LINUX]
 				"weight"	"900"
 				"antialias" "1"
 				"yres"	"1024 1199"
@@ -558,7 +585,8 @@ Scheme
 			"5"
 			{
 				"name"		"Verdana"
-				"tall"		"17"
+				"tall"		"17" [!$LINUX]
+				"tall"		"22" [$LINUX]
 				"weight"	"1000"
 				"antialias" "1"
 				"yres"	"1200 10000"
@@ -1007,7 +1035,8 @@ Scheme
 			"1"
 			{
 				"name"		"Verdana"
-				"tall"		"12"
+				"tall"		"12" [!$LINUX]
+				"tall"      "15" [$LINUX]
 				"weight"	"700"
 				"yres"	"480 599"
 				"dropshadow"	"1"
@@ -1015,7 +1044,8 @@ Scheme
 			"2"
 			{
 				"name"		"Verdana"
-				"tall"		"13"
+				"tall"		"13" [!$LINUX]
+				"tall"		"16" [$LINUX]
 				"weight"	"700"
 				"yres"	"600 767"
 				"dropshadow"	"1"
@@ -1023,7 +1053,8 @@ Scheme
 			"3"
 			{
 				"name"		"Verdana"
-				"tall"		"14"
+				"tall"		"14" [!$LINUX]
+				"tall"		"18" [$LINUX]
 				"weight"	"700"
 				"yres"	"768 1023"
 				"dropshadow"	"1"
@@ -1031,7 +1062,8 @@ Scheme
 			"4"
 			{
 				"name"		"Verdana"
-				"tall"		"16" //"20"
+				"tall"		"16" [!$LINUX] //"20"
+				"tall"		"20" [$LINUX]
 				"weight"	"700"
 				"yres"	"1024 1199"
 				"dropshadow"	"1"
@@ -1039,7 +1071,8 @@ Scheme
 			"5"
 			{
 				"name"		"Verdana"
-				"tall"		"16" //"24"
+				"tall"		"16" [!$LINUX] //"24"
+				"tall"		"20" [$LINUX]
 				"weight"	"700"
 				"yres"	"1200 10000"
 				"dropshadow"	"1"

--- a/game/neo/resource/chatscheme.res
+++ b/game/neo/resource/chatscheme.res
@@ -312,7 +312,8 @@ Scheme
 			"1"
 			{
 				"name"		"Verdana"
-				"tall"		"12"
+				"tall"		"12" [!$LINUX]
+				"tall"      "15" [$LINUX]
 				"weight"	"700"
 				"yres"	"480 599"
 				"dropshadow"	"1"
@@ -320,7 +321,8 @@ Scheme
 			"2"
 			{
 				"name"		"Verdana"
-				"tall"		"13"
+				"tall"		"13" [!$LINUX]
+				"tall"		"16" [$LINUX]
 				"weight"	"700"
 				"yres"	"600 767"
 				"dropshadow"	"1"
@@ -328,7 +330,8 @@ Scheme
 			"3"
 			{
 				"name"		"Verdana"
-				"tall"		"14"
+				"tall"		"14" [!$LINUX]
+				"tall"		"18" [$LINUX]
 				"weight"	"700"
 				"yres"	"768 1023"
 				"dropshadow"	"1"
@@ -336,7 +339,8 @@ Scheme
 			"4"
 			{
 				"name"		"Verdana"
-				"tall"		"16" //"20"
+				"tall"		"16" [!$LINUX] //"20"
+				"tall"		"20" [$LINUX]
 				"weight"	"700"
 				"yres"	"1024 1199"
 				"dropshadow"	"1"
@@ -344,7 +348,8 @@ Scheme
 			"5"
 			{
 				"name"		"Verdana"
-				"tall"		"16" //"24"
+				"tall"		"16" [!$LINUX] //"24"
+				"tall"		"20" [$LINUX]
 				"weight"	"700"
 				"yres"	"1200 10000"
 				"dropshadow"	"1"
@@ -352,7 +357,8 @@ Scheme
 			"5"
 			{
 				"name"		"Verdana"
-				"tall"		"18" //"22"
+				"tall"		"18" [!$LINUX] //"22"
+				"tall"		"24" [$LINUX]
 				"weight"	"700"
 				"yres"	"1200 1440"
 				"dropshadow"	"1"
@@ -360,7 +366,8 @@ Scheme
 			"6"
 			{
 				"name"		"Verdana"
-				"tall"		"20" //"24"
+				"tall"		"20" [!$LINUX] //"24"
+				"tall"		"26" [$LINUX]
 				"weight"	"700"
 				"yres"	"1441 1600"
 				"dropshadow"	"1"


### PR DESCRIPTION
## Description
For some reason Verdana is very small on Linux (might be a problem with other fonts as well but Verdana is most noticable).

Note that I compared with OGNT because I couldn't be bothered to run NT;RE on Windows.

<img width="436" height="635" alt="image" src="https://github.com/user-attachments/assets/a3940899-3bb5-4dbd-bd56-2b2c2d50b6a1" />

<img width="982" height="254" alt="Screenshot_20260226_222144" src="https://github.com/user-attachments/assets/e3b7dfc4-7629-475d-a3e1-642868b94c14" />
<img width="1466" height="351" alt="Screenshot_20260226_222224" src="https://github.com/user-attachments/assets/8eb467d5-7dde-44aa-a0e8-08688ba91546" />
<img width="1935" height="434" alt="Screenshot_20260226_222254" src="https://github.com/user-attachments/assets/4109d3ea-4ddb-4564-9b68-1aea51af25d6" />

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

