### PR TITLE
Bots apply nav pathing penalties based on weapon limits

### DIFF
--- a/src/game/server/nav_area.cpp
+++ b/src/game/server/nav_area.cpp
@@ -258,7 +258,36 @@ CNavArea::CNavArea( void )
 	m_funcNavCostVector.RemoveAll();
 
 	m_nVisTestCounter = (uint32)-1;
+
+#ifdef NEO
+	m_visibleAreaCount = 0;
+#endif
 }
+
+
+#ifdef NEO
+//--------------------------------------------------------------------------------------------------------------
+struct CountPotentiallyVisibleAreas
+{
+	int count;
+	CountPotentiallyVisibleAreas() : count(0) {}
+	bool operator()( CNavArea* area )
+	{
+		count++;
+		return true;
+	}
+};
+
+
+//--------------------------------------------------------------------------------------------------------------
+void CNavArea::ComputePotentiallyVisibleAreaCount()
+{
+	CountPotentiallyVisibleAreas counter;
+	const_cast<CNavArea*>(this)->ForAllPotentiallyVisibleAreas( counter );
+	m_visibleAreaCount = counter.count;
+}
+#endif
+
 
 //--------------------------------------------------------------------------------------------------------------
 /**

--- a/src/game/server/nav_area.h
+++ b/src/game/server/nav_area.h
@@ -520,6 +520,10 @@ public:
 	virtual bool IsPartiallyVisible( const Vector &eye, const CBaseEntity *ignore = NULL ) const;				// return true if any portion of the area is visible from given eyepoint (CPU intensive)
 
 	virtual bool IsPotentiallyVisible( const CNavArea *area ) const;		// return true if given area is potentially visible from somewhere in this area (very fast)
+#ifdef NEO
+	int GetPotentiallyVisibleAreaCount() const { return m_visibleAreaCount; }
+	void ComputePotentiallyVisibleAreaCount();
+#endif
 	virtual bool IsPotentiallyVisibleToTeam( int team ) const;				// return true if any portion of this area is visible to anyone on the given team (very fast)
 
 	virtual bool IsCompletelyVisible( const CNavArea *area ) const;			// return true if given area is completely visible from somewhere in this area (very fast)
@@ -662,6 +666,9 @@ private:
 	*/
 
 	static unsigned int m_nextID;								// used to allocate unique IDs
+#ifdef NEO
+	int m_visibleAreaCount;
+#endif
 	unsigned int m_id;											// unique area ID
 	unsigned int m_debugid;
 

--- a/src/game/server/nav_file.cpp
+++ b/src/game/server/nav_file.cpp
@@ -1647,6 +1647,14 @@ NavErrorType CNavMesh::PostLoad( unsigned int version )
 		area->PostLoad();
 	}
 
