### PR TITLE
Fix spec_next/prev not skipping dead players in demos

### DIFF
--- a/src/game/client/hltvcamera.cpp
+++ b/src/game/client/hltvcamera.cpp
@@ -642,6 +642,10 @@ void C_HLTVCamera::SpecNextPlayer( bool bInverse )
 			continue;
 
 		// only follow living players 
+#ifdef NEO
+		if ( pPlayer->IsPlayerDead() )
+			continue;
+#endif
 		if ( pPlayer->IsObserver() )
 			continue;
 


### PR DESCRIPTION
## Description
Fix a case where in server demos, spec_next/spec_prev does not correctly skip dead players.

The current behaviour is technically parity, but the beacons overlay tool we've been using for OGNT demo casts has a patch to fix this, so I guess by a loose definition this would be plugin-parity.

## Steps to reproduce

```
tv_enable 1;
tv_autorecord 1;
neo_bot_quota 10;
map ntre_dawn_ctg;
jointeam 0;

// Then let it record until some bots die, and then:

disconnect;
playdemo <name_of_demo>;
```
Then, while the demo is playing, pause once there are some dead bots in the field and try going through the player list with mouse1 or mouse2.

### What happens
Some of the dead players are being spectated in chase cam

### What should happen
The dead players are skipped


## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #
- related #

