### PR TITLE
Allow swim up and swim down controls to move the player up and down the ladder

### DIFF
--- a/src/game/shared/gamemovement.cpp
+++ b/src/game/shared/gamemovement.cpp
@@ -3137,6 +3137,14 @@ bool CGameMovement::LadderMove( void )
 	if ( mv->m_nButtons & IN_MOVERIGHT )
 		rightSpeed += climbSpeed;
 
+#ifdef NEO
+	if (mv->m_flUpMove)
+	{
+		forwardSpeed = mv->m_flUpMove > 0 ? climbSpeed : -climbSpeed;
+		rightSpeed = 0;
+	}
+#endif // NEO
+
 	if ( mv->m_nButtons & IN_JUMP )
 	{
 		player->SetMoveType( MOVETYPE_WALK );
@@ -3154,7 +3162,11 @@ bool CGameMovement::LadderMove( void )
 			//	pev->velocity.x, pev->velocity.y, pev->velocity.z);
 			// Calculate player's intended velocity
 			//Vector velocity = (forward * gpGlobals->v_forward) + (right * gpGlobals->v_right);
+#ifdef NEO
+			VectorScale( mv->m_flUpMove ? -player->m_vecLadderNormal : m_vecForward, forwardSpeed, velocity );
+#else
 			VectorScale( m_vecForward, forwardSpeed, velocity );
+#endif // NEO
 			VectorMA( velocity, rightSpeed, m_vecRight, velocity );
 
 			// Perpendicular in the ladder plane


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Mostly for bots which struggle to move straight up a ladder. When using these controls the direction of the player's camera is ignored when determining which way to move when on a ladder.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
