### PR TITLE
v28 cherry-pick: Fix server crash when auto recording server-side (#1882)

### DIFF
--- a/src/game/shared/neo/neo_misc.cpp
+++ b/src/game/shared/neo/neo_misc.cpp
@@ -2,12 +2,13 @@
 
 #ifdef CLIENT_DLL
 #include "steamclientpublic.h"
+#include "vgui/ISystem.h"
 #endif // CLIENT_DLL
 #include "cbase.h"
 #include "neo_gamerules.h"
-#include "vgui/ISystem.h"
 #include "tier3.h"
 #include <filesystem.h>
+#include <ctime>
 
 extern ConVar sv_neo_comp_name;
 
@@ -88,9 +89,10 @@ bool StartAutoRecording()
 
 	// Time and date
 	char timeSection[16];
-	int year, month, dayOfWeek, day, hour, minute, second;
-	g_pVGuiSystem->GetCurrentTimeAndDate(&year, &month, &dayOfWeek, &day, &hour, &minute, &second);
-	V_snprintf(timeSection, sizeof(timeSection), "%04d%02d%02d-%02d%02d", year, month, day, hour, minute);
+	const time_t timeVal = time(nullptr);
+	std::tm tmStruct{};
+	std::tm tmd = *(Plat_localtime(&timeVal, &tmStruct));
+	V_sprintf_safe(timeSection, "%04d%02d%02d-%02d%02d", tmd.tm_year + 1900, tmd.tm_mon + 1, tmd.tm_mday, tmd.tm_hour, tmd.tm_min);
 
 	// Competition name
 	char compSection[32];


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

Cherry-pick of: https://github.com/NeotokyoRebuild/neo/pull/1882

## Description
The guess from the crashdump: the server trying to use VGUI global var which may not be initialized for the server and get nullptr deref. Change how datetime is fetched to a stdlib way.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Arch/GCC 15

<!--
## Linked Issues

Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

- fixes #
- related #
-->

