### PR TITLE
Award assists to players for damage inflicted before bot takeover

### DIFF
--- a/src/game/client/neo/c_neo_player.h
+++ b/src/game/client/neo/c_neo_player.h
@@ -184,6 +184,9 @@ public:
 	bool m_bCopyOverTakeoverPlayerDetails{ false };
 	CNetworkHandle(C_NEO_Player, m_hSpectatorTakeoverPlayerTarget);
 	CNetworkHandle(C_NEO_Player, m_hSpectatorTakeoverPlayerImpersonatingMe);
+	C_NEO_Player* GetSpectatorTakeoverPlayerTarget() const { return m_hSpectatorTakeoverPlayerTarget.Get(); }
+	C_NEO_Player* GetSpectatorTakeoverPlayerImpersonatingMe() const { return m_hSpectatorTakeoverPlayerImpersonatingMe.Get(); }
+
 	void CSpectatorTakeoverPlayerUpdateOnDataChanged();
 	void CSpectatorTakeoverPlayerUpdate(C_NEO_Player* pPlayerTakeoverTarget);
 	const char* GetPlayerNameWithTakeoverContext(int player_index);

--- a/src/game/client/neo/ui/neo_hud_deathnotice.cpp
+++ b/src/game/client/neo/ui/neo_hud_deathnotice.cpp
@@ -785,12 +785,34 @@ void CNEOHud_DeathNotice::AddPlayerDeath(IGameEvent* event)
 	C_NEO_Player* pVictim = ToNEOPlayer(UTIL_PlayerByIndex(victim));
 	C_NEO_Player* pAssist = ToNEOPlayer(UTIL_PlayerByIndex(assist));
 
-	if (pKiller)
-		killer_name = pKiller->GetPlayerNameWithTakeoverContext(killer);
+	// Special case: Spectator assisted their own bot-takeover kill
+	// Simplify to "Bot Name + Player Name"
+	if (pKiller && pAssist && killer == assist && killer > 0)
+	{
+		C_NEO_Player* pTakeoverTarget = pKiller->GetSpectatorTakeoverPlayerTarget();
+		if (pTakeoverTarget)
+		{
+			killer_name = pTakeoverTarget->GetNeoPlayerName();
+			assists_name = pAssist->GetNeoPlayerName();
+		}
+	}
+	else
+	{
+		if (pKiller)
+		{
+			killer_name = pKiller->GetPlayerNameWithTakeoverContext(killer);
+		}
+
+		if (pAssist)
+		{
+			assists_name = pAssist->GetPlayerNameWithTakeoverContext(assist);
+		}
+	}
+
 	if (pVictim)
+	{
 		victim_name = pVictim->GetPlayerNameWithTakeoverContext(victim);
-	if (pAssist)
-		assists_name = pAssist->GetPlayerNameWithTakeoverContext(assist);
+	}
 
 	// Make a new death notice
 	DeathNoticeItem deathMsg;

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -3242,7 +3242,8 @@ int	CNEO_Player::OnTakeDamage_Alive(const CTakeDamageInfo& info)
 		// Checking because attacker might be prop or world
 		if (auto *attacker = ToNEOPlayer(info.GetAttacker()))
 		{
-			const int attackerIdx = attacker->entindex();
+			CNEO_Player* pImpersonated = attacker->GetSpectatorTakeoverPlayerTarget();
+			const int attackerIdx = pImpersonated ? pImpersonated->entindex() : attacker->entindex();
 			NEORules()->SetLastAttacker(entindex()); // NEO TODO (Adam) Once we can spectate non-players, let last attacker be non-neoplayer (Jeff)
 
 			// Separate the fractional amount of damage from the whole

--- a/src/game/server/neo/neo_player.h
+++ b/src/game/server/neo/neo_player.h
@@ -184,6 +184,9 @@ public:
 	bool GetBotPauseFiring() const { return !m_botPauseFiringTimer.IsElapsed(); }
 	bool GetSpectatorTakeoverPlayerPending() const { return m_bSpectatorTakeoverPlayerPending; }
 
+	CNEO_Player* GetSpectatorTakeoverPlayerTarget() const { return m_hSpectatorTakeoverPlayerTarget.Get(); }
+	CNEO_Player* GetSpectatorTakeoverPlayerImpersonatingMe() const { return m_hSpectatorTakeoverPlayerImpersonatingMe.Get(); }
+
 	virtual void StartAutoSprint(void) OVERRIDE;
 	virtual void StartSprinting(void) OVERRIDE;
 	virtual void StopSprinting(void) OVERRIDE;

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -3942,7 +3942,9 @@ static CNEO_Player* FetchAssists(CNEO_Player* attacker, CNEO_Player* victim)
 	}
 
 	// Check for assistance (> 50 dmg, not final attacker)
-	const int attackerIdx = attacker->entindex();
+	CNEO_Player* pImpersonated = attacker->GetSpectatorTakeoverPlayerTarget();
+	const int attackerIdx = pImpersonated ? pImpersonated->entindex() : attacker->entindex();
+
 	for (int assistIdx = 1; assistIdx <= gpGlobals->maxClients; ++assistIdx)
 	{
 		if (assistIdx == attackerIdx)
@@ -4119,13 +4121,18 @@ void CNEORules::PlayerKilled(CBasePlayer *pVictim, const CTakeDamageInfo &info)
 		{
 			if (sv_neo_teamdamage_assists.GetBool())
 			{
-				assister->AddPoints(-1, true);
+				// If a bot is being taken over, penalize the impersonator.
+				CNEO_Player* pImpersonator = assister->GetSpectatorTakeoverPlayerImpersonatingMe();
+				CNEO_Player* pPenalized = pImpersonator ? pImpersonator : assister;
+				// bIgnorePlayerTakeover = true to penalize the impersonator
+				pPenalized->AddPoints(-1, true, true);
 			}
 		}
 		// Enemy kill assist
 		else
 		{
-			assister->AddPoints(1, false);
+			// bIgnorePlayerTakeover = true: FetchAssists handled spec-takeover
+			assister->AddPoints(1, false, true);
 		}
 	}
 }


### PR DESCRIPTION
## Description
Give players credit for the damage inflicted before death and bot spectator takeover.
If the player inflicted damage as both the assister and killer, simplify the takeover name as "Bot Name + Player Name"

## Toolchain
- Windows MSVC VS2022
