### PR TITLE
remove noclip ground glide when player noclipping

### DIFF
--- a/src/game/shared/gamemovement.cpp
+++ b/src/game/shared/gamemovement.cpp
@@ -4034,12 +4034,6 @@ void CGameMovement::CategorizePosition( void )
 	if ( player->IsObserver() )
 		return;
 
-#ifdef NEO
-	// don't glide along the ground when noclipping as a player
-	if (player->GetMoveType() == MOVETYPE_NOCLIP)
-		return;
-
-#endif // NEO
 	float flOffset = 2.0f;
 
 	point[0] = mv->GetAbsOrigin()[0];
@@ -4103,11 +4097,19 @@ void CGameMovement::CategorizePosition( void )
 			}
 			else
 			{
+#ifdef NEO
+				// don't glide along a slope when noclipping as a player
+				if (player->GetMoveType() != MOVETYPE_NOCLIP)
+#endif // NEO
 				SetGroundEntity( &pm );
 			}
 		}
 		else
 		{
+#ifdef NEO
+			// don't glide along the ground when noclipping as a player
+			if (player->GetMoveType() != MOVETYPE_NOCLIP)
+#endif // NEO
 			SetGroundEntity( &pm );  // Otherwise, point to index of ent under us.
 		}
 


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Doesn't set the ground entity for players who are noclipping.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1872
