### PR TITLE
Revert "Fix warn for cvar props_break_max_pieces"

### DIFF
--- a/src/game/shared/props_shared.cpp
+++ b/src/game/shared/props_shared.cpp
@@ -22,11 +22,7 @@
 #include "tier0/memdbgon.h"
 
 ConVar sv_pushaway_clientside_size( "sv_pushaway_clientside_size", "15", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY, "Minimum size of pushback objects" );
-#ifdef NEO
-ConVar props_break_max_pieces( "props_break_max_pieces", "-1", FCVAR_REPLICATED, "Maximum prop breakable piece count (-1 = model default)" );
-#else
 ConVar props_break_max_pieces( "props_break_max_pieces", "-1", 0, "Maximum prop breakable piece count (-1 = model default)" );
-#endif
 ConVar props_break_max_pieces_perframe( "props_break_max_pieces_perframe", "-1", FCVAR_REPLICATED, "Maximum prop breakable piece count per frame (-1 = model default)" );
 #ifdef GAME_DLL
 extern ConVar breakable_multiplayer;


### PR DESCRIPTION
## Description
This reverts commit b6c170ff4e9491394c0a2a1ac88aa87ef783fddf.

The commit was part of the PR #1753

Reverted due to problems as described in: https://github.com/NeotokyoRebuild/neo/pull/1753#issuecomment-3979864981

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1753 

