### PR TITLE
Juggernaut bots can alt-fire grenades

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -964,22 +964,7 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 		{
 			if (myWeapon->GetNeoWepBits() & NEO_WEP_BALC)
 			{
-				auto *pBalc = static_cast<CWeaponBALC *>(myWeapon);
-				// Minimum viable firing BALC
-				// TODO: Proper heat management for higher difficulty bots
-				me->ReleaseWalkButton(); // NEO Jank: this actually cancels sprint
-
-				// NEO JANK: To simplify alt fire input management
-				// we allow the bot to bypass button-hold charge firing requirement
-				if ( (me->GetTimeSinceWeaponFired() >= pBalc->GetChargeDuration())
-					&& threatRange >= 300.0f )
-				{
-					pBalc->ShootGrenade(me);
-				}
-				else
-				{
-					me->PressFireButton(GetFireDurationByDifficulty(me));
-				}
+				FireBalcAtEnemy( me, myWeapon, threat, threatRange );
 				return;
 			}
 			else if (myWeapon->m_iClip1 <= 0)
@@ -1048,6 +1033,33 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 			}
 		}
 	}
+}
+
+
+//---------------------------------------------------------------------------------------------
+void CNEOBotMainAction::FireBalcAtEnemy( CNEOBot *me, CNEOBaseCombatWeapon *myWeapon, const CKnownEntity *threat, float threatRange )
+{
+	Assert( myWeapon->GetNeoWepBits() & NEO_WEP_BALC );
+	auto *pBalc = static_cast<CWeaponBALC *>( myWeapon );
+	me->ReleaseWalkButton(); // NEO Jank: this actually cancels sprint
+
+	// NEO JANK: To simplify alt fire input management
+	// we allow the bot to bypass button-hold charge firing requirement
+	// with approximation of charge fire delay
+	if ( threatRange > 300.0f && ( me->GetTimeSinceWeaponFired() > pBalc->GetChargeDuration() * 1.2f ) )
+	{
+		// Check if threat is clearly exposed for a shot
+		const CNavArea *meArea = me->GetLastKnownArea();
+		const CNavArea *targetArea = TheNavMesh->GetNearestNavArea( threat->GetEntity()->GetAbsOrigin() );
+		if ( meArea && targetArea && meArea->IsCompletelyVisible( targetArea ) )
+		{
+			pBalc->ShootGrenade( me );
+			return;
+		}
+	}
+
+	// Fallback to using the primary fire mode
+	me->PressFireButton( GetFireDurationByDifficulty( me ) );
 }
 
 

--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -15,6 +15,7 @@
 #include "bot/behavior/nav_entities/neo_bot_nav_ent_move_to.h"
 #include "bot/behavior/nav_entities/neo_bot_nav_ent_wait.h"
 #include "bot/behavior/neo_bot_tactical_monitor.h"
+#include "weapons/weapon_balc.h"
 
 ConVar neo_bot_path_lookahead_range( "neo_bot_path_lookahead_range", "300" );
 ConVar neo_bot_sniper_aim_error( "neo_bot_sniper_aim_error", "0.01", FCVAR_CHEAT );
