### PR TITLE
Customizable rate limit for cloak and vision when bound to mouse wheel

### DIFF
--- a/src/game/client/in_main.cpp
+++ b/src/game/client/in_main.cpp
@@ -462,7 +462,7 @@ void KeyDownHoldReplaceToggle( kbutton_t *b, const char *c )
 KeyDown with a minimum time between any two keydowns of a button. Not intended to limit players, rather its to help players not accidentally execute actions bound to the mouse wheel more than once
 ============
 */
-ConVar cl_neo_mouse_wheel_action_cool_down("cl_neo_mouse_wheel_action_cool_down", "0.3", FCVAR_ARCHIVE, "If the mouse wheel is bound to an action with a mouse wheel delay, controls how long that delay is to prevent accidental activations of the action", true, 0, true, 1.f);
+ConVar cl_neo_mouse_wheel_action_cool_down("cl_neo_mouse_wheel_action_cool_down", "0", FCVAR_ARCHIVE, "If the mouse wheel is bound to an action with a mouse wheel delay, controls how long that delay is to prevent accidental activations of the action", true, 0, true, 1.f);
 static float nextMouseWheelUp = 0.f;
 static float nextMouseWheelDown = 0.f;
 void KeyDownWithMouseWheelDelay(kbutton_t* b, const char* c)


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Intended to stop accidentally toggling the two on and off repeatedly when bound to the mouse wheel

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022