### PR TITLE
Add medium (new default) option to extended killfeed

### DIFF
--- a/src/game/client/neo/ui/neo_hud_deathnotice.cpp
+++ b/src/game/client/neo/ui/neo_hud_deathnotice.cpp
@@ -701,7 +701,7 @@ void CNEOHud_DeathNotice::RetireExpiredDeathNotices( void )
 //-----------------------------------------------------------------------------
 // Purpose: Server's told us that someone's died
 //-----------------------------------------------------------------------------
-ConVar cl_neo_hud_extended_killfeed("cl_neo_hud_extended_killfeed", "1", FCVAR_ARCHIVE, "Show extra events in killfeed", true, 0, true, 1);
+ConVar cl_neo_hud_extended_killfeed("cl_neo_hud_extended_killfeed", "1", FCVAR_ARCHIVE, "Show extra events in killfeed. 1 = Objectives, 2 = Objectives and rank-ups", true, 0, true, 2);
 void CNEOHud_DeathNotice::FireGameEvent(IGameEvent* event)
 {
 	if (!g_PR)
@@ -722,13 +722,9 @@ void CNEOHud_DeathNotice::FireGameEvent(IGameEvent* event)
 	{
 		AddPlayerDeath(event);
 	}
-	else if (!cl_neo_hud_extended_killfeed.GetBool())
+	else if (cl_neo_hud_extended_killfeed.GetInt() < 1)
 	{
 		return;
-	}
-	else if (!Q_stricmp(eventName, "player_rankchange"))
-	{
-		AddPlayerRankChange(event);
 	}
 	else if (!Q_stricmp(eventName, "ghost_capture"))
 	{
@@ -741,6 +737,14 @@ void CNEOHud_DeathNotice::FireGameEvent(IGameEvent* event)
 	else if (!Q_stricmp(eventName, "vip_death"))
 	{
 		AddVIPDeath(event);
+	}
+	else if (cl_neo_hud_extended_killfeed.GetInt() < 2)
+	{
+		return;
+	}
+	else if (!Q_stricmp(eventName, "player_rankchange"))
+	{
+		AddPlayerRankChange(event);
 	}
 
 }

--- a/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/src/game/client/neo/ui/neo_root_settings.cpp
@@ -635,7 +635,7 @@ void NeoSettingsRestore(NeoSettings *ns, const NeoSettings::Keys::Flags flagsKey
 		pHUD->bShowPos = cvr->cl_showpos.GetBool();
 		pHUD->iShowFps = cvr->cl_showfps.GetInt();
 		pHUD->bEnableRangeFinder = cvr->cl_neo_hud_rangefinder_enabled.GetBool();
-		pHUD->bExtendedKillfeed = cvr->cl_neo_hud_extended_killfeed.GetBool();
+		pHUD->iExtendedKillfeed = cvr->cl_neo_hud_extended_killfeed.GetInt();
 		pHUD->iKdinfoToggletype = cvr->cl_neo_kdinfo_toggletype.GetInt();
 		pHUD->bShowHudContextHints = cvr->cl_neo_hud_context_hint_enabled.GetBool();
 
@@ -889,7 +889,7 @@ void NeoSettingsSave(const NeoSettings *ns)
 		cvr->cl_showpos.SetValue(pHUD->bShowPos);
 		cvr->cl_showfps.SetValue(pHUD->iShowFps);
 		cvr->cl_neo_hud_rangefinder_enabled.SetValue(pHUD->bEnableRangeFinder);
-		cvr->cl_neo_hud_extended_killfeed.SetValue(pHUD->bExtendedKillfeed);
+		cvr->cl_neo_hud_extended_killfeed.SetValue(pHUD->iExtendedKillfeed);
 		cvr->cl_neo_kdinfo_toggletype.SetValue(pHUD->iKdinfoToggletype);
 		cvr->cl_neo_hud_context_hint_enabled.SetValue(pHUD->bShowHudContextHints);
 
@@ -1430,6 +1430,12 @@ static const wchar_t *IFF_LABELS[] = {
 #endif // GLOWS_ENABLE
 };
 
+static const wchar_t *EXT_KILLFEED_LABELS[] = {
+	L"Disabled",
+	L"Objectives",
+	L"Objectives & rank-ups"
+};
+
 void NeoSettings_HUD(NeoSettings *ns)
 {
 	NeoSettings::HUD *pHud = &ns->hud;
@@ -1442,7 +1448,7 @@ void NeoSettings_HUD(NeoSettings *ns)
 	NeoUI::RingBoxBool(L"Show position", &pHud->bShowPos);
 	NeoUI::RingBox(L"Show FPS", SHOWFPS_LABELS, ARRAYSIZE(SHOWFPS_LABELS), &pHud->iShowFps);
 	NeoUI::RingBoxBool(L"Show rangefinder", &pHud->bEnableRangeFinder);
-	NeoUI::RingBoxBool(L"Extended Killfeed", &pHud->bExtendedKillfeed);
+	NeoUI::RingBox(L"Extended killfeed", EXT_KILLFEED_LABELS, ARRAYSIZE(EXT_KILLFEED_LABELS), &pHud->iExtendedKillfeed);
 	NeoUI::RingBox(L"Killer damage info auto show", KDMGINFO_TOGGLETYPE_LABELS, KDMGINFO_TOGGLETYPE__TOTAL, &pHud->iKdinfoToggletype);
 
 #ifdef GLOWS_ENABLE

--- a/src/game/client/neo/ui/neo_root_settings.h
+++ b/src/game/client/neo/ui/neo_root_settings.h
@@ -198,7 +198,7 @@ struct NeoSettings
 		bool bShowPos;
 		int iShowFps;
 		bool bEnableRangeFinder;
-		bool bExtendedKillfeed;
+		int iExtendedKillfeed;
 		bool bShowHudContextHints;
 		int iKdinfoToggletype;
 


### PR DESCRIPTION
## Description
Make _cl_neo_hud_extended_killfeed_ an int instead of bool.
0 = Disabled
1 = Objectives (Default)
2 = Objectives & rank-ups

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1746 

