### PR TITLE
Enable bot following/waypoints by default

### DIFF
--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -161,7 +161,7 @@ void CheckPingButton(CNEO_Player* player)
 	}
 }
 
-ConVar sv_neo_bot_cmdr_enable("sv_neo_bot_cmdr_enable", "0",
+ConVar sv_neo_bot_cmdr_enable("sv_neo_bot_cmdr_enable", "1",
 	FCVAR_REPLICATED | FCVAR_ARCHIVE, "Allow bots to follow you after you press use on them", true, 0, true, 1);
 
 #ifdef GAME_DLL


### PR DESCRIPTION
## Description
Enable by default feature to press use on bots and have them follow you

## Toolchain
- Windows MSVC VS2022

## Related
- related #1778 (This PR would disable this alternative feature by default)
- related #1345 (For related code context)
