### PR TITLE
Discourage bots from pathing through deadly areas

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -252,7 +252,7 @@ EventDesiredResult< CNEOBot > CNEOBotMainAction::OnStuck( CNEOBot *me )
 	// so the overall fairness may balance out for both teams sharing common sticking points.
 	if ( const CNavArea *navArea = me->GetLastKnownArea() )
 	{
-		CNEOBotPathReservations()->IncrementAreaStuckPenalty( navArea->GetID() );
+		CNEOBotPathReservations()->IncrementAreaAvoidPenalty( navArea->GetID() );
 	}
 	else
 	{
@@ -260,7 +260,7 @@ EventDesiredResult< CNEOBot > CNEOBotMainAction::OnStuck( CNEOBot *me )
 		CNavArea *nearestArea = TheNavMesh->GetNearestNavArea( me->GetAbsOrigin() );
 		if ( nearestArea )
 		{
-			CNEOBotPathReservations()->IncrementAreaStuckPenalty( nearestArea->GetID() );
+			CNEOBotPathReservations()->IncrementAreaAvoidPenalty( nearestArea->GetID() );
 		}
 	}
 
@@ -273,7 +273,7 @@ EventDesiredResult< CNEOBot > CNEOBotMainAction::OnStuck( CNEOBot *me )
 			{
 				if ( nextSegment->area )
 				{
-					CNEOBotPathReservations()->IncrementAreaStuckPenalty( nextSegment->area->GetID() );
+					CNEOBotPathReservations()->IncrementAreaAvoidPenalty( nextSegment->area->GetID() );
 				}
 			}
 		}