+#ifdef NEO
+	FOR_EACH_VEC( TheNavAreas, vit )
+	{
+		CNavArea *area = TheNavAreas[ vit ];
+		area->ComputePotentiallyVisibleAreaCount();
+	}
+#endif
+
 	// allow hiding spots to compute information
 	FOR_EACH_VEC( TheHidingSpots, hit )
 	{

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_enemy.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_enemy.cpp
@@ -49,7 +49,8 @@ ActionResult< CNEOBot >	CNEOBotCtgEnemy::Update( CNEOBot *me, float interval )
 	// Investigate the ghost carrier's position
 	if ( m_repathTimer.IsElapsed() )
 	{
-		CNEOBotPathCompute( me, m_path, pGhostCarrier->GetAbsOrigin(), DEFAULT_ROUTE );
+		// FASTEST_ROUTE: don't waste chase time looking for cover
+		CNEOBotPathCompute( me, m_path, pGhostCarrier->GetAbsOrigin(), FASTEST_ROUTE );
 		m_repathTimer.Start( RandomFloat( 0.2f, 1.0f ) );
 	}
 	m_path.Update( me );

--- a/src/game/server/neo/bot/neo_bot_path_cost.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_cost.cpp
@@ -5,17 +5,33 @@
 #include "neo_bot_locomotion.h"
 #include "nav_mesh.h"
 #include "neo_bot_path_reservation.h"
+#include "weapon_neobasecombatweapon.h"
 
 extern ConVar neo_bot_path_reservation_enable;
 
 ConVar neo_bot_path_around_friendly_cooldown("neo_bot_path_around_friendly_cooldown", "2.0", FCVAR_CHEAT,
 	"How often to check for friendly path dispersion", false, 0, false, 60);
 
-ConVar neo_bot_path_penalty_jump_multiplier("neo_bot_path_penalty_jump_multiplier", "100.0", FCVAR_CHEAT,
+ConVar neo_bot_path_penalty_jump_multiplier("neo_bot_path_penalty_jump_multiplier", "1000.0", FCVAR_CHEAT,
 	"Maximum penalty multiplier for jump height changes in pathfinding", false, 0.01f, false, 1000.0f);
 
 ConVar neo_bot_path_penalty_ladder_multiplier("neo_bot_path_penalty_ladder_multiplier", "3.0", FCVAR_CHEAT,
 	"Penalty multiplier for ladder traversal in pathfinding", true, 0.1f, true, 100.0f);
+
+ConVar neo_bot_path_penalty_exposure_base("neo_bot_path_penalty_exposure_base", "5.0", FCVAR_CHEAT,
+	"General additional penalty per visible area for bots to avoid exposed areas", true, 0.0f, false, 0.0f);
+
+ConVar neo_bot_path_penalty_exposure_pistol("neo_bot_path_penalty_exposure_pistol", "10.0", FCVAR_CHEAT,
+	"Additional penalty per visible area for bots wielding pistol caliber weapons", true, 0.0f, false, 0.0f);
+
+ConVar neo_bot_path_penalty_exposure_shotgun("neo_bot_path_penalty_exposure_shotgun", "20.0", FCVAR_CHEAT,
+	"Additional penalty per visible area for shotgun-wielding bots", true, 0.0f, false, 0.0f);
+
+ConVar neo_bot_path_penalty_exposure_inverse_base_battle_rifle("neo_bot_path_penalty_exposure_inverse_base_battle_rifle", "500.0", FCVAR_CHEAT,
+	"Base penalty for calculating inverse traversal penalty for semi-auto battle rifles", true, 1.0f, false, 0.0f);
+
+ConVar neo_bot_path_penalty_exposure_inverse_base_scoped("neo_bot_path_penalty_exposure_inverse_base_scoped", "1000.0", FCVAR_CHEAT,
+	"Base penalty for calculating inverse traversal penalty for scoped weapons", true, 1.0f, false, 0.0f);
 
 //-------------------------------------------------------------------------------------------------
 CNEOBotPathCost::CNEOBotPathCost(CNEOBot* me, RouteType routeType)
@@ -125,6 +141,50 @@ float CNEOBotPathCost::operator()(CNavArea* baseArea, CNavArea* fromArea, const 
 		{
 			cost += CNEOBotPathReservations()->GetPredictedFriendlyPathCount(area->GetID(), m_me->GetTeamNumber()) * neo_bot_path_reservation_penalty.GetFloat();
 			cost += CNEOBotPathReservations()->GetAreaAvoidPenalty(area->GetID());
+
+			// Weapon range penalties
+			CNEOBaseCombatWeapon* myWeapon = ToNEOWeapon(m_me->GetActiveWeapon());
+			const int nWeaponBits = myWeapon->GetNeoWepBits();
+			if (myWeapon && (nWeaponBits & NEO_WEP_FIREARM))
+			{
+				constexpr int nShotgunBits = NEO_WEP_AA13 | NEO_WEP_SUPA7;
+				constexpr int nBattleRifleBits = NEO_WEP_M41 | NEO_WEP_M41_S;
+				constexpr int nPistolCaliberBits = NEO_WEP_MILSO | NEO_WEP_TACHI | NEO_WEP_KYLA
+					| NEO_WEP_MPN | NEO_WEP_MPN_S | NEO_WEP_JITTE | NEO_WEP_JITTE_S | NEO_WEP_SRM | NEO_WEP_SRM_S;
+
+				const int visibleAreaCount = area->GetPotentiallyVisibleAreaCount();
+
+				if (nWeaponBits & nPistolCaliberBits)
+				{
+					// Weapons that don't have max first shot accuracy
+					const float exposurePenalty = neo_bot_path_penalty_exposure_pistol.GetFloat();
+					dist += visibleAreaCount * exposurePenalty;
+				}
+				else if (nWeaponBits & nShotgunBits)
+				{
+					// Weapons that have spread that can't hit long range targets
+					const float exposurePenalty = neo_bot_path_penalty_exposure_shotgun.GetFloat();
+					dist += visibleAreaCount * exposurePenalty;
+				}
+				else if (nWeaponBits & nBattleRifleBits)
+				{
+					// Weapons that benefit from medium sightlines that can see many NavAreas
+					const float baseline_penalty = neo_bot_path_penalty_exposure_inverse_base_battle_rifle.GetFloat();
+					dist += baseline_penalty / visibleAreaCount;
+				}
+				else if (nWeaponBits & NEO_WEP_SCOPEDWEAPON)
+				{
+					// Weapons that benefit from long sightlines that can see many NavAreas
+					const float baseline_penalty = neo_bot_path_penalty_exposure_inverse_base_scoped.GetFloat();
+					dist += baseline_penalty / visibleAreaCount;
+				}
+				else
+				{
+					// Generally avoiding exposed areas when traversing a wide open area
+					const float exposurePenalty = neo_bot_path_penalty_exposure_base.GetFloat();
+					dist += visibleAreaCount * exposurePenalty;
+				}
+			}
 
 			if (m_routeType == SAFEST_ROUTE)
 			{

--- a/src/game/server/neo/bot/neo_bot_path_cost.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_cost.cpp
@@ -10,13 +10,13 @@
 extern ConVar neo_bot_path_reservation_enable;
 
 ConVar neo_bot_path_around_friendly_cooldown("neo_bot_path_around_friendly_cooldown", "2.0", FCVAR_CHEAT,
-	"How often to check for friendly path dispersion", false, 0, false, 60);
+	"How often to check for friendly path dispersion", true, 0, true, 60);
 
-ConVar neo_bot_path_penalty_jump_multiplier("neo_bot_path_penalty_jump_multiplier", "1000.0", FCVAR_CHEAT,
-	"Maximum penalty multiplier for jump height changes in pathfinding", false, 0.01f, false, 1000.0f);
+ConVar neo_bot_path_penalty_jump_multiplier("neo_bot_path_penalty_jump_multiplier", "100000.0", FCVAR_CHEAT,
+	"Maximum penalty multiplier for jump height changes in pathfinding", true, 0.01f, false, 0.0f);
 
 ConVar neo_bot_path_penalty_ladder_multiplier("neo_bot_path_penalty_ladder_multiplier", "3.0", FCVAR_CHEAT,
-	"Penalty multiplier for ladder traversal in pathfinding", true, 0.1f, true, 100.0f);
+	"Penalty multiplier for ladder traversal in pathfinding", true, 0.1f, false, 0.0f);
 
 ConVar neo_bot_path_penalty_exposure_base("neo_bot_path_penalty_exposure_base", "5.0", FCVAR_CHEAT,
 	"General additional penalty per visible area for bots to avoid exposed areas", true, 0.0f, false, 0.0f);

--- a/src/game/server/neo/bot/neo_bot_path_cost.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_cost.cpp
@@ -143,46 +143,51 @@ float CNEOBotPathCost::operator()(CNavArea* baseArea, CNavArea* fromArea, const 
 			cost += CNEOBotPathReservations()->GetAreaAvoidPenalty(area->GetID());
 
 			// Weapon range penalties
-			CNEOBaseCombatWeapon* myWeapon = ToNEOWeapon(m_me->GetActiveWeapon());
-			const int nWeaponBits = myWeapon->GetNeoWepBits();
-			if (myWeapon && (nWeaponBits & NEO_WEP_FIREARM))
+			auto* myWeapon = assert_cast<CNEOBaseCombatWeapon*>(m_me->GetActiveWeapon());
+			if (myWeapon)
 			{
-				constexpr int nShotgunBits = NEO_WEP_AA13 | NEO_WEP_SUPA7;
-				constexpr int nBattleRifleBits = NEO_WEP_M41 | NEO_WEP_M41_S;
-				constexpr int nPistolCaliberBits = NEO_WEP_MILSO | NEO_WEP_TACHI | NEO_WEP_KYLA
-					| NEO_WEP_MPN | NEO_WEP_MPN_S | NEO_WEP_JITTE | NEO_WEP_JITTE_S | NEO_WEP_SRM | NEO_WEP_SRM_S;
+				const int nWeaponBits = myWeapon->GetNeoWepBits();
+				if (nWeaponBits & NEO_WEP_FIREARM)
+				{
+					const int visibleAreaCount = area->GetPotentiallyVisibleAreaCount();
+					if (visibleAreaCount > 0)
+					{
+						constexpr int nShotgunBits = NEO_WEP_AA13 | NEO_WEP_SUPA7;
+						constexpr int nBattleRifleBits = NEO_WEP_M41 | NEO_WEP_M41_S;
+						constexpr int nPistolCaliberBits = NEO_WEP_MILSO | NEO_WEP_TACHI | NEO_WEP_KYLA
+							| NEO_WEP_MPN | NEO_WEP_MPN_S | NEO_WEP_JITTE | NEO_WEP_JITTE_S | NEO_WEP_SRM | NEO_WEP_SRM_S;
 
-				const int visibleAreaCount = area->GetPotentiallyVisibleAreaCount();
-
-				if (nWeaponBits & nPistolCaliberBits)
-				{
-					// Weapons that don't have max first shot accuracy
-					const float exposurePenalty = neo_bot_path_penalty_exposure_pistol.GetFloat();
-					dist += visibleAreaCount * exposurePenalty;
-				}
-				else if (nWeaponBits & nShotgunBits)
-				{
-					// Weapons that have spread that can't hit long range targets
-					const float exposurePenalty = neo_bot_path_penalty_exposure_shotgun.GetFloat();
-					dist += visibleAreaCount * exposurePenalty;
-				}
-				else if (nWeaponBits & nBattleRifleBits)
-				{
-					// Weapons that benefit from medium sightlines that can see many NavAreas
-					const float baseline_penalty = neo_bot_path_penalty_exposure_inverse_base_battle_rifle.GetFloat();
-					dist += baseline_penalty / visibleAreaCount;
-				}
-				else if (nWeaponBits & NEO_WEP_SCOPEDWEAPON)
-				{
-					// Weapons that benefit from long sightlines that can see many NavAreas
-					const float baseline_penalty = neo_bot_path_penalty_exposure_inverse_base_scoped.GetFloat();
-					dist += baseline_penalty / visibleAreaCount;
-				}
-				else
-				{
-					// Generally avoiding exposed areas when traversing a wide open area
-					const float exposurePenalty = neo_bot_path_penalty_exposure_base.GetFloat();
-					dist += visibleAreaCount * exposurePenalty;
+						if (nWeaponBits & nPistolCaliberBits)
+						{
+							// Weapons that don't have max first shot accuracy
+							const float exposurePenalty = neo_bot_path_penalty_exposure_pistol.GetFloat();
+							cost += visibleAreaCount * exposurePenalty;
+						}
+						else if (nWeaponBits & nShotgunBits)
+						{
+							// Weapons that have spread that can't hit long range targets
+							const float exposurePenalty = neo_bot_path_penalty_exposure_shotgun.GetFloat();
+							cost += visibleAreaCount * exposurePenalty;
+						}
+						else if (nWeaponBits & nBattleRifleBits)
+						{
+							// Weapons that benefit from medium sightlines that can see many NavAreas
+							const float baseline_penalty = neo_bot_path_penalty_exposure_inverse_base_battle_rifle.GetFloat();
+							cost += baseline_penalty / visibleAreaCount;
+						}
+						else if (nWeaponBits & NEO_WEP_SCOPEDWEAPON)
+						{
+							// Weapons that benefit from long sightlines that can see many NavAreas
+							const float baseline_penalty = neo_bot_path_penalty_exposure_inverse_base_scoped.GetFloat();
+							cost += baseline_penalty / visibleAreaCount;
+						}
+						else
+						{
+							// Generally avoiding exposed areas when traversing a wide open area
+							const float exposurePenalty = neo_bot_path_penalty_exposure_base.GetFloat();
+							cost += visibleAreaCount * exposurePenalty;
+						}
+					}
 				}
 			}
 

--- a/src/game/server/neo/bot/neo_bot_path_cost.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_cost.cpp
@@ -5,7 +5,6 @@
 #include "neo_bot_locomotion.h"
 #include "nav_mesh.h"
 #include "neo_bot_path_reservation.h"
-#include "weapon_neobasecombatweapon.h"
 
 extern ConVar neo_bot_path_reservation_enable;
 

--- a/src/game/server/neo/bot/neo_bot_path_reservation.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_reservation.cpp
@@ -29,7 +29,7 @@ ConVar neo_bot_path_reservation_avoid_penalty_enable("neo_bot_path_reservation_a
 ConVar neo_bot_path_reservation_killed_penalty("neo_bot_path_reservation_killed_penalty", "10", FCVAR_NONE,
     "Path selection penalty added to a nav area each time a bot dies moving through that area.", true, 0, false, 0);
 
-ConVar neo_bot_path_reservation_onstuck_penalty("neo_bot_path_reservation_onstuck_penalty", "10000", FCVAR_NONE,
+ConVar neo_bot_path_reservation_onstuck_penalty("neo_bot_path_reservation_onstuck_penalty", "1000", FCVAR_NONE,
     "Path selection penalty added to a nav area each time a bot gets stuck moving through that area.", true, 0, false, 0);
 
 

--- a/src/game/server/neo/bot/neo_bot_path_reservation.cpp
+++ b/src/game/server/neo/bot/neo_bot_path_reservation.cpp
@@ -12,13 +12,13 @@ ConVar neo_bot_path_reservation_enable("neo_bot_path_reservation_enable", "1", F
     "Enable the bot path reservation system.", true, 0, true, 1);
 
 ConVar neo_bot_path_reservation_duration("neo_bot_path_reservation_duration", "30.0", FCVAR_NONE,
-    "How long a path reservation lasts, in seconds.", true, 1, true, 1000000);
+    "How long a path reservation lasts, in seconds.", true, 1, false, 0);
 
-ConVar neo_bot_path_reservation_distance("neo_bot_path_reservation_distance", "10000", FCVAR_NONE,
-    "How far along the path to reserve, in Hammer units.", true, 0, true, 1000000);
+ConVar neo_bot_path_reservation_distance("neo_bot_path_reservation_distance", "100000", FCVAR_NONE,
+    "How far along the path to reserve, in Hammer units.", true, 0, false, 0);
 
-ConVar neo_bot_path_reservation_penalty("neo_bot_path_reservation_penalty", "100", FCVAR_NONE,
-    "Pathing cost penalty for a reserved area.", true, 0, true, 1000000);
+ConVar neo_bot_path_reservation_penalty("neo_bot_path_reservation_penalty", "10000", FCVAR_NONE,
+    "Pathing cost penalty for a reserved area.", true, 0, false, 0);
 
 ConVar neo_bot_path_reservation_friendly_penalty_enable("neo_bot_path_reservation_friendly_penalty_enable", "1", FCVAR_NONE,
     "Whether to update or retrieve the area friendly reservation penalty.", true, 0, true, 1);

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -260,4 +260,14 @@ private:
 
 };
 
+
+inline CNEOBaseCombatWeapon *ToNEOWeapon(CBaseCombatWeapon *pWeapon)
+{
+	if (!pWeapon)
+	{
+		return nullptr;
+	}
+	return dynamic_cast<CNEOBaseCombatWeapon*>(pWeapon);
+}
+
 #endif // WEAPON_NEO_BASECOMBATWEAPON_SHARED_H

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -260,14 +260,4 @@ private:
 
 };
 
-
-inline CNEOBaseCombatWeapon *ToNEOWeapon(CBaseCombatWeapon *pWeapon)
-{
-	if (!pWeapon)
-	{
-		return nullptr;
-	}
-	return dynamic_cast<CNEOBaseCombatWeapon*>(pWeapon);
-}
-
 #endif // WEAPON_NEO_BASECOMBATWEAPON_SHARED_H


### PR DESCRIPTION
## Description
Bots consider relative level of exposure of a NavArea when deciding paths through the NavMesh
- Bots with shotguns shy away from NavAreas that have many visibility connections
- Bots with pistol caliber weapons slightly avoid areas but to a lesser degree
- Bots with scoped/semi-auto weapons favor exposed NavAreas with long sightlines
- Generally, a minor penalty is applied for NavArea exposure for bots to avoid wide open exposed NavAreas, unless they have a scoped/battle rifle

## Toolchain
- Windows MSVC VS2022
