### PR TITLE
Camera shouldn't lean when observing in third person.

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -1688,6 +1688,11 @@ void C_BasePlayer::CalcChaseCamView(Vector& eyeOrigin, QAngle& eyeAngles, float&
 	// HPE_END
 	//=============================================================================
 
+#ifdef NEO
+	// Same as above, and in NT players can lean
+	viewangles.z = 0;
+#endif
+
 	m_flObserverChaseDistance += gpGlobals->frametime*48.0f;
 
 	float flMinDistance = CHASE_CAM_DISTANCE_MIN;


### PR DESCRIPTION
## Description
Zero out the roll component when in chasecam.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #781 
- related #

