### PR TITLE
Bots drop weapon if command feature disabled

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_scenario_monitor.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_scenario_monitor.cpp
@@ -9,15 +9,15 @@
 #include "bot/behavior/nav_entities/neo_bot_nav_ent_destroy_entity.h"
 #include "bot/behavior/nav_entities/neo_bot_nav_ent_move_to.h"
 #include "bot/behavior/nav_entities/neo_bot_nav_ent_wait.h"
-#include "bot/behavior/neo_bot_tactical_monitor.h"
-#include "bot/behavior/neo_bot_retreat_to_cover.h"
-#include "bot/behavior/neo_bot_get_health.h"
-#include "bot/behavior/neo_bot_get_ammo.h"
-#include "bot/behavior/neo_bot_command_follow.h"
-#include "bot/behavior/neo_bot_pause.h"
-
 #include "bot/behavior/neo_bot_attack.h"
+#include "bot/behavior/neo_bot_command_follow.h"
+#include "bot/behavior/neo_bot_get_ammo.h"
+#include "bot/behavior/neo_bot_get_health.h"
+#include "bot/behavior/neo_bot_pause.h"
+#include "bot/behavior/neo_bot_retreat_to_cover.h"
 #include "bot/behavior/neo_bot_seek_and_destroy.h"
+#include "bot/behavior/neo_bot_tactical_monitor.h"
+#include "bot/behavior/neo_bot_throw_weapon_at_user.h"
 
 #include "bot/behavior/neo_bot_scenario_monitor.h"
 
@@ -83,6 +83,18 @@ ActionResult< CNEOBot >	CNEOBotScenarioMonitor::Update( CNEOBot *me, float inter
 		if (sv_neo_bot_cmdr_debug_pause_uncommanded.GetBool())
 		{
 			return SuspendFor(new CNEOBotPause, "Paused by debug convar sv_neo_bot_cmdr_debug_pause_uncommanded");
+		}
+	}
+	else
+	{
+		if (me->m_hCommandingPlayer.Get())
+		{
+			CNEO_Player* pCommander = me->m_hCommandingPlayer.Get();
+
+			if (CNEOBotThrowWeaponAtUser::ReadyAimToThrowWeapon(me, pCommander))
+			{
+				return SuspendFor(new CNEOBotThrowWeaponAtUser(pCommander), "Throwing primary weapon to user");
+			}
 		}
 	}
 

--- a/src/game/server/neo/bot/behavior/neo_bot_throw_weapon_at_player.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_throw_weapon_at_player.cpp
@@ -20,12 +20,19 @@ ActionResult< CNEOBot >	CNEOBotThrowWeaponAtPlayer::OnStart( CNEOBot *me, Action
 		return Done( "No target player to throw weapon at" );
 	}
 