--- a/src/game/server/neo/bot/neo_bot_path_cost.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_cost.cpp
@@ -124,7 +124,7 @@ float CNEOBotPathCost::operator()(CNavArea* baseArea, CNavArea* fromArea, const 
 		if ( !m_bIgnoreReservations && (m_routeType != FASTEST_ROUTE) )
 		{
 			cost += CNEOBotPathReservations()->GetPredictedFriendlyPathCount(area->GetID(), m_me->GetTeamNumber()) * neo_bot_path_reservation_penalty.GetFloat();
-			cost += CNEOBotPathReservations()->GetAreaStuckPenalty(area->GetID());
+			cost += CNEOBotPathReservations()->GetAreaAvoidPenalty(area->GetID());
 
 			if (m_routeType == SAFEST_ROUTE)
 			{

--- a/src/game/server/neo/bot/neo_bot_path_reservation.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_reservation.cpp
@@ -23,11 +23,14 @@ ConVar neo_bot_path_reservation_penalty("neo_bot_path_reservation_penalty", "100
 ConVar neo_bot_path_reservation_friendly_penalty_enable("neo_bot_path_reservation_friendly_penalty_enable", "1", FCVAR_NONE,
     "Whether to update or retrieve the area friendly reservation penalty.", true, 0, true, 1);
 
-ConVar neo_bot_path_reservation_onstuck_penalty_enable("neo_bot_path_reservation_onstuck_penalty_enable", "1", FCVAR_NONE,
-    "Whether to update or retrieve the area onstuck penalty.", true, 0, true, 1);
+ConVar neo_bot_path_reservation_avoid_penalty_enable("neo_bot_path_reservation_avoid_penalty_enable", "1", FCVAR_NONE,
+    "Whether to update or retrieve the area avoid penalty.", true, 0, true, 1);
+
+ConVar neo_bot_path_reservation_killed_penalty("neo_bot_path_reservation_killed_penalty", "10", FCVAR_NONE,
+    "Path selection penalty added to a nav area each time a bot dies moving through that area.", true, 0, false, 0);
 
 ConVar neo_bot_path_reservation_onstuck_penalty("neo_bot_path_reservation_onstuck_penalty", "10000", FCVAR_NONE,
-    "Path selection penalty added to a nav area each time a bot gets stuck moving through that area.", true, 0, true, 1000000);
+    "Path selection penalty added to a nav area each time a bot gets stuck moving through that area.", true, 0, false, 0);
 
 
 
@@ -248,7 +251,7 @@ void CNEOBotPathReservationSystem::Clear()
         m_AreaPathCounts[team].RemoveAll();
     }
     m_BotReservedAreas.RemoveAll();
-    m_AreaOnStuckPenalties.RemoveAll();
+    m_AreaAvoidPenalties.RemoveAll();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -308,34 +311,34 @@ int CNEOBotPathReservationSystem::GetPredictedFriendlyPathCount( int areaID, int
 }
 
 //-------------------------------------------------------------------------------------------------
-void CNEOBotPathReservationSystem::IncrementAreaAvoidPenalty(unsigned int navAreaID)
+void CNEOBotPathReservationSystem::IncrementAreaAvoidPenalty(unsigned int navAreaID, float penaltyAmount)
 {
-    if ( !neo_bot_path_reservation_onstuck_penalty_enable.GetBool() )
+    if ( !neo_bot_path_reservation_avoid_penalty_enable.GetBool() )
     {
         return;
     }
 
-    unsigned short index = m_AreaOnStuckPenalties.Find(navAreaID);
-    if (index == m_AreaOnStuckPenalties.InvalidIndex())
+    unsigned short index = m_AreaAvoidPenalties.Find(navAreaID);
+    if (index == m_AreaAvoidPenalties.InvalidIndex())
     {
-        index = m_AreaOnStuckPenalties.Insert(navAreaID, 0.0f);
+        index = m_AreaAvoidPenalties.Insert(navAreaID, 0.0f);
     }
 
-    m_AreaOnStuckPenalties[index] += neo_bot_path_reservation_onstuck_penalty.GetFloat();
+    m_AreaAvoidPenalties[index] += penaltyAmount;
 }
 
 //-------------------------------------------------------------------------------------------------
-float CNEOBotPathReservationSystem::GetAreaStuckPenalty(unsigned int navAreaID) const
+float CNEOBotPathReservationSystem::GetAreaAvoidPenalty(unsigned int navAreaID) const
 {
-    if ( !neo_bot_path_reservation_onstuck_penalty_enable.GetBool() )
+    if ( !neo_bot_path_reservation_avoid_penalty_enable.GetBool() )
     {
         return 0.0f;
     }
 
-    unsigned short index = m_AreaOnStuckPenalties.Find(navAreaID);
-    if (index != m_AreaOnStuckPenalties.InvalidIndex())
+    unsigned short index = m_AreaAvoidPenalties.Find(navAreaID);
+    if (index != m_AreaAvoidPenalties.InvalidIndex())
     {
-        return m_AreaOnStuckPenalties[index];
+        return m_AreaAvoidPenalties[index];
     }
     return 0.0f;
 }

--- a/src/game/server/neo/bot/neo_bot_path_reservation.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_reservation.cpp
@@ -308,7 +308,7 @@ int CNEOBotPathReservationSystem::GetPredictedFriendlyPathCount( int areaID, int
 }
 
 //-------------------------------------------------------------------------------------------------
-void CNEOBotPathReservationSystem::IncrementAreaStuckPenalty(unsigned int navAreaID)
+void CNEOBotPathReservationSystem::IncrementAreaAvoidPenalty(unsigned int navAreaID)
 {
     if ( !neo_bot_path_reservation_onstuck_penalty_enable.GetBool() )
     {

--- a/src/game/server/neo/bot/neo_bot_path_reservation.h
+++ b/src/game/server/neo/bot/neo_bot_path_reservation.h
@@ -42,7 +42,7 @@ public:
         return lhs.GetSerialNumber() < rhs.GetSerialNumber();
     }
 
-    CNEOBotPathReservationSystem() : m_BotReservedAreas(EHandleLessFunc), m_AreaOnStuckPenalties(DefLessFunc(unsigned int))
+    CNEOBotPathReservationSystem() : m_BotReservedAreas(EHandleLessFunc), m_AreaAvoidPenalties(DefLessFunc(unsigned int))
     {
         for (int i = 0; i < TEAM__TOTAL; ++i)
         {
@@ -61,8 +61,8 @@ public:
     void DecrementPredictedFriendlyPathCount( int areaID, int teamID );
     int GetPredictedFriendlyPathCount( int areaID, int teamID ) const;
 
-    void IncrementAreaAvoidPenalty(unsigned int navAreaID);
-    float GetAreaStuckPenalty(unsigned int navAreaID) const;
+    void IncrementAreaAvoidPenalty(unsigned int navAreaID, float penaltyAmount);
+    float GetAreaAvoidPenalty(unsigned int navAreaID) const;
 
     // Allow the global accessor to access private members if needed, though constructor handles init now.
     friend CNEOBotPathReservationSystem* CNEOBotPathReservations();
@@ -71,7 +71,7 @@ private:
     CUtlMap<int, ReservationInfo> m_Reservations[TEAM__TOTAL];
     CUtlMap<EHANDLE, BotReservedAreas_t> m_BotReservedAreas;
     CUtlMap<int, int> m_AreaPathCounts[TEAM__TOTAL];
-    CUtlMap<unsigned int, float> m_AreaOnStuckPenalties;
+    CUtlMap<unsigned int, float> m_AreaAvoidPenalties;
 };
 
 
@@ -81,3 +81,5 @@ extern ConVar neo_bot_path_reservation_enable;
 extern ConVar neo_bot_path_reservation_penalty;
 extern ConVar neo_bot_path_reservation_duration;
 extern ConVar neo_bot_path_reservation_distance;
+extern ConVar neo_bot_path_reservation_onstuck_penalty;
+extern ConVar neo_bot_path_reservation_killed_penalty;

--- a/src/game/server/neo/bot/neo_bot_path_reservation.h
+++ b/src/game/server/neo/bot/neo_bot_path_reservation.h
@@ -61,7 +61,7 @@ public:
     void DecrementPredictedFriendlyPathCount( int areaID, int teamID );
     int GetPredictedFriendlyPathCount( int areaID, int teamID ) const;
 
-    void IncrementAreaStuckPenalty(unsigned int navAreaID);
+    void IncrementAreaAvoidPenalty(unsigned int navAreaID);
     float GetAreaStuckPenalty(unsigned int navAreaID) const;
 
     // Allow the global accessor to access private members if needed, though constructor handles init now.


### PR DESCRIPTION
## Description
Add a small pathing penalty to the NavArea a bot was killed at. Over the course of a match, bots will try other paths that have fewer occurrences of deaths. Intended to emulate players trying different map traversal strategies as they learn a map.

## Toolchain
- Windows MSVC VS2022

## Related Work
- related #1598

