### PR TITLE
Bots look out for grenades when retreating

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_from_grenade.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_from_grenade.cpp
@@ -226,7 +226,7 @@ ActionResult< CNEOBot >	CNEOBotRetreatFromGrenade::Update( CNEOBot *me, float in
 
 	if (!m_coverArea)
 	{
-		return SuspendFor(new CNEOBotRetreatToCover, "Reacting to contact instead");
+		return Done("Reacting to contact instead");
 	}
 
 	if ( me->GetLastKnownArea() != m_coverArea || !bIsExposed )

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
@@ -5,6 +5,7 @@
 #include "neo_smokelineofsightblocker.h"
 #include "bot/neo_bot.h"
 #include "bot/behavior/neo_bot_grenade_dispatch.h"
+#include "bot/behavior/neo_bot_retreat_from_grenade.h"
 #include "bot/behavior/neo_bot_retreat_to_cover.h"
 #include "bot/neo_bot_path_compute.h"
 
@@ -203,6 +204,17 @@ ActionResult< CNEOBot >	CNEOBotRetreatToCover::OnStart( CNEOBot *me, Action< CNE
 //---------------------------------------------------------------------------------------------
 ActionResult< CNEOBot >	CNEOBotRetreatToCover::Update( CNEOBot *me, float interval )
 {
+	if ( m_grenadeCheckTimer.IsElapsed() )
+	{
+		m_grenadeCheckTimer.Start( 0.2f );
+
+		CBaseEntity *dangerousGrenade = CNEOBotRetreatFromGrenade::FindDangerousGrenade( me );
+		if ( dangerousGrenade )
+		{
+			return SuspendFor( new CNEOBotRetreatFromGrenade( dangerousGrenade ), "Encountered grenade while retreating to cover!" );
+		}
+	}
+
 	const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat( true );
 
 	if (!threat)

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
@@ -211,7 +211,8 @@ ActionResult< CNEOBot >	CNEOBotRetreatToCover::Update( CNEOBot *me, float interv
 		CBaseEntity *dangerousGrenade = CNEOBotRetreatFromGrenade::FindDangerousGrenade( me );
 		if ( dangerousGrenade )
 		{
-			return SuspendFor( new CNEOBotRetreatFromGrenade( dangerousGrenade ), "Encountered grenade while retreating to cover!" );
+			// ChangeTo: Avoid behavior pingpong if grenade avoidance can't find cover
+			return ChangeTo( new CNEOBotRetreatFromGrenade( dangerousGrenade ), "Encountered grenade while retreating to cover!" );
 		}
 	}
 

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.h
@@ -25,6 +25,7 @@ private:
 	CountdownTimer m_repathTimer;
 
 	CNavArea *m_coverArea;
+	CountdownTimer m_grenadeCheckTimer;
 	CountdownTimer m_grenadeThrowCooldownTimer;
 	CountdownTimer m_waitInCoverTimer;
 


### PR DESCRIPTION
## Description
Bot tactical monitor behaviors can prevent the other behaviors from triggering, and while that mostly has limited consequence, this resulted in bots ignoring grenades when running for a cover spot during their retreat behavior.  This PR introduces the same grenade avoidance logic from tactical monitor into the retreat to cover behavior, so that bots can visibly react to grenades when they were running for cover.

## Toolchain
- Windows MSVC VS2022
