### PR TITLE
Revert NEO changes to CTEHL2MPFireBullets

### DIFF
--- a/src/game/client/hl2mp/c_te_hl2mp_shotgun_shot.cpp
+++ b/src/game/client/hl2mp/c_te_hl2mp_shotgun_shot.cpp
@@ -33,11 +33,7 @@ public:
 	int		m_iAmmoID;
 	int		m_iWeaponIndex;
 	int		m_iSeed;
-#ifdef NEO
-	Vector	m_vSpread;
-#else
 	float	m_flSpread;
-#endif
 	int		m_iShots;
 	bool	m_bDoImpacts;
 	bool	m_bDoTracers;
@@ -73,38 +69,22 @@ void C_TEHL2MPFireBullets::CreateEffects( void )
 
 	if ( pEnt )
 	{
-#ifdef NEO
-		C_NEO_Player *pPlayer = dynamic_cast<C_NEO_Player *>(pEnt);
-#else
 		C_BasePlayer *pPlayer = dynamic_cast<C_BasePlayer *>(pEnt);
-#endif
 		if ( pPlayer && pPlayer->GetActiveWeapon() )
 		{
-#ifdef NEO
-			CNEOBaseCombatWeapon *pWpn = dynamic_cast<CNEOBaseCombatWeapon *>( pPlayer->GetActiveWeapon() );
-#else
-			C_BaseCombatWeapon *pWpn = dynamic_cast<C_BaseCombatWeapon *>( pPlayer->GetActiveWeapon() );
-#endif		
+			C_BaseCombatWeapon *pWpn = dynamic_cast<C_BaseCombatWeapon *>( pPlayer->GetActiveWeapon() );		
 
 			if ( pWpn )
 			{
 				int iSeed = m_iSeed;
 					
-#ifdef NEO
-				CNEOShotManipulator Manipulator(m_iShots, m_vecDir, pPlayer, pWpn);
-#else
 				CShotManipulator Manipulator( m_vecDir );
-#endif
 				for (int iShot = 0; iShot < m_iShots; iShot++)
 				{
 					RandomSeed( iSeed );	// init random system with this seed
 
 					// Don't run the biasing code for the player at the moment.
-#ifdef NEO
-					Vector vecDir = Manipulator.ApplySpread( m_vSpread );
-#else
 					Vector vecDir = Manipulator.ApplySpread( Vector( m_flSpread, m_flSpread, m_flSpread ) );
-#endif
 					Vector vecEnd = m_vecOrigin + vecDir * MAX_TRACE_LENGTH;
 					trace_t tr;
 					CTraceFilterSkipPlayerAndViewModelOnly traceFilter;
@@ -175,11 +155,7 @@ BEGIN_RECV_TABLE_NOBASE(C_TEHL2MPFireBullets, DT_TEHL2MPFireBullets )
 	RecvPropInt( RECVINFO( m_iShots ) ),
 	RecvPropInt( RECVINFO( m_iPlayer ) ),
 	RecvPropInt( RECVINFO( m_iWeaponIndex ) ),
-#ifdef NEO
-	RecvPropVector(RECVINFO( m_vSpread )),
-#else
 	RecvPropFloat( RECVINFO( m_flSpread ) ),
-#endif
 	RecvPropBool( RECVINFO( m_bDoImpacts ) ),
 	RecvPropBool( RECVINFO( m_bDoTracers ) ),
 END_RECV_TABLE()

--- a/src/game/server/hl2mp/te_hl2mp_shotgun_shot.cpp
+++ b/src/game/server/hl2mp/te_hl2mp_shotgun_shot.cpp
@@ -36,11 +36,7 @@ public:
 	CNetworkVar( int, m_iAmmoID );
 	CNetworkVar( int, m_iSeed );
 	CNetworkVar( int, m_iShots );
-#ifdef NEO
-	CNetworkVector( m_vSpread );
-#else
 	CNetworkVar( float, m_flSpread );
-#endif
 	CNetworkVar( bool, m_bDoImpacts );
 	CNetworkVar( bool, m_bDoTracers );
 };
@@ -68,11 +64,7 @@ IMPLEMENT_SERVERCLASS_ST_NOBASE(CTEHL2MPFireBullets, DT_TEHL2MPFireBullets)
 	SendPropInt( SENDINFO( m_iSeed ), NUM_BULLET_SEED_BITS, SPROP_UNSIGNED ),
 	SendPropInt( SENDINFO( m_iShots ), 5, SPROP_UNSIGNED ),
 	SendPropInt( SENDINFO( m_iPlayer ), 6, SPROP_UNSIGNED ), 	// max 64 players, see MAX_PLAYERS
-#ifdef NEO
-	SendPropVector( SENDINFO( m_vSpread ), -1),
-#else
 	SendPropFloat( SENDINFO( m_flSpread ), 10, 0, 0, 1 ),	
-#endif
 	SendPropBool( SENDINFO( m_bDoImpacts ) ),
 	SendPropBool( SENDINFO( m_bDoTracers ) ),
 END_SEND_TABLE()
@@ -89,11 +81,7 @@ void TE_HL2MPFireBullets(
 	int	iAmmoID,
 	int iSeed,
 	int iShots,
-#ifdef NEO
-	const Vector &vSpread,
-#else
 	float flSpread,
-#endif
 	bool bDoTracers,
 	bool bDoImpacts )
 {
@@ -105,11 +93,7 @@ void TE_HL2MPFireBullets(
 	g_TEHL2MPFireBullets.m_vecDir = vDir;
 	g_TEHL2MPFireBullets.m_iSeed = iSeed;
 	g_TEHL2MPFireBullets.m_iShots = iShots;
-#ifdef NEO
-	g_TEHL2MPFireBullets.m_vSpread = vSpread;
-#else
 	g_TEHL2MPFireBullets.m_flSpread = flSpread;
-#endif
 	g_TEHL2MPFireBullets.m_iAmmoID = iAmmoID;
 	g_TEHL2MPFireBullets.m_bDoTracers = bDoTracers;
 	g_TEHL2MPFireBullets.m_bDoImpacts = bDoImpacts;


### PR DESCRIPTION
## Description
Revert `NEO` changes to `CTEHL2MPFireBullets`, because we are no longer using it since #1759 was merged.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #1763 
