### PR TITLE
Bots crouch when following pings if commander was crouched

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_command_follow.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_command_follow.cpp
@@ -226,6 +226,7 @@ bool CNEOBotCommandFollow::FollowCommandChain(CNEOBot* me)
 		// Use sv_neo_bot_cmdr_stop_distance_sq for consistent bot collection range
 		// follow_stop_distance_sq would be confusing if player doesn't know about distance tuning
 		me->m_hLeadingPlayer = pCommander;
+		m_bCrouchWhenFollowingPing = false; // watch commander's stance
 		m_vGoalPos = CNEO_Player::VECTOR_INVALID_WAYPOINT;
 		pCommander->m_vLastPingByStar.GetForModify(me->GetStar()) = CNEO_Player::VECTOR_INVALID_WAYPOINT;
 	}
@@ -236,6 +237,7 @@ bool CNEOBotCommandFollow::FollowCommandChain(CNEOBot* me)
 		if (pCommander->m_vLastPingByStar.Get(me->GetStar()) != me->m_vLastPingByStar.Get(me->GetStar()))
 		{
 			me->m_hLeadingPlayer = nullptr; // Stop following and start travelling to ping
+			m_bCrouchWhenFollowingPing = pCommander->IsDucking();
 			m_vGoalPos = pCommander->m_vLastPingByStar.Get(me->GetStar());
 			me->m_vLastPingByStar.GetForModify(me->GetStar()) = pCommander->m_vLastPingByStar.Get(me->GetStar());
 
@@ -248,8 +250,14 @@ bool CNEOBotCommandFollow::FollowCommandChain(CNEOBot* me)
 			else
 			{
 				me->m_hLeadingPlayer = pCommander; // fallback to following commander
+				m_bCrouchWhenFollowingPing = false; // watch commander's stance
 				// continue with leader following logic below
 			}
+		}
+
+		if (m_bCrouchWhenFollowingPing)
+		{
+			me->PressCrouchButton(0.3f);
 		}
 
 		if (FanOutAndCover(me, m_vGoalPos))
@@ -266,6 +274,7 @@ bool CNEOBotCommandFollow::FollowCommandChain(CNEOBot* me)
 		else
 		{
 			me->m_hLeadingPlayer = pCommander; // fallback to following commander
+			m_bCrouchWhenFollowingPing = false; // watch commander's stance
 			// continue with leader following logic below
 		}
 	}

--- a/src/game/server/neo/bot/behavior/neo_bot_command_follow.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_command_follow.cpp
@@ -233,6 +233,7 @@ bool CNEOBotCommandFollow::FollowCommandChain(CNEOBot* me)
 		// Use sv_neo_bot_cmdr_stop_distance_sq for consistent bot collection range
 		// follow_stop_distance_sq would be confusing if player doesn't know about distance tuning
 		me->m_hLeadingPlayer = pCommander;
+		m_bCrouchWhenFollowingPing = false; // watch commander's stance
 		m_vGoalPos = CNEO_Player::VECTOR_INVALID_WAYPOINT;
 		pCommander->m_vLastPingByStar.GetForModify(me->GetStar()) = CNEO_Player::VECTOR_INVALID_WAYPOINT;
 	}
@@ -244,6 +245,7 @@ bool CNEOBotCommandFollow::FollowCommandChain(CNEOBot* me)
 		{
 			SendUpdateToCommander( me, "On my way." );
 			me->m_hLeadingPlayer = nullptr; // Stop following and start travelling to ping
+			m_bCrouchWhenFollowingPing = pCommander->IsDucking();
 			m_vGoalPos = pCommander->m_vLastPingByStar.Get(me->GetStar());
 			me->m_vLastPingByStar.GetForModify(me->GetStar()) = pCommander->m_vLastPingByStar.Get(me->GetStar());
 
@@ -256,8 +258,14 @@ bool CNEOBotCommandFollow::FollowCommandChain(CNEOBot* me)
 			else
 			{
 				me->m_hLeadingPlayer = pCommander; // fallback to following commander
+				m_bCrouchWhenFollowingPing = false; // watch commander's stance
 				// continue with leader following logic below
 			}
+		}
+
+		if (m_bCrouchWhenFollowingPing)
+		{
+			me->PressCrouchButton(0.3f);
 		}
 
 		if (FanOutAndCover(me, m_vGoalPos))
@@ -274,6 +282,7 @@ bool CNEOBotCommandFollow::FollowCommandChain(CNEOBot* me)
 		else
 		{
 			me->m_hLeadingPlayer = pCommander; // fallback to following commander
+			m_bCrouchWhenFollowingPing = false; // watch commander's stance
 			// continue with leader following logic below
 		}
 	}

--- a/src/game/server/neo/bot/behavior/neo_bot_command_follow.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_command_follow.h
@@ -29,6 +29,7 @@ private:
 	CNEOBotGhostEquipmentHandler m_ghostEquipmentHandler;
 
 	IntervalTimer m_commanderLookingAtMeTimer;
+	bool m_bCrouchWhenFollowingPing = false;
 	bool m_bWasCommanderLookingAtMe = false;
 
 	EHANDLE m_hTargetEntity;

--- a/src/game/server/neo/bot/behavior/neo_bot_command_follow.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_command_follow.h
@@ -30,6 +30,7 @@ private:
 	CNEOBotGhostEquipmentHandler m_ghostEquipmentHandler;
 
 	IntervalTimer m_commanderLookingAtMeTimer;
+	bool m_bCrouchWhenFollowingPing = false;
 	bool m_bWasCommanderLookingAtMe = false;
 
 	EHANDLE m_hTargetEntity;


### PR DESCRIPTION
## Description
Allow ordering bots to stay in a crouched position by having bots check the commander's crouch state when they receive a ping waypoint.  If the commander was crouched, bots will stay crouched when moving to and waiting at the ping waypoint.

## Toolchain
- Windows MSVC VS2022
