### PR TITLE
Bots can always see the ghost carrier

### DIFF
--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1366,6 +1366,11 @@ float CNEO_Player::GetFogObscuredRatio(CBaseEntity* target) const
 		return 0.0f; // Not obscured
 	}
 
+	if (targetPlayer->IsCarryingGhost())
+	{
+		return 0.0f;
+	}
+
 	// From this point on, assume we are counting bonus points towards observer detection
 	float flDetectionBonus = 0.0f; // # of factors that are helping the observer detect the target
 


### PR DESCRIPTION
## Description
Bots can see the ghost carrier because of the beacon.

## Toolchain
- Windows MSVC VS2022

## Related
- related #1600: When the IsAbleToSee exception for the ghost carrier was removed to resolve some related behavioral bugs, this accidentally made the ghost carrier less visible while cloaked to bots.

