### PR TITLE
Only Support bots should utilize smoke for concealment

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_grenade_dispatch.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_grenade_dispatch.cpp
@@ -55,9 +55,9 @@ Action< CNEOBot > *CNEOBotGrenadeDispatch::ChooseGrenadeThrowBehavior( const CNE
 		if ( sv_neo_bot_grenade_use_frag.GetBool() && (bits & NEO_WEP_FRAG_GRENADE) )
 		{
 			pFragGrenade = static_cast< CWeaponGrenade * >( pNeoWep );
-			if ( pSmokeGrenade )
+			if ( pSmokeGrenade || (me->GetClass() != NEO_CLASS_SUPPORT) )
 			{
-				break; // found both
+				break; // done searching
 			}
 		}
 		else if ( sv_neo_bot_grenade_use_smoke.GetBool() && (bits & NEO_WEP_SMOKE_GRENADE) )
@@ -65,7 +65,7 @@ Action< CNEOBot > *CNEOBotGrenadeDispatch::ChooseGrenadeThrowBehavior( const CNE
 			pSmokeGrenade = static_cast< CWeaponSmokeGrenade * >( pNeoWep );
 			if ( pFragGrenade )
 			{
-				break; // found both
+				break; // done searching
 			}
 		}
 	}
@@ -76,7 +76,7 @@ Action< CNEOBot > *CNEOBotGrenadeDispatch::ChooseGrenadeThrowBehavior( const CNE
 	}
 
 	// Should I toss a smoke grenade?
-	if ( pSmokeGrenade )
+	if ( pSmokeGrenade && (me->GetClass() == NEO_CLASS_SUPPORT) )
 	{
 		for ( int i = 1; i <= gpGlobals->maxClients; i++ )
 		{

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
@@ -47,44 +47,45 @@ public:
 	{
 		VPROF_BUDGET( "CTestAreaAgainstThreats::Inspect", "NextBot" );
 
-		if ( m_me->IsEnemy( known.GetEntity() ) )
+		if ( !m_me->IsEnemy( known.GetEntity() ) )
 		{
-			const CNavArea *threatArea = known.GetLastKnownArea();
+			return true; // Known entity is not my enemy
+		}
 
-			if ( threatArea )
+		const CNavArea *threatArea = known.GetLastKnownArea();
+
+		if ( !threatArea )
+		{
+			return true; // Can't test area if we don't know last area of threat
+		}
+
+		if ( !m_area->IsPotentiallyVisible( threatArea ) )
+		{
+			return true; // Candidate area is not visible by threat
+		}
+
+		// Only consider smoke as concealment if I can see through it but the enemy cannot (thermal vision)
+		CNEO_Player *pThreatPlayer = ToNEOPlayer( known.GetEntity() );
+		if ( pThreatPlayer && (pThreatPlayer->GetClass() != NEO_CLASS_SUPPORT) && (m_me->GetClass() == NEO_CLASS_SUPPORT) )
+		{
+			ScopedSmokeLOS smokeScope( false );
+
+			Vector vecThreatEye = known.GetLastKnownPosition() + pThreatPlayer->GetViewOffset();
+			Vector vecCandidateArea = m_area->GetCenter() + m_me->GetViewOffset();
+
+			trace_t tr;
+			CTraceFilterSimple filter( known.GetEntity(), COLLISION_GROUP_NONE);
+			UTIL_TraceLine( vecThreatEye, vecCandidateArea, MASK_BLOCKLOS, &filter, &tr );
+
+			if ( tr.fraction < 1.0f )
 			{
-				// is area visible by known threat
-				if ( m_area->IsPotentiallyVisible( threatArea ) )
-				{
-					// Is there smoke in this area that I can use for concealment?
-					bool bObscuredBySmoke = false;
-					CNEO_Player *pThreatPlayer = ToNEOPlayer( known.GetEntity() );
-					// Support class can see through smoke
-					if ( pThreatPlayer && (pThreatPlayer->GetClass() != NEO_CLASS_SUPPORT) )
-					{
-						ScopedSmokeLOS smokeScope( false );
-
-						Vector vecThreatEye = known.GetLastKnownPosition() + pThreatPlayer->GetViewOffset();
-						Vector vecCandidateArea = m_area->GetCenter() + m_me->GetViewOffset();
-
-						trace_t tr;
-						CTraceFilterSimple filter( known.GetEntity(), COLLISION_GROUP_NONE);
-						UTIL_TraceLine( vecThreatEye, vecCandidateArea, MASK_BLOCKLOS, &filter, &tr );
-
-						if ( tr.fraction < 1.0f )
-						{
-							bObscuredBySmoke = true;
-						}
-					}
-
-					if ( !bObscuredBySmoke )
-					{
-						++m_exposedThreatCount;
-					}
-				}
+				return true; // Smoke provides concealment from this threat
 			}
 		}
 
+		++m_exposedThreatCount;  // Area is exposed to threat
+
+		// Return true to continue searching other known entities
 		return true;
 	}
 


### PR DESCRIPTION
## Description
While earlier bots could use smoke to hide from each other, feedback from players indicated that humans are less fooled by this ruse, and will fire into the smoke cloud.  This often results in a shooting fish in a barrel effect.  This PR tweaks the bot logic to only deploy and retreat into smoke if their class is Support, so they can take advantage of thermal vision.  Other classes will now prefer hard cover when retreating.  This has a side benefit of saving some CPU instructions when evaluating retreat cover.

## Toolchain
- Windows MSVC VS2022

