### PR TITLE
Fix viewmodel not disappearing when scoped.

### DIFF
--- a/src/game/client/clientmode_shared.cpp
+++ b/src/game/client/clientmode_shared.cpp
@@ -591,7 +591,7 @@ bool ClientModeShared::ShouldDrawViewModel()
 	{
 		auto pPlayer = C_NEO_Player::GetLocalNEOPlayer();
 		auto pTargetPlayer = static_cast<C_NEO_Player *>(pPlayer->GetObserverTarget());
-		if (pTargetPlayer)
+		if (pPlayer->GetObserverMode() == OBS_MODE_IN_EYE && pTargetPlayer)
 		{
 			return !pTargetPlayer->IsInAim();
 		}


### PR DESCRIPTION
## Description
Seems like m_hObserverTarget isn't cleared when the player is alive. Rather than tracking that down I just make sure the player is in IN_EYE camera before using the target to check aim state.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

