### PR TITLE
minimum damage after penetration linear with damage before each penetration

### DIFF
--- a/src/game/shared/baseentity_shared.cpp
+++ b/src/game/shared/baseentity_shared.cpp
@@ -2355,7 +2355,7 @@ void CBaseEntity::HandleShotPenetration(const FireBulletsInfo_t& info,
 	behindMaterialInfo.m_flDistance = info.m_flDistance * (1.0f - tr.fraction);
 	behindMaterialInfo.m_iAmmoType = info.m_iAmmoType;
 	behindMaterialInfo.m_iTracerFreq = info.m_iTracerFreq;
-	behindMaterialInfo.m_flDamage = info.m_flDamage * (1.f - (penUsed / info.m_flPenetration));
+	behindMaterialInfo.m_flDamage = info.m_flDamage * Max(0.25f, (1.f - (penUsed / info.m_flPenetration)));
 	behindMaterialInfo.m_pAttacker = info.m_pAttacker ? info.m_pAttacker : this;
 	behindMaterialInfo.m_nFlags = info.m_nFlags;
 	behindMaterialInfo.m_flPenetration = info.m_flPenetration - penUsed;


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

We don't want bullets with miniscule amounts of damage flying around. When a player sees a blood splatter that should mean that a somewhat significant amount of damage is being done. This makes sure the damage after a bullet exits a surface is at least a quarter of the damage before entering that surface, in line with ognt as suggested by Ochii's decompile

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1866
