### PR TITLE
Don't overlap roundedhud textures

### DIFF
--- a/src/game/client/neo/ui/neo_hud_childelement.cpp
+++ b/src/game/client/neo/ui/neo_hud_childelement.cpp
@@ -59,12 +59,18 @@ CNEOHud_ChildElement::XYHudPos CNEOHud_ChildElement::DrawNeoHudRoundedCommon(
 	const int x0, const int y0, const int x1, const int y1, Color color,
 	bool topLeft, bool topRight, bool bottomLeft, bool bottomRight) const
 {
-	const XYHudPos p{
+	XYHudPos p{
 		.x0w = x0 + m_rounded_width,
 		.x1w = x1 - m_rounded_width,
 		.y0h = y0 + m_rounded_height,
 		.y1h = y1 - m_rounded_height,
 	};
+
+	if (p.y1h < p.y0h)
+		p.y1h = p.y0h = y0 + (0.5 * (y1 - y0));
+
+	if (p.x1w < p.x0w)
+		p.x1w = p.x0w = x0 + (0.5 * (x1 - x0));
 
 	surface()->DrawSetColor(color);
 

--- a/src/game/client/neo/ui/neo_hud_childelement.cpp
+++ b/src/game/client/neo/ui/neo_hud_childelement.cpp
@@ -67,10 +67,10 @@ CNEOHud_ChildElement::XYHudPos CNEOHud_ChildElement::DrawNeoHudRoundedCommon(
 	};
 
 	if (p.y1h < p.y0h)
-		p.y1h = p.y0h = y0 + (0.5 * (y1 - y0));
+		p.y1h = p.y0h = y0 + ((y1 - y0) / 2);
 
 	if (p.x1w < p.x0w)
-		p.x1w = p.x0w = x0 + (0.5 * (x1 - x0));
+		p.x1w = p.x0w = x0 + ((x1 - x0) / 2);
 
 	surface()->DrawSetColor(color);
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

If a neohudrounded box does not have enough space to draw both textures, squash the textures 

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1613