### PR TITLE
v28 cherry-pick: Reset crosshair on resets to fix spectator non-matching-to-player xhair (#1877)

### DIFF
--- a/src/game/client/hud_crosshair.cpp
+++ b/src/game/client/hud_crosshair.cpp
@@ -377,6 +377,17 @@ void CHudCrosshair::GetDrawPosition ( float *pX, float *pY, bool *pbBehindCamera
 ConVar cl_neo_scope_restrict_to_rectangle("cl_neo_scope_restrict_to_rectangle", "1", FCVAR_CHEAT,
 	"Whether to enforce rectangular sniper scope shape regardless of screen ratio.", true, 0.0, true, 1.0);
 
+#ifdef NEO
+
+void CHudCrosshair::resetPlayersCrosshair()
+{
+	V_memset(m_szLocalStrPlayersCrosshair, 0, sizeof(m_szLocalStrPlayersCrosshair));
+	V_memset(m_playersCrosshairInfos, 0, sizeof(m_playersCrosshairInfos));
+	V_memset(m_aflLastCheckedPlayersCrosshair, 0, sizeof(m_aflLastCheckedPlayersCrosshair));
+}
+
+#endif // NEO
+
 void CHudCrosshair::Paint( void )
 {
 	if ( !m_pCrosshair )
@@ -502,7 +513,6 @@ void CHudCrosshair::Paint( void )
 		if (bPlayerIdxValid)
 		{
 			bTakeSpecCrosshair = true;
-			m_playersCrosshairInfos;
 			bThisFrameRefreshCrosshair = false;
 			pCrosshairInfo = &m_playersCrosshairInfos[iPlayerIdx];
 			pszNeoCrosshair = pNeoPlayer->m_szNeoCrosshair.Get();

--- a/src/game/client/hud_crosshair.h
+++ b/src/game/client/hud_crosshair.h
@@ -41,6 +41,8 @@ public:
 	char m_szLocalStrPlayersCrosshair[MAX_PLAYERS][NEO_XHAIR_SEQMAX] = {};
 	CrosshairInfo m_playersCrosshairInfos[MAX_PLAYERS] = {};
 	float m_aflLastCheckedPlayersCrosshair[MAX_PLAYERS] = {};
+
+	void resetPlayersCrosshair();
 #endif
 
 	virtual void	SetCrosshairAngle( const QAngle& angle );

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -474,6 +474,7 @@ C_NEO_Player::C_NEO_Player()
 	m_bPreviouslyReloading = false;
 	m_bLastTickInThermOpticCamo = false;
 	m_bIsAllowedToToggleVision = false;
+	m_bSpecRefreshedStates = false;
 
 	m_flTocFactor = 0.15f;
 
@@ -1154,6 +1155,28 @@ void C_NEO_Player::PreThink( void )
 		m_flCamoAuxLastTime = 0;
 	}
 
+	// If spectating, won't be "alive/dead" so have its own
+	// path of resetting the cache of other players crosshair
+	// data on pre-round freeze time
+	if (IsLocalPlayer() && GetTeamNumber() == TEAM_SPECTATOR)
+	{
+		if (NEORules()->IsRoundPreRoundFreeze())
+		{
+			if (false == m_bSpecRefreshedStates)
+			{
+				if (CHudCrosshair *crosshair = GET_HUDELEMENT(CHudCrosshair))
+				{
+					crosshair->resetPlayersCrosshair();
+				}
+			}
+			m_bSpecRefreshedStates = true;
+		}
+		else
+		{
+			m_bSpecRefreshedStates = false;
+		}
+	}
+
 	if (IsAlive())
 	{
 		if (IsLocalPlayer() && m_bFirstAliveTick)
@@ -1168,6 +1191,12 @@ void C_NEO_Player::PreThink( void )
 			// so it could arrive too late.
 			CLocalPlayerFilter filter;
 			enginesound->SetPlayerDSP(filter, 0, true);
+
+			// Reset the cache of other players crosshair data on spawning in
+			if (CHudCrosshair *crosshair = GET_HUDELEMENT(CHudCrosshair))
+			{
+				crosshair->resetPlayersCrosshair();
+			}
 		}
 	}
 	else
@@ -1604,6 +1633,15 @@ void C_NEO_Player::Spawn( void )
 				neoHud->resetLastUpdateTime();
 				neoHud->resetHUDState();
 			}
+		}
+	}
+
+	// Only do cached crosshair reset for confirmed local player
+	if (IsLocalPlayer())
+	{
+		if (CHudCrosshair *crosshair = GET_HUDELEMENT(CHudCrosshair))
+		{
+			crosshair->resetPlayersCrosshair();
 		}
 	}
 }

--- a/src/game/client/neo/c_neo_player.h
+++ b/src/game/client/neo/c_neo_player.h
@@ -252,6 +252,7 @@ private:
 	bool m_bFirstDeathTick;
 	bool m_bPreviouslyReloading;
 	bool m_bIsAllowedToToggleVision;
+	bool m_bSpecRefreshedStates;
 
 	float m_flLastAirborneJumpOkTime;
 	float m_flLastSuperJumpTime;

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -16,6 +16,7 @@
 #include "engine/IEngineSound.h"
 #include "filesystem.h"
 #include "hltvcamera.h"
+#include "hud_crosshair.h"
 #else
 #include "neo_player.h"
 #include "team.h"
@@ -741,6 +742,18 @@ void CNEORules::ClientSpawned(edict_t* pPlayer)
 	}
 #endif
 #endif
+
+#ifdef CLIENT_DLL
+	// Reset other players crosshair cache on spawning in here
+	C_NEO_Player *pLocalPlayer = C_NEO_Player::GetLocalNEOPlayer();
+	if (pLocalPlayer->index == pPlayer->m_EdictIndex)
+	{
+		if (CHudCrosshair *crosshair = GET_HUDELEMENT(CHudCrosshair))
+		{
+			crosshair->resetPlayersCrosshair();
+		}
+	}
+#endif
 }
 
 int CNEORules::DefaultFOV(void)
@@ -818,6 +831,12 @@ void CNEORules::ResetMapSessionCommon()
 	m_pJuggernautItem = nullptr;
 	m_pJuggernautPlayer = nullptr;
 	m_bGotMatchWinner = false;
+#else // CLIENT_DLL
+	// Reset other players crosshair cache on full map reset
+	if (CHudCrosshair *crosshair = GET_HUDELEMENT(CHudCrosshair))
+	{
+		crosshair->resetPlayersCrosshair();
+	}
 #endif
 }
 


### PR DESCRIPTION




<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
This is kind of a guesswork if it'll fix the spectator seeing crosshair on player that it's not the player's actual crosshair, but I'm assuming the state haven't been refreshed properly especialy the timer till next crosshair refresh and maybe on map change and where player index changes it gets stuck with other player's crosshair.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Arch/GCC 15

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1735

