### PR TITLE
Fix env_sun being hidden when under the centre of view

### DIFF
--- a/src/game/client/glow_overlay.cpp
+++ b/src/game/client/glow_overlay.cpp
@@ -159,7 +159,11 @@ void CGlowOverlay::UpdateSkyGlowObstruction( float zFar, bool bCacheFullSceneSta
 	if ( PixelVisibility_IsAvailable() )
 	{
 		// Trace a ray at the object. 
+#ifdef NEO
+		Vector pos = CurrentViewOrigin() + m_vDirection * zFar * 0.99f;
+#else
 		Vector pos = CurrentViewOrigin() + m_vDirection * zFar * 0.999f;
+#endif
 
 		// UNDONE: Can probably do only the pixelvis query in this case if you can figure out where
 		// to put it - or save the position of this trace


### PR DESCRIPTION
## Description
The sun sprite will vanish if you look directly at it. Can test on culvert

## Toolchain
- Windows MSVC VS2022


