### PR TITLE
Refine bot proactive reload criteria

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_attack.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_attack.cpp
@@ -71,8 +71,7 @@ ActionResult< CNEOBot >	CNEOBotAttack::Update( CNEOBot *me, float interval )
 		// SUPA7 reload can be interrupted so proactively reload
 		if (myWeapon && (myWeapon->GetNeoWepBits() & NEO_WEP_SUPA7) && (myWeapon->Clip1() < myWeapon->GetMaxClip1()))
 		{
-			me->ReleaseFireButton();
-			me->PressReloadButton();
+			me->ReloadIfLowClip(true);
 		}
 		
 		if ( threat->IsVisibleRecently() )

--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -622,10 +622,9 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 		{
 			if ( myWeapon->Clip1() <= 0 )
 			{
-				me->ReleaseFireButton();
 				me->EnableCloak(3.0f);
 				m_isWaitingForFullReload = true;
-				me->PressReloadButton();
+				me->ReloadIfLowClip(true);
 			}
 
 			if ( m_isWaitingForFullReload )
@@ -670,8 +669,7 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 
 		if (myWeapon->Clip1() <= 0)
 		{
-			me->ReleaseFireButton();
-			me->PressReloadButton();
+			me->ReloadIfLowClip(true);
 			m_isWaitingForFullReload = true;
 		}
 
@@ -849,8 +847,7 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 				}
 				else
 				{
-					me->ReleaseFireButton();
-					me->PressReloadButton();
+					me->ReloadIfLowClip(true);
 					m_isWaitingForFullReload = true;
 				}
 				return;

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_lone_wolf.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_lone_wolf.cpp
@@ -47,13 +47,10 @@ ActionResult< CNEOBot >	CNEOBotCtgLoneWolf::Update( CNEOBot *me, float interval 
 	const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat( true );
 
 	CBaseCombatWeapon *pWeapon = me->GetActiveWeapon();
-	if ( !threat && pWeapon && pWeapon->UsesClipsForAmmo1() )
+	if ( !threat && pWeapon )
 	{
-		if ( pWeapon->Clip1() < pWeapon->GetMaxClip1() && me->GetAmmoCount( pWeapon->GetPrimaryAmmoType() ) > 0 )
-		{
-			// Aggressively reload due to lack of backup
-			me->PressReloadButton();
-		}
+		// Aggressively reload due to lack of backup
+		me->ReloadIfLowClip(true); // force reload true
 	}
 
 	// We dropped the ghost to hunt a threat.

--- a/src/game/server/neo/bot/behavior/neo_bot_jgr_capture.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_jgr_capture.cpp
@@ -35,6 +35,7 @@ ActionResult<CNEOBot> CNEOBotJgrCapture::OnStart( CNEOBot *me, Action<CNEOBot> *
 
 	// Ignore enemies while capturing juggernaut
 	me->StopLookingAroundForEnemies();
+	me->ReloadIfLowClip(); // might as well as we're preoccupied
 	return Continue();
 }
 

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
@@ -205,7 +205,11 @@ ActionResult< CNEOBot >	CNEOBotRetreatToCover::Update( CNEOBot *me, float interv
 {
 	const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat( true );
 
-	if ( threat && threat->GetEntity() && threat->GetEntity()->IsPlayer() )
+	if (!threat)
+	{
+		me->ReloadIfLowClip();
+	}
+	else if ( threat->GetEntity() && threat->GetEntity()->IsPlayer() )
 	{
 		CNEO_Player *pThreatPlayer = ToNEOPlayer( threat->GetEntity() );
 		if ( pThreatPlayer && pThreatPlayer->IsCarryingGhost() )

--- a/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.cpp
@@ -435,6 +435,12 @@ ActionResult< CNEOBot >	CNEOBotTacticalMonitor::Update( CNEOBot *me, float inter
 		AvoidBumpingFriends( me );
 	}
 
+	const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat();
+	if ( !threat )
+	{
+		me->ReloadIfLowClip();
+	}
+
 	me->UpdateDelayedThreatNotices();
 
 	return Continue();

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -1606,37 +1606,66 @@ void CNEOBot::EquipBestWeaponForThreat(const CKnownEntity* threat, const bool bN
 void CNEOBot::ReloadIfLowClip(void)
 {
 	CNEOBaseCombatWeapon* myWeapon = static_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
-	if (myWeapon && myWeapon->GetPrimaryAmmoCount() > 0)
+
+	if (!myWeapon)
 	{
-		bool shouldReload = false;
-		// SUPA7 reload doesn't discard ammo
-		if ((myWeapon->GetNeoWepBits() & NEO_WEP_SUPA7) && (myWeapon->Clip1() < myWeapon->GetMaxClip1()))
-		{
-			shouldReload = true;
-		}
-		else
-		{
-			int maxClip = myWeapon->GetMaxClip1();
-			bool isBarrage = IsBarrageAndReloadWeapon(myWeapon);
+		return;
+	}
 
-			int baseThreshold = isBarrage ? (maxClip / 3) : (maxClip / 2);
+	if (myWeapon->GetPrimaryAmmoCount() <= 0)
+	{
+		return;
+	}
 
-			float aggressionFactor = 1.0f - HealthFraction();
+	if (myWeapon->Clip1() >= myWeapon->GetMaxClip1())
+	{
+		return;
+	}
 
-			float dynamicThreshold = baseThreshold + aggressionFactor * (maxClip - baseThreshold);
-
-			if (myWeapon->Clip1() < static_cast<int>(dynamicThreshold))
-			{
-				shouldReload = true;
-			}
-		}
-
-		if (shouldReload)
+	if ((myWeapon->GetNeoWepBits() & NEO_WEP_BALC))
+	{
+		return;
+	}
+	else if ((myWeapon->GetNeoWepBits() & NEO_WEP_SMAC))
+	{
+		return;
+	}
+	else if ((myWeapon->GetNeoWepBits() & NEO_WEP_SUPA7))
+	{
+		// Consider loading slug
+		if ( (myWeapon->m_iSecondaryAmmoCount > 0) && (myWeapon->Clip1() == myWeapon->GetMaxClip1() - 1))
 		{
 			ReleaseFireButton();
-			PressReloadButton();
+			PressAltFireButton();
+			return; // attempt to load slug
+		}
+		// SUPA7 reload doesn't discard ammo, continue
+	}
+	else if (myWeapon->Clip1() > 0)
+	{
+		auto* pPlayer = ToNEOPlayer(this);
+		if ( pPlayer->GetTimeSinceWeaponFired() < 3.0f)
+		{
+			return; // still in the middle of a fight
+		}
+
+		int maxClip = myWeapon->GetMaxClip1();
+		bool isBarrage = IsBarrageAndReloadWeapon(myWeapon);
+
+		int baseThreshold = isBarrage ? (maxClip / 3) : (maxClip / 2);
+
+		float aggressionFactor = 1.0f - HealthFraction();
+
+		float dynamicThreshold = baseThreshold + aggressionFactor * (maxClip - baseThreshold);
+
+		if (myWeapon->Clip1() > static_cast<int>(dynamicThreshold))
+		{
+			return; // reloads drop ammo, still have enough in clip
 		}
 	}
+
+	ReleaseFireButton();
+	PressReloadButton();
 }
 
 

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -1603,7 +1603,7 @@ void CNEOBot::EquipBestWeaponForThreat(const CKnownEntity* threat, const bool bN
 
 //-----------------------------------------------------------------------------------------------------
 // Reload the active weapon if it makes sense for the situation 
-void CNEOBot::ReloadIfLowClip(void)
+void CNEOBot::ReloadIfLowClip(bool bForceReload)
 {
 	CNEOBaseCombatWeapon* myWeapon = static_cast<CNEOBaseCombatWeapon*>(GetActiveWeapon());
 
@@ -1622,15 +1622,22 @@ void CNEOBot::ReloadIfLowClip(void)
 		return;
 	}
 
-	if ((myWeapon->GetNeoWepBits() & NEO_WEP_BALC))
+	if (!(myWeapon->GetNeoWepBits() & NEO_WEP_FIREARM))
 	{
 		return;
 	}
-	else if ((myWeapon->GetNeoWepBits() & NEO_WEP_SMAC))
+
+	if (myWeapon->GetNeoWepBits() & NEO_WEP_BALC)
 	{
 		return;
 	}
-	else if ((myWeapon->GetNeoWepBits() & NEO_WEP_SUPA7))
+
+	if (myWeapon->GetNeoWepBits() & NEO_WEP_SMAC)
+	{
+		return;
+	}
+
+	if (myWeapon->GetNeoWepBits() & NEO_WEP_SUPA7)
 	{
 		// Consider loading slug
 		if ( (myWeapon->m_iSecondaryAmmoCount > 0) && (myWeapon->Clip1() == myWeapon->GetMaxClip1() - 1))
@@ -1658,7 +1665,7 @@ void CNEOBot::ReloadIfLowClip(void)
 
 		float dynamicThreshold = baseThreshold + aggressionFactor * (maxClip - baseThreshold);
 
-		if (myWeapon->Clip1() > static_cast<int>(dynamicThreshold))
+		if (!bForceReload && myWeapon->Clip1() > static_cast<int>(dynamicThreshold))
 		{
 			return; // reloads drop ammo, still have enough in clip
 		}

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -1823,7 +1823,7 @@ bool CNEOBot::IsLineOfFirePenetrationClear(const trace_t &tr, const Vector &from
 
 	// Only bother with fire penetration in short distance
 	auto *neoWeapon = static_cast<CNEOBaseCombatWeapon *>(GetActiveWeapon());
-	if (!neoWeapon)
+	if (!neoWeapon || !(neoWeapon->GetNeoWepBits() & NEO_WEP_FIREARM))
 	{
 		return false;
 	}

--- a/src/game/server/neo/bot/neo_bot.h
+++ b/src/game/server/neo/bot/neo_bot.h
@@ -156,7 +156,7 @@ public:
 
 	bool EquipRequiredWeapon(void);								// if we're required to equip a specific weapon, do it.
 	void EquipBestWeaponForThreat(const CKnownEntity* threat, const bool bNotPrimary = false);	// equip the best weapon we have to attack the given threat
-	void ReloadIfLowClip(void);
+	void ReloadIfLowClip(bool bForceReload = false);
 
 	void PushRequiredWeapon(CNEOBaseCombatWeapon* weapon);				// force us to equip and use this weapon until popped off the required stack
 	void PopRequiredWeapon(void);									// pop top required weapon off of stack and discard


### PR DESCRIPTION
## Description
Tactical Monitor runs on a single thread, so bots can be in extended tactical situations that last longer than their ammo capacity. This PR adds more proactive reload checkpoints, while adding more criteria checks for when to reload.

## Toolchain
- Windows MSVC VS2022


