### PR TITLE
Fix JGR bleeding

### DIFF
--- a/src/game/client/c_basecombatcharacter.cpp
+++ b/src/game/client/c_basecombatcharacter.cpp
@@ -204,6 +204,10 @@ BEGIN_RECV_TABLE(C_BaseCombatCharacter, DT_BaseCombatCharacter)
 	RecvPropInt( RECVINFO( m_iPowerups ) ),
 #endif
 
+#ifdef NEO
+	RecvPropInt( RECVINFO( m_bloodColor ) ),
+#endif
+
 END_RECV_TABLE()
 
 

--- a/src/game/server/basecombatcharacter.cpp
+++ b/src/game/server/basecombatcharacter.cpp
@@ -210,6 +210,10 @@ IMPLEMENT_SERVERCLASS_ST(CBaseCombatCharacter, DT_BaseCombatCharacter)
 	SendPropEHandle( SENDINFO( m_hActiveWeapon ) ),
 	SendPropArray3( SENDINFO_ARRAY3(m_hMyWeapons), SendPropEHandle( SENDINFO_ARRAY(m_hMyWeapons) ) ),
 
+#ifdef NEO
+	SendPropInt( SENDINFO( m_bloodColor ) ),
+#endif
+
 #ifdef INVASION_DLL
 	SendPropInt( SENDINFO(m_iPowerups), MAX_POWERUPS, SPROP_UNSIGNED ), 
 #endif

--- a/src/game/server/basecombatcharacter.h
+++ b/src/game/server/basecombatcharacter.h
@@ -481,7 +481,11 @@ private:
 	void				DestroyGlowEffect( void );
 
 protected:
+#ifdef NEO
+	CNetworkVar( int, m_bloodColor );
+#else
 	int			m_bloodColor;			// color of blood particless
+#endif
 
 	// -------------------
 	// combat ability data

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -3756,7 +3756,7 @@ void CNEO_Player::BecomeJuggernaut()
 	SetMaxHealth(MAX_HEALTH_FOR_CLASS[NEO_CLASS_JUGGERNAUT]);
 	SetHealth(GetMaxHealth());
 	SuitPower_SetCharge(100);
-	//SetBloodColor(DONT_BLEED); Check C_HL2MP_Player::TraceAttack
+	SetBloodColor(DONT_BLEED);
 	m_HL2Local.m_cloakPower = CloakPower_Cap();
 	m_bAllowGibbing = false;
 	m_bInVision = false;


### PR DESCRIPTION
## Description
Blood colour was not networked. It looks like that spot in C_HL2MP_Player is the only place in the codebase where the blood colour is grabbed clientside- there was some discussion about having blood only spawned serverside but thats unrelated, though if that were the case networking this var would not be necessary

## Toolchain
- Windows MSVC VS2022