@@ -963,10 +964,22 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 		{
 			if (myWeapon->GetNeoWepBits() & NEO_WEP_BALC)
 			{
+				auto *pBalc = static_cast<CWeaponBALC *>(myWeapon);
 				// Minimum viable firing BALC
 				// TODO: Proper heat management for higher difficulty bots
 				me->ReleaseWalkButton(); // NEO Jank: this actually cancels sprint
-				me->PressFireButton(GetFireDurationByDifficulty(me));
+
+				// NEO JANK: To simplify alt fire input management
+				// we allow the bot to bypass button-hold charge firing requirement
+				if ( (me->GetTimeSinceWeaponFired() >= pBalc->GetChargeDuration())
+					&& threatRange >= 300.0f )
+				{
+					pBalc->ShootGrenade(me);
+				}
+				else
+				{
+					me->PressFireButton(GetFireDurationByDifficulty(me));
+				}
 				return;
 			}
 			else if (myWeapon->m_iClip1 <= 0)

--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.h
@@ -52,6 +52,7 @@ private:
 	bool m_isWaitingForFullReload;
 
 	void FireWeaponAtEnemy( CNEOBot *me );
+	void FireBalcAtEnemy( CNEOBot *me, CNEOBaseCombatWeapon *myWeapon, const CKnownEntity *threat, float threatRange );
 	float GetFireDurationByDifficulty( CNEOBot *me ) const;
 
 	CHandle< CBaseEntity > m_lastTouch;

--- a/src/game/server/neo/bot/behavior/neo_bot_jgr_juggernaut.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_jgr_juggernaut.cpp
@@ -4,6 +4,8 @@
 #include "bot/neo_bot.h"
 #include "bot/neo_bot_path_compute.h"
 #include "bot/behavior/neo_bot_jgr_juggernaut.h"
+#include "bot/behavior/neo_bot_retreat_to_cover.h"
+#include "weapon_balc.h"
 
 //---------------------------------------------------------------------------------------------
 ActionResult< CNEOBot > CNEOBotJgrJuggernaut::OnStart( CNEOBot *me, Action< CNEOBot > *priorAction )
@@ -25,6 +27,20 @@ ActionResult< CNEOBot > CNEOBotJgrJuggernaut::OnStart( CNEOBot *me, Action< CNEO
 //---------------------------------------------------------------------------------------------
 ActionResult< CNEOBot > CNEOBotJgrJuggernaut::Update( CNEOBot *me, float interval )
 {
+	CBaseCombatWeapon *pWeapon = me->GetActiveWeapon();
+	if ( pWeapon )
+	{
+		CNEOBaseCombatWeapon *pNeoWep = dynamic_cast< CNEOBaseCombatWeapon * >( pWeapon );
+		if ( pNeoWep && ( pNeoWep->GetNeoWepBits() & NEO_WEP_BALC ) )
+		{
+			CWeaponBALC *pBalc = static_cast< CWeaponBALC * >( pNeoWep );
+			if ( pBalc->m_bOverheated )
+			{
+				return SuspendFor( new CNEOBotRetreatToCover(), "BALC overheated - retreating to cover!" );
+			}
+		}
+	}
+
 	ActionResult< CNEOBot > result = UpdateCommon( me, interval );
 	if ( result.IsRequestingChange() || result.IsDone() )
 		return result;

--- a/src/game/shared/neo/weapons/weapon_balc.cpp
+++ b/src/game/shared/neo/weapons/weapon_balc.cpp
@@ -194,8 +194,11 @@ void CWeaponBALC::ShootGrenade(CNEO_Player *pPlayer)
 	m_bCharged = false;
 
 	// View kick
-	pPlayer->ViewPunchReset();
-	AddViewKick();
+	if (!pPlayer->IsBot())
+	{
+		pPlayer->ViewPunchReset();
+		AddViewKick();
+	}
 }
 
 float CWeaponBALC::GetChargeDuration() const

--- a/src/game/shared/neo/weapons/weapon_balc.cpp
+++ b/src/game/shared/neo/weapons/weapon_balc.cpp
@@ -137,59 +137,70 @@ void CWeaponBALC::PrimaryAttack(void)
 		}
 
 		auto pPlayer = ToNEOPlayer(GetOwner());
-		if (!pPlayer)
-		{
-			Assert(false);
-			return;
-		}
+		ShootGrenade(pPlayer);
+	}
+}
 
