### PR TITLE
Fixup crosshair refactor logic issue

### DIFF
--- a/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/src/game/client/neo/ui/neo_root_settings.cpp
@@ -1409,7 +1409,10 @@ void NeoSettings_Crosshair(NeoSettings *ns)
 			}
 			NeoUI::RingBoxBool(L"Draw top line", &pCrosshair->info.bTopLine);
 			NeoUI::SliderInt(L"Circle radius", &pCrosshair->info.iCircleRad, 0, CROSSHAIR_MAX_CIRCLE_RAD);
-			NeoUI::SliderInt(L"Circle segments", &pCrosshair->info.iCircleSegments, 0, CROSSHAIR_MAX_CIRCLE_SEGMENTS);
+			if (pCrosshair->info.iCircleRad > 0)
+			{
+				NeoUI::SliderInt(L"Circle segments", &pCrosshair->info.iCircleSegments, 0, CROSSHAIR_MAX_CIRCLE_SEGMENTS);
+			}
 			static_assert(sizeof(int) == sizeof(NeoHudCrosshairDynamicType));
 			NeoUI::RingBox(L"Dynamic type", CROSSHAIR_DYNAMICTYPE_LABELS, CROSSHAIR_DYNAMICTYPE__TOTAL, (int *)(&pCrosshair->info.eDynamicType));
 		}

--- a/src/game/shared/neo/neo_crosshair.cpp
+++ b/src/game/shared/neo/neo_crosshair.cpp
@@ -200,8 +200,8 @@ void ResetCrosshairToDefault(CrosshairInfo *crh)
 	crh->eDynamicType = CROSSHAIR_DYNAMICTYPE_NONE;
 	crh->bSeparateColorDot = false;
 	crh->colorDot = COLOR_WHITE;
-	crh->colorDotOutline = COLOR_WHITE;
-	crh->colorOutline = COLOR_WHITE;
+	crh->colorDotOutline = COLOR_BLACK;
+	crh->colorOutline = COLOR_BLACK;
 }
 
 void DefaultCrosshairSerial(char (&szSequence)[NEO_XHAIR_SEQMAX])
@@ -357,20 +357,22 @@ static void ImportOrExportCrosshair(const ESerialMode eSerialMode, CrosshairInfo
 				? static_cast<NeoHudCrosshairDynamicType>(SerialInt(crh->eDynamicType, eSerialMode, szMutSeq, iSeqSize, &idx))
 				: CROSSHAIR_DYNAMICTYPE_NONE;
 
-		if (eSerialMode == SERIALMODE_DESERIALIZE)
+		if (iSerialVersion >= NEOXHAIR_SERIAL_ALPHA_V22)
 		{
-			crh->bSeparateColorDot = false;
-			crh->colorDot = COLOR_BLACK;
-			crh->colorDotOutline = COLOR_BLACK;
-			crh->colorOutline = COLOR_BLACK;
-		}
-		if (iSerialVersion >= NEOXHAIR_SERIAL_ALPHA_V22 && (bNotCompact || crh->iCenterDot > 0))
-		{
-			crh->bSeparateColorDot = SerialBool(crh->bSeparateColorDot, eSerialMode, szMutSeq, iSeqSize, &idx);
-			if (bNotCompact || crh->bSeparateColorDot)
+			if (bNotCompact || crh->iCenterDot > 0)
 			{
-				crh->colorDot.SetRawColor(SerialInt(crh->colorDot.GetRawColor(), eSerialMode, szMutSeq, iSeqSize, &idx));
-				crh->colorDotOutline.SetRawColor(SerialInt(crh->colorDotOutline.GetRawColor(), eSerialMode, szMutSeq, iSeqSize, &idx));
+				crh->bSeparateColorDot = SerialBool(crh->bSeparateColorDot, eSerialMode, szMutSeq, iSeqSize, &idx);
+				if (bNotCompact || crh->bSeparateColorDot)
+				{
+					crh->colorDot.SetRawColor(SerialInt(crh->colorDot.GetRawColor(), eSerialMode, szMutSeq, iSeqSize, &idx));
+					if (bNotCompact || crh->iOutline > 0)
+					{
+						crh->colorDotOutline.SetRawColor(SerialInt(crh->colorDotOutline.GetRawColor(), eSerialMode, szMutSeq, iSeqSize, &idx));
+					}
+				}
+			}
+			if (bNotCompact || crh->iOutline > 0)
+			{
 				crh->colorOutline.SetRawColor(SerialInt(crh->colorOutline.GetRawColor(), eSerialMode, szMutSeq, iSeqSize, &idx));
 			}
 		}
@@ -389,6 +391,7 @@ bool ImportCrosshair(CrosshairInfo *crh, const char *pszSequence)
 	V_memcpy(szMutSeq, pszSequence, sizeof(char) * iSeqSize);
 	szMutSeq[iSeqSize] = '\0';
 
+	ResetCrosshairToDefault(crh);
 	ImportOrExportCrosshair(SERIALMODE_DESERIALIZE, crh, szMutSeq, iSeqSize);
 	return true;
 }


### PR DESCRIPTION
Outline color should be dealt by if there's an outline or not, not by dot. Also make sure to reset to default settings before reading in crosshair serial.


