### PR TITLE
Suicides should also award assist points.

### DIFF
--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -3958,22 +3958,22 @@ void CNEORules::PlayerKilled(CBasePlayer *pVictim, const CTakeDamageInfo &info)
 			}
 #endif
 		}
+	}
 
-		if (auto *assister = FetchAssists(attacker, victim))
+	if (auto *assister = FetchAssists(attacker, victim))
+	{
+		// Team kill assist
+		if (assister->GetTeamNumber() == victim->GetTeamNumber())
 		{
-			// Team kill assist
-			if (assister->GetTeamNumber() == victim->GetTeamNumber())
+			if (sv_neo_teamdamage_assists.GetBool())
 			{
-				if (sv_neo_teamdamage_assists.GetBool())
-				{
-					assister->AddPoints(-1, true);
-				}
+				assister->AddPoints(-1, true);
 			}
-			// Enemy kill assist
-			else
-			{
-				assister->AddPoints(1, false);
-			}
+		}
+		// Enemy kill assist
+		else
+		{
+			assister->AddPoints(1, false);
 		}
 	}
 }


### PR DESCRIPTION
## Description
Move the awarding of assist points out of the `victim != attacker` if-block.

Note that the assister isn't indicated in the killfeed due to #1230.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 15.2.1 20260209

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- related #1230