-		if ((gpGlobals->curtime - m_flLastAttackTime) > 0.5f)
-		{
-			m_nNumShotsFired = 0;
-		}
-		else
-		{
-			++m_nNumShotsFired;
-		}
-		m_flLastAttackTime = gpGlobals->curtime;
+void CWeaponBALC::ShootGrenade(CNEO_Player *pPlayer)
+{
+	if (!pPlayer)
+	{
+		Assert(false);
+		return;
+	}
 
-		SendWeaponAnim(GetPrimaryAttackActivity());
-		SetWeaponIdleTime(gpGlobals->curtime + 2.0);
-		pPlayer->DoAnimationEvent(PLAYERANIMEVENT_ATTACK_PRIMARY);
+	if ((gpGlobals->curtime - m_flLastAttackTime) > 0.5f)
+	{
+		m_nNumShotsFired = 0;
+	}
+	else
+	{
+		++m_nNumShotsFired;
+	}
+	m_flLastAttackTime = gpGlobals->curtime;
 
-		WeaponSound(BURST);
+	SendWeaponAnim(GetPrimaryAttackActivity());
+	SetWeaponIdleTime(gpGlobals->curtime + 2.0);
+	pPlayer->DoAnimationEvent(PLAYERANIMEVENT_ATTACK_PRIMARY);
+
+	WeaponSound(BURST);
 
 #ifdef GAME_DLL
-		const Vector vecSrc = pPlayer->Weapon_ShootPosition();
-		Vector vecThrow;
+	const Vector vecSrc = pPlayer->Weapon_ShootPosition();
+	Vector vecThrow;
 
-		AngleVectors(pPlayer->EyeAngles() + pPlayer->GetPunchAngle(), &vecThrow);
-		VectorScale(vecThrow, 2000.0f, vecThrow);
+	AngleVectors(pPlayer->EyeAngles() + pPlayer->GetPunchAngle(), &vecThrow);
+	VectorScale(vecThrow, 2000.0f, vecThrow);
 
-		QAngle angles;
-		VectorAngles(vecThrow, angles);
-		CGrenadeAR2 *pGrenade = assert_cast<CGrenadeAR2*>(Create("grenade_ar2", vecSrc, angles, pPlayer));
-		pGrenade->SetAbsVelocity(vecThrow);
+	QAngle angles;
+	VectorAngles(vecThrow, angles);
+	CGrenadeAR2 *pGrenade = assert_cast<CGrenadeAR2 *>(Create("grenade_ar2", vecSrc, angles, pPlayer));
+	pGrenade->SetAbsVelocity(vecThrow);
 
-		pGrenade->SetLocalAngularVelocity(RandomAngle(-400, 400));
-		pGrenade->SetMoveType(MOVETYPE_FLYGRAVITY, MOVECOLLIDE_FLY_BOUNCE);
-		pGrenade->SetThrower(GetOwner());
-		pGrenade->SetDamage(BALC_CHARGE_SHOT_DAMAGE);
+	pGrenade->SetLocalAngularVelocity(RandomAngle(-400, 400));
+	pGrenade->SetMoveType(MOVETYPE_FLYGRAVITY, MOVECOLLIDE_FLY_BOUNCE);
+	pGrenade->SetThrower(GetOwner());
+	pGrenade->SetDamage(BALC_CHARGE_SHOT_DAMAGE);
 
-		CSoundEnt::InsertSound(SOUND_COMBAT, GetAbsOrigin(), 1000, 0.2, GetOwner(), SOUNDENT_CHANNEL_WEAPON);
+	CSoundEnt::InsertSound(SOUND_COMBAT, GetAbsOrigin(), 1000, 0.2, GetOwner(), SOUNDENT_CHANNEL_WEAPON);
+	pPlayer->OnMyWeaponFired(this); // to update GetTimeSinceWeaponFired
 #endif
-		const int iAmmoCost = int((GetDefaultClip1() + 10) / BALC_CHARGE_SHOT_MAX);
-		m_iPrimaryAmmoCount = Max(0, m_iPrimaryAmmoCount - iAmmoCost);
+	const int iAmmoCost = int((GetDefaultClip1() + 10) / BALC_CHARGE_SHOT_MAX);
+	m_iPrimaryAmmoCount = Max(0, m_iPrimaryAmmoCount - iAmmoCost);
 
-		m_flNextPrimaryAttack = m_flNextPrimaryAttack + BALC_CHARGE_SHOT_RATE;
+	m_flNextPrimaryAttack = gpGlobals->curtime + BALC_CHARGE_SHOT_RATE;
 
-		m_bCharging = false;
-		m_bCharged = false;
+	m_bCharging = false;
+	m_bCharged = false;
 
-		//View kick
-		pPlayer->ViewPunchReset();
-		AddViewKick();
-	}
+	// View kick
+	pPlayer->ViewPunchReset();
+	AddViewKick();
+}
+
+float CWeaponBALC::GetChargeDuration() const
+{
+	return BALC_CHARGE_DURATION;
 }
 
 void CWeaponBALC::SecondaryAttack(void)

--- a/src/game/shared/neo/weapons/weapon_balc.h
+++ b/src/game/shared/neo/weapons/weapon_balc.h
@@ -41,6 +41,8 @@ public:
 	virtual NEO_WEP_BITS_UNDERLYING_TYPE GetNeoWepBits(void) const override { return NEO_WEP_BALC | NEO_WEP_FIREARM; }
 	virtual int GetNeoWepXPCost(const int neoClass) const override { return 20; }
 	virtual void ItemPostFrame() override;
+	void ShootGrenade(CNEO_Player *pPlayer);
+	float GetChargeDuration() const;
 
 	virtual float GetSpeedScale(void) const OVERRIDE { return 1.0f; }
 


### PR DESCRIPTION
## Description
Exposed an interface to the BALC that allows firing the alt fire grenades without having to hold down a key, the latter action being quite difficult for bots to do consistently. Also added retreat logic for Juggernaut bots when their gun overheats, now that the secondary fire expends significant heat.

## Toolchain
- Windows MSVC VS2022
