### PR TITLE
Bots pause firing after inflicting team damage

### DIFF
--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -469,7 +469,7 @@ void CNEOBot::PressFireButton(float duration)
 {
 	// can't fire if stunned
 	// @todo Tom Bui: Eventually, we'll probably want to check the actual weapon for supress fire
-	if (HasAttribute(CNEOBot::SUPPRESS_FIRE))
+	if ( GetBotPauseFiring() || HasAttribute(CNEOBot::SUPPRESS_FIRE) )
 	{
 		ReleaseFireButton();
 		return;

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -3290,8 +3290,15 @@ int	CNEO_Player::OnTakeDamage_Alive(const CTakeDamageInfo& info)
 					attacker->m_iTeamDamageInflicted += iDamage;
 				}
 
-				if (info.GetDamageType() & (DMG_BULLET | DMG_SLASH | DMG_BUCKSHOT)) {
+				constexpr const int botDamageTypes = DMG_SLASH | DMG_BULLET | DMG_BUCKSHOT;
+				if (info.GetDamageType() & botDamageTypes)
+				{
 					++m_iBotDetectableBleedingInjuryEvents;
+				}
+
+				if (bIsTeamDmg && NEORules()->IsTeamplay() && attacker->IsBot() && (info.GetDamageType() & botDamageTypes))
+				{
+					attacker->m_botPauseFiringTimer.Start(1.0f);
 				}
 			}
 		}

--- a/src/game/server/neo/neo_player.h
+++ b/src/game/server/neo/neo_player.h
@@ -180,6 +180,7 @@ public:
 	bool GetInThermOpticCamo() const { return m_bInThermOpticCamo; }
 	// bots can't see anything, so they need an additional timer for cloak disruption events
 	bool GetBotCloakStateDisrupted() const { return !m_botThermOpticCamoDisruptedTimer.IsElapsed(); }
+	bool GetBotPauseFiring() const { return !m_botPauseFiringTimer.IsElapsed(); }
 	bool GetSpectatorTakeoverPlayerPending() const { return m_bSpectatorTakeoverPlayerPending; }
 
 	virtual void StartAutoSprint(void) OVERRIDE;
@@ -245,6 +246,8 @@ private:
 
 	// tracks time since last cloak disruption event for bots who can't actually see
 	CountdownTimer m_botThermOpticCamoDisruptedTimer;
+	// cooldown after inflicting accidental team damage
+	CountdownTimer m_botPauseFiringTimer;
 
 private:
 	float GetActiveWeaponSpeedScale() const;


### PR DESCRIPTION
## Description
While bots currently avoid pulling the trigger when a friendly is in their direct line of fire, weapon spread often expands to hit teammates, especially for inaccurate weapons and shotguns. Bots have been tweaked to pause for a moment if they have injured their teammate, in order to reduce the volume of fire that is directed at friendlies in team-based modes.

## Toolchain
- Windows MSVC VS2022
