### PR TITLE
`sv_neo_restore_...` - Give XP/deaths to players, restore from backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ out
 /game/neo/cfg/config.cfg
 /game/neo/cfg/rain.cfg
 
+# Match session restore file
+/game/neo/scripts/match_session_restore_point.txt
+
 # Shader state debug image dumps
 /game/neo/*.tga
 

--- a/src/game/server/CMakeLists.txt
+++ b/src/game/server/CMakeLists.txt
@@ -1447,6 +1447,7 @@ set(UNITY_SOURCE_NEO_SRC_SERVER
     neo/neo_te_tocflash.cpp
     neo/neo_typeconverter.cpp
     neo/neo_dm_spawn.cpp
+    neo/neo_gamerules_restore.cpp
 )
 
 set_source_files_properties(
@@ -1497,6 +1498,7 @@ target_sources_grouped(
     neo/neo_te_tocflash.h
     neo/neo_tracefilter_collisiongroupdelta.h
     neo/neo_dm_spawn.h
+    neo/neo_gamerules_restore.h
     ${UNITY_SOURCE_NEO_SRC_SERVER}
 )
 

--- a/src/game/server/neo/neo_gamerules_restore.cpp
+++ b/src/game/server/neo/neo_gamerules_restore.cpp
@@ -1,0 +1,431 @@
+#include "neo_gamerules_restore.h"
+
+#include "cbase.h"
+#include "convar.h"
+#include "KeyValues.h"
+#include "filesystem.h"
+#include "neo_gamerules.h"
+
+#include <ctime>
+
+#define GIVEXP_SESSION_RESTORE_FNAME "match_session_restore_point.txt"
+#define GIVEXP_SESSION_RESTORE_KV_ROOT "neo_match_session"
+
+static ConVar sv_neo_restore_xp_death_any_round("sv_neo_restore_xp_death_any_round", "0",
+		FCVAR_REPLICATED | FCVAR_CHEAT | FCVAR_DONTRECORD,
+		"Permit giving XP at any round rather than restricting to only readyup stage",
+		true, 0.0f, true, 1.0f);
+
+static ConVar sv_neo_restore_session_allow_name_match("sv_neo_restore_session_allow_name_match", "0",
+		FCVAR_REPLICATED | FCVAR_DONTRECORD,
+		"Permit restoring session with matching players name",
+		true, 0.0f, true, 1.0f);
+
+extern ConVar sv_neo_readyup_lobby;
+extern ConVar sv_neo_comp;
+
+static inline bool InReadyUpState()
+{
+	return (sv_neo_readyup_lobby.GetBool() && NEORules()->GetRoundStatus() == NeoRoundStatus::Idle);
+}
+
+static inline bool InLiveState()
+{
+	return (NEORules()->GetRoundStatus() == RoundLive || NEORules()->GetRoundStatus() == PostRound);
+}
+
+static void RestoreSetRoundNumber(const int iRoundNumber, const char *pszFuncName)
+{
+	if (iRoundNumber < 0)
+	{
+		Msg("%s: error: Cannot have negative round number\n", pszFuncName);
+		return;
+	}
+
+	NEORules()->SetRoundNumber(iRoundNumber);
+	if (InReadyUpState() || InLiveState())
+	{
+		NEORules()->m_iNextRestore.iRoundNumber = iRoundNumber;
+		NEORules()->m_iNextRestore.flags |= NEXT_ROUND_GAMERULE_RESTORE_FLAG_ROUND_NUMBER;
+	}
+	else
+	{
+		NEORules()->m_iNextRestore.flags &= ~(NEXT_ROUND_GAMERULE_RESTORE_FLAG_ROUND_NUMBER);
+	}
+
+	Msg("%s: Round number set %d\n", pszFuncName, NEORules()->roundNumber());
+}
+
+static void RestoreSetRoundsWon(const int iRoundsWonJinrai, const int iRoundsWonNSF, const char *pszFuncName)
+{
+	if (iRoundsWonJinrai < 0 || iRoundsWonNSF < 0)
+	{
+		Msg("%s: error: Cannot have negative rounds won\n", pszFuncName);
+		return;
+	}
+
+	GetGlobalTeam(TEAM_JINRAI)->SetRoundsWon(iRoundsWonJinrai);
+	GetGlobalTeam(TEAM_NSF)->SetRoundsWon(iRoundsWonNSF);
+	if (InReadyUpState() || InLiveState())
+	{
+		NEORules()->m_iNextRestore.iRoundsWonJinrai = iRoundsWonJinrai;
+		NEORules()->m_iNextRestore.iRoundsWonNSF = iRoundsWonNSF;
+		NEORules()->m_iNextRestore.flags |= NEXT_ROUND_GAMERULE_RESTORE_FLAG_ROUNDSWONS;
+	}
+	else
+	{
+		NEORules()->m_iNextRestore.flags &= ~(NEXT_ROUND_GAMERULE_RESTORE_FLAG_ROUNDSWONS);
+	}
+
+	Msg("%s: Rounds won set: Jinrai %d, NSF %d\n",
+			pszFuncName,
+			GetGlobalTeam(TEAM_JINRAI)->GetRoundsWon(),
+			GetGlobalTeam(TEAM_NSF)->GetRoundsWon());
+}
+
+static void RestoreSetScore(const int iScoreJinrai, const int iScoreNSF, const char *pszFuncName)
+{
+	GetGlobalTeam(TEAM_JINRAI)->SetScore(iScoreJinrai);
+	GetGlobalTeam(TEAM_NSF)->SetScore(iScoreNSF);
+	if (InReadyUpState() || InLiveState())
+	{
+		NEORules()->m_iNextRestore.iScoreJinrai = iScoreJinrai;
+		NEORules()->m_iNextRestore.iScoreNSF = iScoreNSF;
+		NEORules()->m_iNextRestore.flags |= NEXT_ROUND_GAMERULE_RESTORE_FLAG_SCORES;
+	}
+	else
+	{
+		NEORules()->m_iNextRestore.flags &= ~(NEXT_ROUND_GAMERULE_RESTORE_FLAG_SCORES);
+	}
+
+	Msg("%s: Score set Jinrai %d, NSF %d\n",
+			pszFuncName,
+			GetGlobalTeam(TEAM_JINRAI)->GetScore(), GetGlobalTeam(TEAM_NSF)->GetScore());
+}
+
+// NEO NOTE (nullsystem): If iDeaths < 0, it won't be set
+static void RestoreSetXPDeath(CNEO_Player *pNeoPlayer, const int iXP, const int iDeaths,
+		const char *pszFuncName)
+{
+	if (false == InLiveState())
+	{
+		pNeoPlayer->m_iXP.Set(iXP);
+		if (iDeaths >= 0)
+		{
+			pNeoPlayer->ResetDeathCount();
+			pNeoPlayer->IncrementDeathCount(iDeaths);
+		}
+	}
+
+	if (InReadyUpState() || InLiveState())
+	{
+		pNeoPlayer->m_iNextRestore.iXP = iXP;
+		pNeoPlayer->m_iNextRestore.flags |= NEXT_ROUND_PLAYER_RESTORE_FLAG_XP;
+		if (iDeaths >= 0)
+		{
+			pNeoPlayer->m_iNextRestore.iDeaths = iDeaths;
+			pNeoPlayer->m_iNextRestore.flags |= NEXT_ROUND_PLAYER_RESTORE_FLAG_DEATH;
+		}
+		else
+		{
+			pNeoPlayer->m_iNextRestore.flags &= ~(NEXT_ROUND_PLAYER_RESTORE_FLAG_DEATH);
+		}
+	}
+	else
+	{
+		pNeoPlayer->m_iNextRestore.flags &=
+				~(NEXT_ROUND_PLAYER_RESTORE_FLAG_XP | NEXT_ROUND_PLAYER_RESTORE_FLAG_DEATH);
+	}
+
+	if (iDeaths >= 0)
+	{
+		Msg("%s: Given %d XP and %d deaths to %s%s\n", pszFuncName, iXP, iDeaths,
+				pNeoPlayer->GetNeoPlayerName(), InLiveState() ? " next round" : "");
+	}
+	else
+	{
+		Msg("%s: Given %d XP to %s%s\n", pszFuncName, iXP,
+				pNeoPlayer->GetNeoPlayerName(), InLiveState() ? " next round" : "");
+	}
+}
+
+CON_COMMAND(sv_neo_restore_session, "Restore the previous session")
+{
+	if (false == sv_neo_restore_xp_death_any_round.GetBool() && false == InReadyUpState())
+	{
+		Msg("%s: error: Cannot set XPs if not idle and in a ready up lobby\n", __func__);
+		return;
+	}
+
+	KeyValues *kv = new KeyValues(GIVEXP_SESSION_RESTORE_KV_ROOT);
+	if (false == kv->LoadFromFile(g_pFullFileSystem, "scripts/" GIVEXP_SESSION_RESTORE_FNAME))
+	{
+		Msg("%s: error: No restore session file found\n", __func__);
+		kv->deleteThis();
+		return;
+	}
+
+	if (KeyValues *kvInfo = kv->FindKey("info"))
+	{
+		const char *pszInfileMap = kvInfo->GetString("map");
+		const char *pszCurMap = gpGlobals->mapname.ToCStr();
+		if (0 != V_strcmp(pszInfileMap, pszCurMap))
+		{
+			Msg("%s: Will not restore since map session differs: in file %s vs current %s\n",
+					__func__, pszInfileMap, pszCurMap);
+			kv->deleteThis();
+			return;
+		}
+	}
+
+	if (KeyValues *kvScore = kv->FindKey("score"))
+	{
+		RestoreSetScore(kvScore->GetInt("jinrai"), kvScore->GetInt("nsf"), __func__);
+	}
+
+	if (KeyValues *kvRounds = kv->FindKey("rounds"))
+	{
+		RestoreSetRoundNumber(kvRounds->GetInt("number"), __func__);
+		RestoreSetRoundsWon(kvRounds->GetInt("jinrai"), kvRounds->GetInt("nsf"), __func__);
+	}
+
+	if (KeyValues *kvPlayersList = kv->FindKey("players_list"))
+	{
+		for (KeyValues *kvPlayer = kvPlayersList->GetFirstTrueSubKey();
+				kvPlayer;
+				kvPlayer = kvPlayer->GetNextTrueSubKey())
+		{
+			if (0 != V_strcmp(kvPlayer->GetName(), "player"))
+			{
+				continue;
+			}
+
+			CNEO_Player *pNeoPlayerUpdate = nullptr;
+
+			const char *pszSteamID3 = kvPlayer->GetString("steamid3");
+			const char *pszName = kvPlayer->GetString("name");
+
+			CSteamID fileSteamID;
+			if (fileSteamID.SetFromStringStrict(pszSteamID3, k_EUniversePublic)
+					&& fileSteamID.IsValid())
+			{
+				for (int i = 1; i <= gpGlobals->maxClients; i++)
+				{
+					auto pNeoPlayer = static_cast<CNEO_Player *>(UTIL_PlayerByIndex(i));
+					if (pNeoPlayer && false == pNeoPlayer->IsBot())
+					{
+						const CSteamID playerSteamID = GetSteamIDForPlayerIndex(pNeoPlayer->entindex());
+						if (playerSteamID.IsValid() && playerSteamID == fileSteamID)
+						{
+							pNeoPlayerUpdate = pNeoPlayer;
+							break;
+						}
+					}
+				}
+			}
+
+			if (sv_neo_restore_session_allow_name_match.GetBool() && nullptr == pNeoPlayerUpdate)
+			{
+				for (int i = 1; i <= gpGlobals->maxClients; i++)
+				{
+					auto pNeoPlayer = static_cast<CNEO_Player *>(UTIL_PlayerByIndex(i));
+					if (pNeoPlayer && 0 == V_strcmp(pNeoPlayer->GetNeoPlayerName(), pszName))
+					{
+						pNeoPlayerUpdate = pNeoPlayer;
+						break;
+					}
+				}
+			}
+
+			if (pNeoPlayerUpdate)
+			{
+				// Only readyup state can set full session restore
+				const int iXP = kvPlayer->GetInt("xp");
+				const int iDeaths = kvPlayer->GetInt("deaths");
+				RestoreSetXPDeath(pNeoPlayerUpdate, iXP, iDeaths, __func__);
+			}
+			else
+			{
+				Msg("%s: Player steamID: %s, name: %s skipped: not found\n",
+						__func__, pszSteamID3, pszName);
+			}
+		}
+	}
+
+	kv->deleteThis();
+}
+
+void MatchSessionBackup()
+{
+	// Match session backup only used for competitive mode
+	if (false == sv_neo_comp.GetBool())
+	{
+		return;
+	}
+
+	char szDateTime[32] = {};
+	KeyValues *kv = new KeyValues(GIVEXP_SESSION_RESTORE_KV_ROOT);
+
+	{
+		KeyValues *kvInfo = new KeyValues("info");
+		kvInfo->SetString("map", gpGlobals->mapname.ToCStr());
+		{
+			// Time is not de-serialized on read, mainly descriptive
+			const time_t timeVal = time(nullptr);
+			std::tm tmd{};
+			Plat_localtime(&timeVal, &tmd);
+			V_sprintf_safe(szDateTime, "%04d-%02d-%02d %02d:%02d:%02d",
+					tmd.tm_year + 1900, tmd.tm_mon + 1, tmd.tm_mday,
+					tmd.tm_hour, tmd.tm_min, tmd.tm_sec);
+			kvInfo->SetString("datetime", szDateTime);
+		}
+		kv->AddSubKey(kvInfo);
+	}
+
+	{
+		KeyValues *kvScore = new KeyValues("score");
+		kvScore->SetInt("jinrai", GetGlobalTeam(TEAM_JINRAI)->GetScore());
+		kvScore->SetInt("nsf", GetGlobalTeam(TEAM_NSF)->GetScore());
+		kv->AddSubKey(kvScore);
+	}
+
+	{
+		KeyValues *kvRounds = new KeyValues("rounds");
+		kvRounds->SetInt("number", NEORules()->roundNumber());
+		kvRounds->SetInt("jinrai", GetGlobalTeam(TEAM_JINRAI)->GetRoundsWon());
+		kvRounds->SetInt("nsf", GetGlobalTeam(TEAM_NSF)->GetRoundsWon());
+		kv->AddSubKey(kvRounds);
+	}
+
+	{
+		KeyValues *kvPlayersList = new KeyValues("players_list");
+		for (int i = 1; i <= gpGlobals->maxClients; i++)
+		{
+			auto pNeoPlayer = static_cast<CNEO_Player *>(UTIL_PlayerByIndex(i));
+			if (pNeoPlayer
+					&& (pNeoPlayer->GetTeamNumber() == TEAM_JINRAI
+						|| pNeoPlayer->GetTeamNumber() == TEAM_NSF))
+			{
+				KeyValues *kvPlayer = new KeyValues("player");
+				kvPlayer->SetInt("xp", pNeoPlayer->m_iXP.Get());
+				kvPlayer->SetInt("deaths", pNeoPlayer->DeathCount());
+				// team - Unused on de-serialization as steamid3 is enough, but have descriptive purpose
+				kvPlayer->SetString("team", (pNeoPlayer->GetTeamNumber() == TEAM_JINRAI) ? "j" : "n");
+				// name - Always set regardless of sv_neo_restore_session_name_match, have a descriptive
+				//        purpose when looking inside the file
+				kvPlayer->SetString("name", pNeoPlayer->GetNeoPlayerName());
+				{
+					const CSteamID playerSteamID = GetSteamIDForPlayerIndex(pNeoPlayer->entindex());
+					if (playerSteamID.IsValid())
+					{
+						kvPlayer->SetString("steamid3", playerSteamID.Render());
+					}
+				}
+				kvPlayersList->AddSubKey(kvPlayer);
+			}
+		}
+		kv->AddSubKey(kvPlayersList);
+	}
+
+	if (kv->SaveToFile(g_pFullFileSystem, "scripts/" GIVEXP_SESSION_RESTORE_FNAME))
+	{
+		Msg("Session backed up at %s\n", szDateTime);
+	}
+	else
+	{
+		Msg("Session backup failed to save at %s!\n", szDateTime);
+	}
+
+	kv->deleteThis();
+}
+
+CON_COMMAND(sv_neo_restore_round_number, "Set the next round number")
+{
+	if (2 != args.ArgC())
+	{
+		Msg("Usage: %s <round number>\n", __func__);
+		return;
+	}
+
+	const int iRoundNumber = V_atoi(args[1]);
+	RestoreSetRoundNumber(iRoundNumber, __func__);
+}
+
+CON_COMMAND(sv_neo_restore_rounds_won, "Set the rounds won")
+{
+	if (3 != args.ArgC())
+	{
+		Msg("Usage: %s <jinrai won> <nsf won>\n", __func__);
+		return;
+	}
+
+	const int iRoundsWonJinrai = V_atoi(args[1]);
+	const int iRoundsWonNSF = V_atoi(args[2]);
+	RestoreSetRoundsWon(iRoundsWonJinrai, iRoundsWonNSF, __func__);
+}
+
+CON_COMMAND(sv_neo_restore_team_scores, "Set the scores for each team (not used in CTG, use sv_neo_restore_rounds_won)")
+{
+	if (3 != args.ArgC())
+	{
+		Msg("Usage: %s <jinrai score> <nsf score>\n", __func__);
+		return;
+	}
+
+	const int iJinraiScore = V_atoi(args[1]);
+	const int iNSFScore = V_atoi(args[2]);
+	RestoreSetScore(iJinraiScore, iNSFScore, __func__);
+}
+
+CON_COMMAND(sv_neo_restore_xp, "Give a player XP (and death) count")
+{
+	static constexpr const char SZ_COMMON_USAGE_PF[] = "Usage: %s <player argument> <xp> <deaths (optional)>\n";
+
+	if (!IN_BETWEEN_EQ(3, args.ArgC(), 4))
+	{
+		Msg(SZ_COMMON_USAGE_PF, __func__);
+		return;
+	}
+
+	const char *pszNameFind = args[1];
+	const int iXP = V_atoi(args[2]);
+	if (false == IN_BETWEEN_EQ(-99, iXP, 1000))
+	{
+		Msg("%s: error: Unreasonable XP\n", __func__);
+		return;
+	}
+
+	const int iDeaths = (args.ArgC() == 4) ? V_atoi(args[3]) : -1;
+	if (4 == args.ArgC() && false == IN_BETWEEN_EQ(0, iDeaths, 1000))
+	{
+		Msg((iDeaths < 0)
+				? "%s: error: Death count must be positive\n"
+				: "%s: error: Unresonable death count\n"
+				, __func__);
+		Msg(SZ_COMMON_USAGE_PF, __func__);
+		return;
+	}
+
+	if (false == sv_neo_restore_xp_death_any_round.GetBool() && false == InReadyUpState())
+	{
+		Msg("%s: error: Cannot set XPs if not idle and in a ready up lobby\n", __func__);
+		return;
+	}
+
+	for (int i = 1; i <= gpGlobals->maxClients; ++i)
+	{
+		auto pNeoPlayer = static_cast<CNEO_Player*>(UTIL_PlayerByIndex(i));
+		if (pNeoPlayer)
+		{
+			const char *pszNameCmp = pNeoPlayer->GetNeoPlayerName();
+			if (0 == V_strcmp(pszNameCmp, pszNameFind))
+			{
+				RestoreSetXPDeath(pNeoPlayer, iXP, iDeaths, __func__);
+				return;
+			}
+		}
+	}
+
+	Msg("%s: error: Cannot find player \"%s\"\n", __func__, pszNameFind);
+}
+

--- a/src/game/server/neo/neo_gamerules_restore.cpp
+++ b/src/game/server/neo/neo_gamerules_restore.cpp
@@ -21,29 +21,18 @@ static ConVar sv_neo_restore_session_allow_name_match("sv_neo_restore_session_al
 		"Permit restoring session with matching players name",
 		true, 0.0f, true, 1.0f);
 
-extern ConVar sv_neo_readyup_lobby;
 extern ConVar sv_neo_comp;
-
-static inline bool InReadyUpState()
-{
-	return (sv_neo_readyup_lobby.GetBool() && NEORules()->GetRoundStatus() == NeoRoundStatus::Idle);
-}
-
-static inline bool InLiveState()
-{
-	return (NEORules()->GetRoundStatus() == RoundLive || NEORules()->GetRoundStatus() == PostRound);
-}
 
 static void RestoreSetRoundNumber(const int iRoundNumber, const char *pszFuncName)
 {
 	if (iRoundNumber < 0)
 	{
-		Msg("%s: error: Cannot have negative round number\n", pszFuncName);
+		Warning("%s: error: Cannot have negative round number\n", pszFuncName);
 		return;
 	}
 
 	NEORules()->SetRoundNumber(iRoundNumber);
-	if (InReadyUpState() || InLiveState())
+	if (NEORules()->InReadyUpState() || NEORules()->InRoundState())
 	{
 		NEORules()->m_iNextRestore.iRoundNumber = iRoundNumber;
 		NEORules()->m_iNextRestore.flags |= NEXT_ROUND_GAMERULE_RESTORE_FLAG_ROUND_NUMBER;
@@ -60,13 +49,13 @@ static void RestoreSetRoundsWon(const int iRoundsWonJinrai, const int iRoundsWon
 {
 	if (iRoundsWonJinrai < 0 || iRoundsWonNSF < 0)
 	{
-		Msg("%s: error: Cannot have negative rounds won\n", pszFuncName);
+		Warning("%s: error: Cannot have negative rounds won\n", pszFuncName);
 		return;
 	}
 
 	GetGlobalTeam(TEAM_JINRAI)->SetRoundsWon(iRoundsWonJinrai);
 	GetGlobalTeam(TEAM_NSF)->SetRoundsWon(iRoundsWonNSF);
-	if (InReadyUpState() || InLiveState())
+	if (NEORules()->InReadyUpState() || NEORules()->InRoundState())
 	{
 		NEORules()->m_iNextRestore.iRoundsWonJinrai = iRoundsWonJinrai;
 		NEORules()->m_iNextRestore.iRoundsWonNSF = iRoundsWonNSF;
@@ -87,7 +76,7 @@ static void RestoreSetScore(const int iScoreJinrai, const int iScoreNSF, const c
 {
 	GetGlobalTeam(TEAM_JINRAI)->SetScore(iScoreJinrai);
 	GetGlobalTeam(TEAM_NSF)->SetScore(iScoreNSF);
-	if (InReadyUpState() || InLiveState())
+	if (NEORules()->InReadyUpState() || NEORules()->InRoundState())
 	{
 		NEORules()->m_iNextRestore.iScoreJinrai = iScoreJinrai;
 		NEORules()->m_iNextRestore.iScoreNSF = iScoreNSF;
@@ -107,7 +96,7 @@ static void RestoreSetScore(const int iScoreJinrai, const int iScoreNSF, const c
 static void RestoreSetXPDeath(CNEO_Player *pNeoPlayer, const int iXP, const int iDeaths,
 		const char *pszFuncName)
 {
-	if (false == InLiveState())
+	if (false == NEORules()->InRoundState())
 	{
 		pNeoPlayer->m_iXP.Set(iXP);
 		if (iDeaths >= 0)
@@ -117,7 +106,7 @@ static void RestoreSetXPDeath(CNEO_Player *pNeoPlayer, const int iXP, const int 
 		}
 	}
 
-	if (InReadyUpState() || InLiveState())
+	if (NEORules()->InReadyUpState() || NEORules()->InRoundState())
 	{
 		pNeoPlayer->m_iNextRestore.iXP = iXP;
 		pNeoPlayer->m_iNextRestore.flags |= NEXT_ROUND_PLAYER_RESTORE_FLAG_XP;
@@ -140,27 +129,27 @@ static void RestoreSetXPDeath(CNEO_Player *pNeoPlayer, const int iXP, const int 
 	if (iDeaths >= 0)
 	{
 		Msg("%s: Given %d XP and %d deaths to %s%s\n", pszFuncName, iXP, iDeaths,
-				pNeoPlayer->GetNeoPlayerName(), InLiveState() ? " next round" : "");
+				pNeoPlayer->GetNeoPlayerName(), NEORules()->InRoundState() ? " next round" : "");
 	}
 	else
 	{
 		Msg("%s: Given %d XP to %s%s\n", pszFuncName, iXP,
-				pNeoPlayer->GetNeoPlayerName(), InLiveState() ? " next round" : "");
+				pNeoPlayer->GetNeoPlayerName(), NEORules()->InRoundState() ? " next round" : "");
 	}
 }
 
 CON_COMMAND(sv_neo_restore_session, "Restore the previous session")
 {
-	if (false == sv_neo_restore_xp_death_any_round.GetBool() && false == InReadyUpState())
+	if (false == sv_neo_restore_xp_death_any_round.GetBool() && false == NEORules()->InReadyUpState())
 	{
-		Msg("%s: error: Cannot set XPs if not idle and in a ready up lobby\n", __func__);
+		Warning("%s: error: Cannot set XPs if not idle and in a ready up lobby\n", __func__);
 		return;
 	}
 
 	KeyValues *kv = new KeyValues(GIVEXP_SESSION_RESTORE_KV_ROOT);
 	if (false == kv->LoadFromFile(g_pFullFileSystem, "scripts/" GIVEXP_SESSION_RESTORE_FNAME))
 	{
-		Msg("%s: error: No restore session file found\n", __func__);
+		Warning("%s: error: No restore session file found\n", __func__);
 		kv->deleteThis();
 		return;
 	}
@@ -171,7 +160,7 @@ CON_COMMAND(sv_neo_restore_session, "Restore the previous session")
 		const char *pszCurMap = gpGlobals->mapname.ToCStr();
 		if (0 != V_strcmp(pszInfileMap, pszCurMap))
 		{
-			Msg("%s: Will not restore since map session differs: in file %s vs current %s\n",
+			Warning("%s: Will not restore since map session differs: in file %s vs current %s\n",
 					__func__, pszInfileMap, pszCurMap);
 			kv->deleteThis();
 			return;
@@ -246,7 +235,7 @@ CON_COMMAND(sv_neo_restore_session, "Restore the previous session")
 			}
 			else
 			{
-				Msg("%s: Player steamID: %s, name: %s skipped: not found\n",
+				Warning("%s: Player steamID: %s, name: %s skipped: not found\n",
 						__func__, pszSteamID3, pszName);
 			}
 		}
@@ -333,7 +322,7 @@ void MatchSessionBackup()
 	}
 	else
 	{
-		Msg("Session backup failed to save at %s!\n", szDateTime);
+		Warning("Session backup failed to save at %s!\n", szDateTime);
 	}
 
 	kv->deleteThis();
@@ -343,7 +332,7 @@ CON_COMMAND(sv_neo_restore_round_number, "Set the next round number")
 {
 	if (2 != args.ArgC())
 	{
-		Msg("Usage: %s <round number>\n", __func__);
+		Warning("Usage: %s <round number>\n", __func__);
 		return;
 	}
 
@@ -355,7 +344,7 @@ CON_COMMAND(sv_neo_restore_rounds_won, "Set the rounds won")
 {
 	if (3 != args.ArgC())
 	{
-		Msg("Usage: %s <jinrai won> <nsf won>\n", __func__);
+		Warning("Usage: %s <jinrai won> <nsf won>\n", __func__);
 		return;
 	}
 
@@ -368,7 +357,7 @@ CON_COMMAND(sv_neo_restore_team_scores, "Set the scores for each team (not used 
 {
 	if (3 != args.ArgC())
 	{
-		Msg("Usage: %s <jinrai score> <nsf score>\n", __func__);
+		Warning("Usage: %s <jinrai score> <nsf score>\n", __func__);
 		return;
 	}
 
@@ -383,32 +372,23 @@ CON_COMMAND(sv_neo_restore_xp, "Give a player XP (and death) count")
 
 	if (!IN_BETWEEN_EQ(3, args.ArgC(), 4))
 	{
-		Msg(SZ_COMMON_USAGE_PF, __func__);
+		Warning(SZ_COMMON_USAGE_PF, __func__);
 		return;
 	}
 
 	const char *pszNameFind = args[1];
 	const int iXP = V_atoi(args[2]);
-	if (false == IN_BETWEEN_EQ(-99, iXP, 1000))
-	{
-		Msg("%s: error: Unreasonable XP\n", __func__);
-		return;
-	}
-
 	const int iDeaths = (args.ArgC() == 4) ? V_atoi(args[3]) : -1;
-	if (4 == args.ArgC() && false == IN_BETWEEN_EQ(0, iDeaths, 1000))
+	if (4 == args.ArgC() && (iDeaths < 0))
 	{
-		Msg((iDeaths < 0)
-				? "%s: error: Death count must be positive\n"
-				: "%s: error: Unresonable death count\n"
-				, __func__);
-		Msg(SZ_COMMON_USAGE_PF, __func__);
+		Warning("%s: error: Death count must be positive\n", __func__);
+		Warning(SZ_COMMON_USAGE_PF, __func__);
 		return;
 	}
 
-	if (false == sv_neo_restore_xp_death_any_round.GetBool() && false == InReadyUpState())
+	if (false == sv_neo_restore_xp_death_any_round.GetBool() && false == NEORules()->InReadyUpState())
 	{
-		Msg("%s: error: Cannot set XPs if not idle and in a ready up lobby\n", __func__);
+		Warning("%s: error: Cannot set XPs if not idle and in a ready up lobby\n", __func__);
 		return;
 	}
 
@@ -426,6 +406,6 @@ CON_COMMAND(sv_neo_restore_xp, "Give a player XP (and death) count")
 		}
 	}
 
-	Msg("%s: error: Cannot find player \"%s\"\n", __func__, pszNameFind);
+	Warning("%s: error: Cannot find player \"%s\"\n", __func__, pszNameFind);
 }
 

--- a/src/game/server/neo/neo_gamerules_restore.h
+++ b/src/game/server/neo/neo_gamerules_restore.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// Both Jinrai and NSF scores and rounds won are set together
+enum NextRoundGameruleRestoreFlag_
+{
+	NEXT_ROUND_GAMERULE_RESTORE_FLAG_NIL = 0,
+	NEXT_ROUND_GAMERULE_RESTORE_FLAG_SCORES = 1 << 0,
+	NEXT_ROUND_GAMERULE_RESTORE_FLAG_ROUND_NUMBER = 1 << 1,
+	NEXT_ROUND_GAMERULE_RESTORE_FLAG_ROUNDSWONS = 1 << 2,
+};
+typedef int NextRoundGameruleRestoreFlags;
+
+enum NextRoundPlayerRestoreFlag_
+{
+	NEXT_ROUND_PLAYER_RESTORE_FLAG_NIL = 0,
+	NEXT_ROUND_PLAYER_RESTORE_FLAG_XP = 1 << 0,
+	NEXT_ROUND_PLAYER_RESTORE_FLAG_DEATH = 1 << 1,
+};
+typedef int NextRoundPlayerRestoreFlags;
+
+// Backup current match state to disk
+void MatchSessionBackup();
+

--- a/src/game/server/neo/neo_player.h
+++ b/src/game/server/neo/neo_player.h
@@ -14,6 +14,7 @@ class INEOPlayerAnimState;
 #include "hl2mp_player.h"
 #include "in_buttons.h"
 #include "neo_crosshair.h"
+#include "neo_gamerules_restore.h"
 
 #include "neo_player_shared.h"
 
@@ -271,6 +272,14 @@ public:
 	CNetworkVar(int, m_iClassBeforeTakeover);
 
 	CNetworkVar(int, m_iXP);
+
+	struct NeoRestore
+	{
+		NextRoundPlayerRestoreFlags flags;
+		int iXP;
+		int iDeaths;
+	};
+	NeoRestore m_iNextRestore;
 
 	CNetworkVar(int, m_iLoadoutWepChoice);
 	CNetworkVar(int, m_iNextSpawnClassChoice);

--- a/src/game/server/neo/neo_player.h
+++ b/src/game/server/neo/neo_player.h
@@ -279,7 +279,7 @@ public:
 		int iXP;
 		int iDeaths;
 	};
-	NeoRestore m_iNextRestore;
+	NeoRestore m_iNextRestore = {};
 
 	CNetworkVar(int, m_iLoadoutWepChoice);
 	CNetworkVar(int, m_iNextSpawnClassChoice);

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -600,34 +600,6 @@ static inline void FireLegacyEvent_NeoRoundEnd()
 }
 
 #ifdef GAME_DLL
-CON_COMMAND( sv_neo_score_set_jinrai, "Set point count for team Jinrai" )
-{
-	if ( 2 != args.ArgC() )
-	{
-		Msg( "Usage: %s <score>\n", __FUNCTION__ );
-		return;
-	}
-	
-	CTeam *jinrai = GetGlobalTeam( TEAM_JINRAI );
-	Assert( jinrai );
-	jinrai->SetScore( atoi( args[1] ) );
-	jinrai->SetRoundsWon( atoi( args[1] ) );
-}
-
-CON_COMMAND( sv_neo_score_set_nsf, "Set point count for team NSF" )
-{
-	if ( 2 != args.ArgC() )
-	{
-		Msg( "Usage: %s <score>\n", __FUNCTION__ );
-		return;
-	}
-	
-	CTeam *nsf = GetGlobalTeam( TEAM_NSF );
-	Assert( nsf );
-	nsf->SetScore( atoi( args[1] ) );
-	nsf->SetRoundsWon( atoi( args[1] ) );
-}
-
 static void CvarChanged_WeaponStay(IConVar* convar, const char* pOldVal, float flOldVal)
 {
 	auto wep = gEntList.NextEntByClass((CNEOBaseCombatWeapon*)NULL);

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -2649,7 +2649,7 @@ const int CNEORules::GetRoundLimit() const
 void CNEORules::StartNextRound()
 {
 	// Only check ready-up on idle state
-	const bool bLobby = sv_neo_readyup_lobby.GetBool() && m_nRoundStatus == NeoRoundStatus::Idle;
+	const bool bLobby = InReadyUpState();
 	const int iThres = sv_neo_readyup_teamplayersthres.GetInt();
 	const bool bEqualThres = (iThres == GetGlobalTeam(TEAM_JINRAI)->GetNumPlayers()) && (iThres == GetGlobalTeam(TEAM_NSF)->GetNumPlayers());
 	const auto readyPlayers = FetchReadyPlayers();
@@ -4714,6 +4714,16 @@ bool CNEORules::IsJuggernautLocked() const
 	}
 
 	return false;
+}
+
+bool CNEORules::InReadyUpState() const
+{
+	return (sv_neo_readyup_lobby.GetBool() && m_nRoundStatus == NeoRoundStatus::Idle);
+}
+
+bool CNEORules::InRoundState() const
+{
+	return (IsRoundLive() || m_nRoundStatus == NeoRoundStatus::PostRound);
 }
 
 const char *CNEORules::GetTeamClantag(const int iTeamNum) const

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -35,6 +35,7 @@
 #include "nav_mesh.h"
 #include "neo_npc_dummy.h"
 #include "materialsystem/imaterialsystem.h"
+#include "neo_gamerules_restore.h"
 
 #include <utility>
 
@@ -2830,6 +2831,38 @@ void CNEORules::StartNextRound()
 	++m_iRoundNumber;
 	SetRoundStatus(NeoRoundStatus::PreRoundFreeze);
 
+	if (bFromStarting)
+	{
+		m_pRestoredInfos.Purge();
+		// If game was in warmup then also decide on game mode here
+
+		CTeam *pJinrai = GetGlobalTeam(TEAM_JINRAI);
+		CTeam *pNSF = GetGlobalTeam(TEAM_NSF);
+		Assert(pJinrai && pNSF);
+		pJinrai->SetScore(0);
+		pJinrai->SetRoundsWon(0);
+		pNSF->SetScore(0);
+		pNSF->SetRoundsWon(0);
+	}
+
+	if (m_iNextRestore.flags & NEXT_ROUND_GAMERULE_RESTORE_FLAG_SCORES)
+	{
+		GetGlobalTeam(TEAM_JINRAI)->SetScore(m_iNextRestore.iScoreJinrai);
+		GetGlobalTeam(TEAM_NSF)->SetScore(m_iNextRestore.iScoreNSF);
+	}
+	if (m_iNextRestore.flags & NEXT_ROUND_GAMERULE_RESTORE_FLAG_ROUND_NUMBER)
+	{
+		// Have to be before going through players or they spawn the wrong side
+		// when this gets set!
+		m_iRoundNumber = m_iNextRestore.iRoundNumber;
+	}
+	if (m_iNextRestore.flags & NEXT_ROUND_GAMERULE_RESTORE_FLAG_ROUNDSWONS)
+	{
+		GetGlobalTeam(TEAM_JINRAI)->SetRoundsWon(m_iNextRestore.iRoundsWonJinrai);
+		GetGlobalTeam(TEAM_NSF)->SetRoundsWon(m_iNextRestore.iRoundsWonNSF);
+	}
+	m_iNextRestore = {}; // Zero-out
+
 	for (int i = 1; i <= gpGlobals->maxClients; i++)
 	{
 		CNEO_Player *pPlayer = (CNEO_Player*)UTIL_PlayerByIndex(i);
@@ -2879,6 +2912,17 @@ void CNEORules::StartNextRound()
 		pPlayer->m_bIsPendingTKKick = false;
 
 		pPlayer->SetTestMessageVisible(false);
+
+		if (pPlayer->m_iNextRestore.flags & NEXT_ROUND_PLAYER_RESTORE_FLAG_XP)
+		{
+			pPlayer->m_iXP.Set(pPlayer->m_iNextRestore.iXP);
+		}
+		if (pPlayer->m_iNextRestore.flags & NEXT_ROUND_PLAYER_RESTORE_FLAG_DEATH)
+		{
+			pPlayer->ResetDeathCount();
+			pPlayer->IncrementDeathCount(pPlayer->m_iNextRestore.iDeaths);
+		}
+		pPlayer->m_iNextRestore = {}; // Zero-out
 	}
 
 	m_flPrevThinkKick = 0.0f;
@@ -2889,20 +2933,8 @@ void CNEORules::StartNextRound()
 	m_bTeamBeenAwardedDueToCapPrevent = false;
 	V_memset(m_arrayiEntPrevCap, 0, sizeof(m_arrayiEntPrevCap));
 	m_iEntPrevCapSize = 0;
-	if (bFromStarting)
-	{
-		m_pRestoredInfos.Purge();
-		// If game was in warmup then also decide on game mode here
 
-		CTeam *pJinrai = GetGlobalTeam(TEAM_JINRAI);
-		CTeam *pNSF = GetGlobalTeam(TEAM_NSF);
-		Assert(pJinrai && pNSF);
-		pJinrai->SetScore(0);
-		pJinrai->SetRoundsWon(0);
-		pNSF->SetScore(0);
-		pNSF->SetRoundsWon(0);
-	}
-
+	MatchSessionBackup();
 	FireLegacyEvent_NeoRoundEnd();
 
 	char RoundMsg[27];

--- a/src/game/shared/neo/neo_gamerules.h
+++ b/src/game/shared/neo/neo_gamerules.h
@@ -22,6 +22,7 @@
 	#include "neo_player.h"
 	#include "neo_ghost_spawn_point.h"
 	#include "utlhashtable.h"
+	#include "neo_gamerules_restore.h"
 #endif
 
 #include "neo_player_shared.h"
@@ -377,6 +378,7 @@ public:
 		return GetOpposingTeam(player->GetTeamNumber());
 	}
 
+	inline void SetRoundNumber(const int iNewVal) { m_iRoundNumber.Set(iNewVal); }
     inline int roundNumber() const { return m_iRoundNumber; }
     inline bool roundNumberIsEven() const { return (roundNumber() % 2 == 0); }
 
@@ -540,6 +542,20 @@ private:
 public:
 	// VIP networked variables
 	CNetworkVar(int, m_iEscortingTeam);
+
+#ifdef GAME_DLL
+	// sv_neo_restore_...
+	struct NeoRestore
+	{
+		NextRoundGameruleRestoreFlags flags;
+		int iScoreJinrai;
+		int iScoreNSF;
+		int iRoundNumber;
+		int iRoundsWonJinrai;
+		int iRoundsWonNSF;
+	};
+	NeoRestore m_iNextRestore = {};
+#endif
 };
 
 inline CNEORules *NEORules()

--- a/src/game/shared/neo/neo_gamerules.h
+++ b/src/game/shared/neo/neo_gamerules.h
@@ -358,6 +358,8 @@ public:
 	const Vector& GetJuggernautMarkerPos() const;
 	bool IsJuggernautLocked() const;
 
+	bool InReadyUpState() const;
+	bool InRoundState() const;
 
 	int GetOpposingTeam(const int team) const
 	{


### PR DESCRIPTION
## Description
<!--
Put in description here...
-->

Native implementation of XP/deaths restoration, with an extra to automatically backup and manually restore whole session.

ConVars:
* `sv_neo_restore_xp_death_any_round` - Allow setting XP/session anytime
* `sv_neo_restore_session_allow_name_match` - Allow name matching
  in session restore

Commands:
* `sv_neo_restore_session` - Restore entire session from backup
* `sv_neo_restore_round_number` - Force round number
* `sv_neo_restore_rounds_won` - Force Jinrai/NSF rounds won
* `sv_neo_restore_team_scores` - Force Jinrai/NSF scores
* `sv_neo_restore_xp` - Force XP on a player

Removed commands:
* `sv_neo_score_set_[jinrai/nsf]` - Replaced by `sv_neo_restore_...` equivalent

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0
-->
- Linux GCC Distro Native Arch/GCC 15

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1878


