### PR TITLE
Bots hold cover angles towards incoming threats

### DIFF
--- a/src/game/server/NextBot/NextBotKnownEntity.h
+++ b/src/game/server/NextBot/NextBotKnownEntity.h
@@ -101,6 +101,13 @@ public:
 		m_isVisible = visible;
 	}
 
+#ifdef NEO
+	void UpdateLastSeenTime( void )
+	{
+		m_whenLastSeen = gpGlobals->curtime;
+	}
+#endif
+
 	virtual bool IsVisibleInFOVNow( void ) const	// return true if this entity is currently visible and in my field of view
 	{
 		return m_isVisible;


### PR DESCRIPTION
## Description
Bots have a very short memory of recent unseen threats (3 seconds), so in order to encourage bots to hold threat angles for a longer period of time, we use the directional movement of the potential threat as a general heuristic of whether the threat is still pursuing the bot.

## Toolchain
- Windows MSVC VS2022