### PR TITLE
Don't stay scoped while playing bolt animation

### DIFF
--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -58,6 +58,10 @@ bool IsAllowedToZoom(CNEOBaseCombatWeapon *pWep)
 		return false;
 	}
 
+	if (pWep->GetNeoWepBits() & NEO_WEP_SRS && pWep->GetIdealActivity() == ACT_VM_PULLBACK) {
+		return false;
+	}
+
 	// These weapons are not allowed to be zoomed in with.
 	const auto forbiddenZooms =
 		NEO_WEP_DETPACK |

--- a/src/game/shared/neo/weapons/weapon_srs.cpp
+++ b/src/game/shared/neo/weapons/weapon_srs.cpp
@@ -77,7 +77,6 @@ void CWeaponSRS::ItemPreFrame()
 			{
 				return BaseClass::ItemPreFrame();
 			}
-			pOwner->Weapon_SetZoom(false);
 		}
 		// Only queue the bolting anim once; we want to allow the player
 		// to cancel this with manual weapon quick-switching.


### PR DESCRIPTION
## Description
We should probably move `IsAllowedToZoom` to NEOBaseCombatWeapon` and then override in the SRS class, but this is good enough for now. Basically just return false if weapon is SRS and we're playing the bolt animation.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1793
