### PR TITLE
Fix sv_neo_server_autorecord for listen servers

### DIFF
--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -1849,9 +1849,6 @@ float CNEORules::MirrorDamageMultiplier() const
 
 void CNEORules::FireGameEvent(IGameEvent* event)
 {
-#ifdef GAME_DLL
-	static bool isServerRecording = false;
-#endif // GAME_DLL
 	const char *type = event->GetName();
 
 	if (Q_strcmp(type, "round_start") == 0)
@@ -1868,9 +1865,9 @@ void CNEORules::FireGameEvent(IGameEvent* event)
 #ifdef GAME_DLL
 		m_flNeoRoundStartTime = gpGlobals->curtime;
 		m_flNeoNextRoundStartTime = 0;
-		if (sv_neo_server_autorecord.GetBool() && !isServerRecording)
+		if (sv_neo_server_autorecord.GetBool() && !m_bServerIsCurrentlyAutoRecording)
 		{
-			isServerRecording = StartAutoRecording();
+			m_bServerIsCurrentlyAutoRecording = StartAutoRecording();
 		}
 #endif
 	}
@@ -1885,7 +1882,7 @@ void CNEORules::FireGameEvent(IGameEvent* event)
 #endif
 #ifdef GAME_DLL
 		engine->ServerCommand("tv_stoprecord;");
-		isServerRecording = false;
+		m_bServerIsCurrentlyAutoRecording = false;
 #endif // GAME_DLL
 	}
 }

--- a/src/game/shared/neo/neo_gamerules.h
+++ b/src/game/shared/neo/neo_gamerules.h
@@ -483,6 +483,7 @@ private:
 	int m_iEntPrevCapSize = 0;
 	int m_iPrintHelpCounter = 0;
 	bool m_bGamemodeTypeBeenInitialized = false;
+	bool m_bServerIsCurrentlyAutoRecording = false;
 	friend class CNEO_GhostBoundary;
 	friend class CNEOGhostSpawnPoint;
 	friend class CMultiplayRules;


### PR DESCRIPTION
## Description
Fix `sv_neo_server_autorecord 1` for listen servers, after disconnecting and creating another listen server.

Replaces the static local boolean `isServerRecording` with a new `CNEORules::m_bServerIsCurrentlyAutoRecording` member variable which will properly reset upon the rules object destruction.

## Steps to reproduce
* In the main menu, set the cvars:
```
sv_neo_comp 1;
neo_bot_quota 10; // enough bots for both teams
tv_enable 1;
sv_neo_server_autorecord 1;
```
* Start a listen server from console: `map ntre_oilstain_ctg;`
* Join spectator, wait for server auto-recording to start
* Use `disconnect;` to leave and destruct the listen server
* Make a new listen server with: `map ntre_oilstain_ctg;`
* Join spectator, wait for server auto-recording to start

### What should happen

Server auto-recording starts correctly on both times.

### What actually happens

The `static bool isServerRecording` state carries over, and prevents the second listen server instance from starting the server recording.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #
- related #

