### PR TITLE
Raise the particle limit

### DIFF
--- a/src/game/client/particle_iterators.h
+++ b/src/game/client/particle_iterators.h
@@ -18,7 +18,11 @@
 
 #define NUM_PARTICLES_PER_BATCH 200
 #ifndef _XBOX
+#ifdef NEO
+#define MAX_TOTAL_PARTICLES		4096
+#else
 #define MAX_TOTAL_PARTICLES		2048	// Max particles in the world
+#endif
 #else
 #define MAX_TOTAL_PARTICLES		1024
 #endif


### PR DESCRIPTION
## Description
This limit was made with 2004 hardware in mind
It is the distant year 2026, humanity has progressed very little,

Raising the limit because its still fairly easy to hit. Not that this should excuse any unoptimsed use of particles!

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1701 

