### PR TITLE
+use sound only for local player and new sound

### DIFF
--- a/src/game/server/hl2/hl2_player.cpp
+++ b/src/game/server/hl2/hl2_player.cpp
@@ -3973,8 +3973,7 @@ void CHL2_Player::ItemPostFrame()
 	{
 		m_bPlayUseDenySound = false;
 #ifdef NEO
-		CRecipientFilter filter;
-		filter.AddRecipient( this );
+		CSingleUserRecipientFilter filter( this );
 		EmitSound( filter, entindex(), "HL2Player.UseDeny" );
 #else
 		EmitSound( "HL2Player.UseDeny" );


### PR DESCRIPTION
## Description
Get rid of HL2 sound, make it local player only

[neoAssets](https://github.com/NeotokyoRebuild/neoAssets/pull/109)<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

## Toolchain
- Windows MSVC VS2022


