### PR TITLE
Don't show damage info while still alive.

### DIFF
--- a/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
+++ b/src/game/client/neo/ui/neo_hud_killer_damage_info.cpp
@@ -175,8 +175,7 @@ void CNEOHud_KillerDamageInfo::UpdateStateForNeoHudElementDraw()
 
 	// If to show or not
 	const bool bNextPlayerShownHud = localPlayer
-			&& ((const_cast<C_NEO_Player *>(localPlayer)->IsPlayerDead() && g_neoKDmgInfos.bHasDmgInfos) ||
-				(NEORules()->GetRoundStatus() == NeoRoundStatus::PostRound && NEORules()->roundNumber() > 0))
+			&& (const_cast<C_NEO_Player *>(localPlayer)->IsPlayerDead() && g_neoKDmgInfos.bHasDmgInfos)
 			&& (localPlayer->GetTeamNumber() == TEAM_JINRAI ||
 				localPlayer->GetTeamNumber() == TEAM_NSF);
 	const bool bToShownStateChanged = (bNextPlayerShownHud && bNextPlayerShownHud != m_bPlayerShownHud);
@@ -424,9 +423,9 @@ void CNEOHud_KillerDamageInfo::DrawNeoHudElement()
 			m_uiCtx.iLayoutY += iYOffsetting;
 
 			NeoUI::SwapFont(NeoUI::FONT_NTHORIZSIDES);
-			NeoUI::Label(L"Dealt");
+			NeoUI::Label(L"Dealt to");
 			NeoUI::Label(L"Player");
-			NeoUI::Label(L"Taken");
+			NeoUI::Label(L"Taken from");
 
 			m_uiCtx.iLayoutY -= iYOffsetting;
 
@@ -643,19 +642,19 @@ static void __MsgFunc_DamageInfo(bf_read& msg)
 			char infoLine[128] = {};
 			if (attackerInfo.dealtDmgs > 0 && attackerInfo.takenDmgs > 0)
 			{
-				V_sprintf_safe(infoLine, "%s [%s]: Dealt: %d in %d hits | Taken: %d in %d hits\n",
+				V_sprintf_safe(infoLine, "%s [%s]: Dealt to: %d in %d hits | Taken from: %d in %d hits\n",
 						   dmgerName, dmgerClass,
 						   attackerInfo.dealtDmgs, attackerInfo.dealtHits, attackerInfo.takenDmgs, attackerInfo.takenHits);
 			}
 			else if (attackerInfo.dealtDmgs > 0)
 			{
-				V_sprintf_safe(infoLine, "%s [%s]: Dealt: %d in %d hits\n",
+				V_sprintf_safe(infoLine, "%s [%s]: Dealt to: %d in %d hits\n",
 						   dmgerName, dmgerClass,
 						   attackerInfo.dealtDmgs, attackerInfo.dealtHits);
 			}
 			else if (attackerInfo.takenDmgs > 0)
 			{
-				V_sprintf_safe(infoLine, "%s [%s]: Taken: %d in %d hits\n",
+				V_sprintf_safe(infoLine, "%s [%s]: Taken from: %d in %d hits\n",
 						   dmgerName, dmgerClass,
 						   attackerInfo.takenDmgs, attackerInfo.takenHits);
 			}

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -2692,6 +2692,14 @@ void CNEORules::StartNextRound()
 			pPlayer->m_iTeamDamageInflicted = 0;
 			pPlayer->m_iTeamKillsInflicted = 0;
 		}
+		else
+		{
+			// Any human player still alive, show them damage stats in round end
+			if (!pPlayer->IsBot() && !pPlayer->IsHLTV() && pPlayer->IsAlive())
+			{
+				pPlayer->StartShowDmgStats(nullptr);
+			}
+		}
 
 		pPlayer->SpectatorTakeoverPlayerRevert(); // hard reset: round restart
 
@@ -3725,12 +3733,6 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 					// This will award the controlled player, if any
 					player->AddPoints(xpAward, false);
 				}
-			}
-
-			// Any human player still alive, show them damage stats in round end
-			if (!player->IsBot() && !player->IsHLTV() && player->IsAlive())
-			{
-				player->StartShowDmgStats(nullptr);
 			}
 		}
 	}


### PR DESCRIPTION
## Description
* Don't show damage info to alive players until the round has fully ended.
* This has the side effect that the popup never actually shows, because it won't show to alive players. The info is still available in the console.
* Reword "Taken" -> "Taken from" and "Dealt" -> "Dealt to" to avoid confusion.

I initially wanted to remove everything but the killer info from the popup, but it seems we have a reliability issue where the damage numbers sometimes don't add up, so leaving everything for now.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- related #1650

