### PR TITLE
Remove black bars in spectator

### DIFF
--- a/game/neo/resource/ui/Spectator.res
+++ b/game/neo/resource/ui/Spectator.res
@@ -1,0 +1,57 @@
+"Resource/UI/SpectatorGUI.res"
+{
+	"SpectatorGUI"
+	{
+		"ControlName"	"Frame"
+		"fieldName"		"SpectatorGUI"
+		"tall"			"480"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"	"0"
+	}
+	"topbar"
+	{
+		"ControlName"	"Panel"
+		"fieldName"		"topbar"
+		"xpos"			"0"
+		"ypos"			"0"
+		"tall"			"0"
+		"wide"			"640"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"	"0"
+	}
+	"bottombarblank"
+	{
+		"ControlName"	"Panel"
+		"fieldName"		"bottombarblank"
+		"xpos"			"0"
+		"ypos"			"428"
+		"tall"			"0"		// this needs to match the size of BottomBar
+		"wide"			"640"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"	"0"
+	}
+	"playerlabel"
+	{
+		"ControlName"	"Label"
+		"fieldName"		"playerlabel"
+		"xpos"			"c-108"
+		"ypos"			"441"
+		"wide"			"216"
+		"tall"			"26"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"0"
+		"enabled"		"1"
+		"tabPosition"	"0"
+		"textAlignment"	"center"
+	}
+}

--- a/src/game/client/game_controls/SpectatorGUI.cpp
+++ b/src/game/client/game_controls/SpectatorGUI.cpp
@@ -87,12 +87,6 @@ ConVar cl_spec_mode(
 	FCVAR_ARCHIVE | FCVAR_USERINFO | FCVAR_SERVER_CAN_EXECUTE,
 	"spectator mode" );
 
-namespace {
-constexpr char LABEL_JINRAI[] = "CTScoreValue";
-constexpr char LABEL_NSF[] = "TERScoreValue";
-}
-
-
 //-----------------------------------------------------------------------------
 // Purpose: left and right buttons pointing buttons
 //-----------------------------------------------------------------------------
@@ -506,8 +500,8 @@ void CSpectatorGUI::ApplySchemeSettings(IScheme *pScheme)
 	m_pTopBar->SetVisible( true );
 
 #ifdef NEO
-	m_scoreValueLabelJinrai = nullptr;
-	m_scoreValueLabelNSF = nullptr;
+	m_pTopBar->SetVisible(false);
+	m_pBottomBarBlank->SetVisible(false);
 #endif
 
 	BaseClass::ApplySchemeSettings( pScheme );
@@ -552,21 +546,6 @@ void CSpectatorGUI::OnThink()
 
 	if ( IsVisible() )
 	{
-#ifdef NEO
-		// Temp fix to hide team scores etc when closing scoreboard.
-		auto pLocalNeoPlayer = C_NEO_Player::GetLocalNEOPlayer();
-		if (pLocalNeoPlayer && pLocalNeoPlayer->IsAlive())
-		{
-			auto scoreboard = gViewPortInterface->FindPanelByName(PANEL_SCOREBOARD);
-			Assert(scoreboard);
-			if (!scoreboard->IsVisible())
-			{
-				SetVisible(false);
-				return;
-			}
-		}
-#endif
-
 		if ( m_bSpecScoreboard != spec_scoreboard.GetBool() )
 		{
 			if ( !spec_scoreboard.GetBool() || !gViewPortInterface->GetActivePanel() )
@@ -577,33 +556,11 @@ void CSpectatorGUI::OnThink()
 		}
 
 #ifdef NEO
-		if (!m_scoreValueLabelJinrai)
-		{
-			m_scoreValueLabelJinrai = static_cast<Label*>(FindChildByName(LABEL_JINRAI));
-		}
-		if (!m_scoreValueLabelNSF)
-		{
-			m_scoreValueLabelNSF = static_cast<Label*>(FindChildByName(LABEL_NSF));
-		}
-		Assert(m_scoreValueLabelJinrai);
-		Assert(m_scoreValueLabelNSF);
-
-		auto pJinTeam = GetGlobalTeam(TEAM_JINRAI);
-		auto pNsfTeam = GetGlobalTeam(TEAM_NSF);
-		if (m_scoreValueLabelJinrai && m_scoreValueLabelNSF && pJinTeam && pNsfTeam)
-		{
-			char scoreBuff[3];
-			V_sprintf_safe(scoreBuff, "%d", Max(0, Min(99, pJinTeam->GetRoundsWon())));
-			m_scoreValueLabelJinrai->SetText(scoreBuff);
-			V_sprintf_safe(scoreBuff, "%d", Max(0, Min(99, pNsfTeam->GetRoundsWon())));
-			m_scoreValueLabelNSF->SetText(scoreBuff);
-		}
-
 		// Update player health
 		if (m_pPlayerLabel->IsVisible())
 		{
 			UpdatePlayerLabel();
-                }
+		}
 
 #endif // NEO
 #ifdef TF_CLIENT_DLL
@@ -786,7 +743,6 @@ void CSpectatorGUI::Update()
 	{
 		m_pPlayerLabel->SetText( L"" );
 	}
-#endif
 
 	// update extra info field
 	wchar_t szEtxraInfo[1024];
@@ -816,6 +772,7 @@ void CSpectatorGUI::Update()
 
 	SetLabelText("extrainfo", szEtxraInfo );
 	SetLabelText("titlelabel", szTitleLabel );
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/client/game_controls/spectatorgui.h
+++ b/src/game/client/game_controls/spectatorgui.h
@@ -94,10 +94,6 @@ protected:
 
 	vgui::Panel *m_pTopBar;
 	vgui::Panel *m_pBottomBarBlank;
-#ifdef NEO
-	vgui::Label *m_scoreValueLabelJinrai = nullptr;
-	vgui::Label *m_scoreValueLabelNSF = nullptr;
-#endif
 
 	vgui::ImagePanel *m_pBannerImage;
 	vgui::Label *m_pPlayerLabel;

--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -416,7 +416,6 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 
 			if (m_iBeepSecsTotal != secsTotal)
 			{
-				DevMsg("beepsTotal: %i, secsTotal: %i\n", m_iBeepSecsTotal, secsTotal);
 				const bool bEndBeep = secsTotal == 0;
 				const float flVol = bEndBeep ? 1.0f : 0.7f;
 				static constexpr int PITCH_END = 165;


### PR DESCRIPTION
## Description
Remove the black bars in spectator, as well as the team scores and map name in the top right corner.
Spectator.res was copied from OGNT cleaned up.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- related #1745 

