### PR TITLE
DebugDrawLine grenade trails for spectators and practicing

### DIFF
--- a/src/game/shared/sdk/sdk_basegrenade_projectile.cpp
+++ b/src/game/shared/sdk/sdk_basegrenade_projectile.cpp
@@ -164,7 +164,7 @@ ConVar cl_neo_grenade_show_path("cl_neo_grenade_show_path", "0", FCVAR_ARCHIVE |
 		if (m_vLastDrawPosition.DistToSqr(origin) < 0.1f)
 			return;
 
-		float r, g, b = 0;
+		float r = 0, g = 0, b = 0;
 		NEORules()->GetTeamGlowColor(GetTeamNumber(), r, g, b);
 		r *= 255;
 		g *= 255;
@@ -172,9 +172,9 @@ ConVar cl_neo_grenade_show_path("cl_neo_grenade_show_path", "0", FCVAR_ARCHIVE |
 		if (GetDamage())
 		{
 			const float timeAlive = (gpGlobals->curtime - m_flNeoCreateTime) * 0.5f;
-			r = Min(255.f, Max(0.f, r * (1 - timeAlive) + (255 * timeAlive)));
-			g = Max(0.f, g * (1 - timeAlive));
-			b = Max(0.f, b * (1 - timeAlive));
+			r = clamp(r * (1 - timeAlive) + (255.f * timeAlive), 0.f, 255.f);
+			g = clamp(g * (1 - timeAlive), 0.f, 255.f);
+			b = clamp(b * (1 - timeAlive), 0.f, 255.f);
 		}
 		DebugDrawLine(m_vLastDrawPosition, origin, r, g, b, true, showPathWhenServerEnabled ? sv_neo_grenade_show_path.GetFloat() : cl_neo_grenade_show_path.GetFloat());
 		m_vLastDrawPosition = origin;

--- a/src/game/shared/sdk/sdk_basegrenade_projectile.h
+++ b/src/game/shared/sdk/sdk_basegrenade_projectile.h
@@ -71,7 +71,7 @@ public:
 	{
 		CBaseEntity *pRecipientEntity = CBaseEntity::Instance( pInfo->m_pClientEnt );
 
-		if ( pRecipientEntity->GetTeamNumber() == TEAM_SPECTATOR ) 
+		if ( pRecipientEntity && pRecipientEntity->GetTeamNumber() == TEAM_SPECTATOR ) 
 		{
 			const char* wantsToSeeProjectilePath = engine->GetClientConVarValue(pRecipientEntity->entindex(), "cl_neo_grenade_show_path");
 			if (wantsToSeeProjectilePath && *wantsToSeeProjectilePath && (V_atof(wantsToSeeProjectilePath) != 0.f))


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->
Contrary to the name of the branch, all that we do server side is make sure the grenade projectile is transmitted to all players who want to see it, those being all spectators with cl_neo_grenade_show_path set to a value greater than 0, or everyone in the case of the cheat protected convar sv_neo_grenade_show_path being set to a value greater than 0. New segments of the path are added client side in the grenade projectile client think function.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022