### PR TITLE
Do or Die

### DIFF
--- a/src/game/client/neo/ui/neo_hud_round_state.cpp
+++ b/src/game/client/neo/ui/neo_hud_round_state.cpp
@@ -251,7 +251,8 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	float roundTimeLeft = NEORules()->GetRoundRemainingTime();
 	const NeoRoundStatus roundStatus = NEORules()->GetRoundStatus();
 	const bool inSuddenDeath = NEORules()->RoundIsInSuddenDeath();
-	const bool inMatchPoint = NEORules()->RoundIsMatchPoint();
+	const bool inDoOrDie = NEORules()->RoundIsDoOrDie();
+	const bool inMatchPoint = !inDoOrDie && NEORules()->RoundIsMatchPoint(); // we don't care about matchpoint if in do or die
 
 	m_pWszStatusUnicode = L"";
 	if (roundStatus == NeoRoundStatus::Idle)
@@ -269,6 +270,10 @@ void CNEOHud_RoundState::UpdateStateForNeoHudElementDraw()
 	else if (inSuddenDeath)
 	{
 		m_pWszStatusUnicode = L"Sudden death";
+	}
+	else if (inDoOrDie)
+	{
+		m_pWszStatusUnicode = L"Do or Die";
 	}
 	else if (inMatchPoint)
 	{

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -263,6 +263,7 @@ BEGIN_NETWORK_TABLE_NOBASE( CNEORules, DT_NEORules )
 	RecvPropInt(RECVINFO(m_nGameTypeSelected)),
 	RecvPropInt(RECVINFO(m_iRoundNumber)),
 	RecvPropBool(RECVINFO(m_bIsMatchPoint)),
+	RecvPropBool(RECVINFO(m_bIsDoOrDie)),
 	RecvPropBool(RECVINFO(m_bIsInSuddenDeath)),
 	RecvPropInt(RECVINFO(m_iHiddenHudElements)),
 	RecvPropInt(RECVINFO(m_iForcedTeam)),
@@ -290,6 +291,7 @@ BEGIN_NETWORK_TABLE_NOBASE( CNEORules, DT_NEORules )
 	SendPropInt(SENDINFO(m_nGameTypeSelected), NumBitsForCount(NEO_GAME_TYPE__TOTAL), SPROP_UNSIGNED),
 	SendPropInt(SENDINFO(m_iRoundNumber)),
 	SendPropBool(SENDINFO(m_bIsMatchPoint)),
+	SendPropBool(SENDINFO(m_bIsDoOrDie)),
 	SendPropBool(SENDINFO(m_bIsInSuddenDeath)),
 	SendPropInt(SENDINFO(m_iHiddenHudElements)),
 	SendPropInt(SENDINFO(m_iForcedTeam)),
@@ -760,6 +762,7 @@ void CNEORules::ResetMapSessionCommon()
 	SetRoundStatus(NeoRoundStatus::Idle);
 	m_iRoundNumber = 0;
 	m_bIsMatchPoint = false;
+	m_bIsDoOrDie = false;
 	m_bIsInSuddenDeath = false;
 	V_memset(m_szNeoJinraiClantag.GetForModify(), 0, NEO_MAX_CLANTAG_LENGTH);
 	V_memset(m_szNeoNSFClantag.GetForModify(), 0, NEO_MAX_CLANTAG_LENGTH);
@@ -3489,6 +3492,24 @@ bool CNEORules::RoundIsMatchPoint() const
 #endif
 }
 
+bool CNEORules::RoundIsDoOrDie() const
+{
+#ifdef CLIENT_DLL
+	return m_bIsDoOrDie;
+#else
+	auto teamJinrai = GetGlobalTeam(TEAM_JINRAI);
+	auto teamNSF = GetGlobalTeam(TEAM_NSF);
+	if (teamJinrai && teamNSF && neo_round_limit.GetInt() != 0)
+	{
+		const int roundsLeft = neo_round_limit.GetInt() - m_iRoundNumber + 1;
+		if ((teamJinrai->GetRoundsWon() + roundsLeft) == teamNSF->GetRoundsWon()) return true;
+		if ((teamNSF->GetRoundsWon() + roundsLeft) == teamJinrai->GetRoundsWon()) return true;
+		return false;
+	}
+	return false;
+#endif
+}
+
 #ifdef GAME_DLL
 void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bool bSwitchTeams, bool bDontAddScore, bool bFinal)
 {
@@ -4367,6 +4388,7 @@ void CNEORules::SetRoundStatus(NeoRoundStatus status)
 			currentHandle = m_pRestoredInfos.NextHandle(currentHandle);
 		}
 
+		m_bIsDoOrDie = RoundIsDoOrDie();
 		m_bIsMatchPoint = RoundIsMatchPoint();
 		m_bIsInSuddenDeath = RoundIsInSuddenDeath();
 	}

--- a/src/game/shared/neo/neo_gamerules.h
+++ b/src/game/shared/neo/neo_gamerules.h
@@ -249,6 +249,7 @@ public:
 
 	bool RoundIsInSuddenDeath() const;
 	bool RoundIsMatchPoint() const;
+	bool RoundIsDoOrDie() const;
 
 	virtual int DefaultFOV(void) override;
 
@@ -476,6 +477,7 @@ private:
 	CNetworkVar(int, m_nGameTypeSelected);
 	CNetworkVar(int, m_iRoundNumber);
 	CNetworkVar(bool, m_bIsMatchPoint);
+	CNetworkVar(bool, m_bIsDoOrDie);
 	CNetworkVar(bool, m_bIsInSuddenDeath);
 	CNetworkString(m_szNeoJinraiClantag, NEO_MAX_CLANTAG_LENGTH);
 	CNetworkString(m_szNeoNSFClantag, NEO_MAX_CLANTAG_LENGTH);


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

The nature of having a round limit, and teams being able to tie individual rounds, means that situations can occur where the team that has fewer points needs to win every single round left including the current one for a chance at victory through sudden death, or an overall tie if sudden death is disabled.

In this situation, stating that the game is in match point is misleading, since while the team with the higher score can technically score another point to win the match, they can also tie the round to win the match.

This PR adds a new term "Do or Die" (credit to Wahaha), which displays in the top hud element instead of "Matchpoint" if the above applies to the current round.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022