+	m_expirationTimer.Start( 5.0f );
+
 	return Continue();
 }
 
 //---------------------------------------------------------------------------------------------
 ActionResult< CNEOBot >	CNEOBotThrowWeaponAtPlayer::Update( CNEOBot *me, float interval )
 {
+	if ( m_expirationTimer.IsElapsed() )
+	{
+		return Done( "Expiration timer elapsed" );
+	}
+
 	CNEO_Player *pTarget = m_hTargetPlayer.Get();
 	if ( !pTarget || !pTarget->IsAlive() )
 	{

--- a/src/game/server/neo/bot/behavior/neo_bot_throw_weapon_at_player.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_throw_weapon_at_player.h
@@ -19,6 +19,9 @@ public:
 
 	virtual const char *GetName( void ) const override { return "ThrowWeaponAtPlayer"; };
 
+protected:
+	CountdownTimer m_expirationTimer;
+
 private:
 	CHandle<CNEO_Player> m_hTargetPlayer;
 };

--- a/src/game/server/neo/bot/behavior/neo_bot_throw_weapon_at_user.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_throw_weapon_at_user.h
@@ -1,0 +1,38 @@
+#ifndef NEO_BOT_THROW_WEAPON_AT_USER_H
+#define NEO_BOT_THROW_WEAPON_AT_USER_H
+#pragma once
+
+#include "bot/behavior/neo_bot_throw_weapon_at_player.h"
+#include "bot/neo_bot.h"
+#include "neo_player.h"
+
+//-----------------------------------------------------------------------------------------
+// If the bot command system is disabled, bots simply drop their weapon for the user
+class CNEOBotThrowWeaponAtUser : public CNEOBotThrowWeaponAtPlayer
+{
+public:
+	CNEOBotThrowWeaponAtUser(CNEO_Player* pTargetPlayer) : CNEOBotThrowWeaponAtPlayer(pTargetPlayer) {}
+
+	virtual void OnEnd(CNEOBot* me, Action< CNEOBot >* nextAction) override
+	{
+		me->m_hCommandingPlayer = nullptr;
+		CNEOBotThrowWeaponAtPlayer::OnEnd(me, nextAction);
+	}
+	
+	virtual const char* GetName(void) const override { return "ThrowWeaponAtUser"; };
+
+	static bool ReadyAimToThrowWeapon(CNEOBot* me, CNEO_Player* pCommander)
+	{
+		me->GetBodyInterface()->AimHeadTowards(pCommander->GetAbsOrigin(), IBody::MANDATORY, 0.2f, nullptr, "Aiming at user's feet to throw weapon");
+
+		Vector vecToUserFeet = pCommander->GetAbsOrigin() - me->EyePosition();
+		vecToUserFeet.NormalizeInPlace();
+
+		Vector vecBotFacing;
+		me->EyeVectors(&vecBotFacing);
+
+		return (vecBotFacing.Dot(vecToUserFeet) > 0.95f);
+	}
+};
+
+#endif // NEO_BOT_THROW_WEAPON_AT_USER_H

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -3280,16 +3280,13 @@ void CNEO_Player::SetTestMessageVisible(bool visible)
 
 void CNEO_Player::ResetBotCommandState()
 {
-	if (sv_neo_bot_cmdr_enable.GetBool())
+	m_hLeadingPlayer = nullptr;
+	m_hCommandingPlayer = nullptr;
+	m_tBotPlayerPingCooldown.Invalidate();
+	m_flBotDynamicFollowDistanceSq = 0.0f;
+	for (int i = 0; i < STAR__TOTAL; ++i)
 	{
-		m_hLeadingPlayer = nullptr;
-		m_hCommandingPlayer = nullptr;
-		m_tBotPlayerPingCooldown.Invalidate();
-		m_flBotDynamicFollowDistanceSq = 0.0f;
-		for (int i = 0; i < STAR__TOTAL; ++i)
-		{
-			m_vLastPingByStar.GetForModify(i) = VECTOR_INVALID_WAYPOINT;
-		}
+		m_vLastPingByStar.GetForModify(i) = VECTOR_INVALID_WAYPOINT;
 	}
 }
 
@@ -3362,11 +3359,6 @@ void CNEO_Player::PlayerUse( void )
 {
 	BaseClass::PlayerUse();
 
-	if (!sv_neo_bot_cmdr_enable.GetBool())
-	{
-		return;
-	}
-
 	if ( (m_afButtonPressed & IN_USE) && !FindUseEntity() )
 	{
 		// Select bot under cursor to follow/unfollow.
@@ -3384,9 +3376,18 @@ void CNEO_Player::PlayerUse( void )
 			CNEO_Player* pTargetPlayer = ToNEOPlayer(tr.m_pEnt);
 			if ( pTargetPlayer && pTargetPlayer->IsBot())
 			{
-				// The hit entity is a bot! Now, toggle its follow state.
-				pTargetPlayer->ToggleBotFollowCommander( this );
-				// TODO: Do we want to allow using players for some kind of communication?
+				if (sv_neo_bot_cmdr_enable.GetBool())
+				{
+					// The hit entity is a bot! Now, toggle its follow state.
+					pTargetPlayer->ToggleBotFollowCommander( this );
+					// TODO: Do we want to allow using players for some kind of communication?
+				}
+				else if (NEORules()->IsTeamplay() && pTargetPlayer->GetTeamNumber() == GetTeamNumber())
+				{
+					// Alt: Triggers throwing primary weapon to user
+					// see neo_bot_scenario_monitor for behavior transition
+					pTargetPlayer->m_hCommandingPlayer = this;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
- When the bot command feature (sv_neo_bot_cmdr_enable) is disabled, pressing use on bots causes them to drop their weapon
- Bots text message their commander with updates

## Toolchain
- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0
