### PR TITLE
Display names longer than max name length defined in iff marker

### DIFF
--- a/src/game/client/neo/ui/neo_hud_friendly_marker.cpp
+++ b/src/game/client/neo/ui/neo_hud_friendly_marker.cpp
@@ -242,7 +242,7 @@ void CNEOHud_FriendlyMarker::DrawPlayer(Color teamColor, C_NEO_Player *player, c
 			textUTF[0] = L'\0';
 #ifdef WIN32
 			g_pVGuiLocalize->ConvertANSIToUnicode(textASCII, textUTF, narrow_cast<int>(Min(sizeof(textUTF), sizeof(wchar_t) * maxLength)));
-			const int numChars = (int)wcslen(textUTF);
+			const int numChars = narrow_cast<int>(wcslen(textUTF));
 #else
 			const int numChars = g_pVGuiLocalize->ConvertANSIToUnicode(textASCII, textUTF, narrow_cast<int>(Min(sizeof(textUTF), sizeof(wchar_t) * maxLength)));
 #endif // WIN32


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

On windows ConvertANSIToUnicode returns a 0 for the length of the wchar_t produced if the string passed in is longer than the max length passed in.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022