### PR TITLE
Run ctest on all builds + NEO_TEST_HIDE_PASS envvar

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -83,6 +83,14 @@ jobs:
     - name: Install libraries
       run: cmake --install ${{ env.build_dir }}
 
+    # Run unit tests
+
+    - name: CTest
+      working-directory: ${{ env.source_dir }}
+      env:
+        NEO_TEST_HIDE_PASS: "1"
+      run: ctest --test-dir build/${{ env.preset_name }}/tests/ --output-on-failure
+
     # Dedicated library
 
     - name: CMake reconfigure dedicated library build
@@ -216,6 +224,14 @@ jobs:
 
     - name: Install libraries
       run: cmake --install ${{ env.build_dir }}
+
+    # Run unit tests
+
+    - name: CTest
+      working-directory: ${{ env.source_dir }}
+      env:
+        NEO_TEST_HIDE_PASS: "1"
+      run: ctest --test-dir build/${{ env.preset_name }}/tests/ --output-on-failure
 
     # Dedicated library
 

--- a/src/tests/test_util.h
+++ b/src/tests/test_util.h
@@ -3,6 +3,7 @@
 #include "strtools.h"
 #include "mathlib/mathlib.h"
 #include <cstdio>
+#include <cstdlib>
 
 #define DATA_XTRA_NAME_SIZE 64
 
@@ -18,6 +19,7 @@ static int g_testFailuresFn;
 static int g_testTotalFn;
 static int g_retVal;
 static bool g_testFnPass;
+static bool g_testHidePass;
 
 static bool _TestVerify(const bool bPass, const char *pszCondStr,
 		const char *pszFile, const int iLine)
@@ -96,7 +98,7 @@ static void _TestCompareStr(const char *lhs, const char *pszLhs,
 		test_name(); \
 		if (g_testFnPass) \
 		{ \
-			printf("%s: %s PASSED\n", g_szName, #test_name); \
+			if (false == g_testHidePass) printf("%s: %s PASSED\n", g_szName, #test_name); \
 		} \
 		else \
 		{ \
@@ -121,7 +123,7 @@ static void _TestCompareStr(const char *lhs, const char *pszLhs,
 			test_name(&datas[tIdx], tIdx); \
 			if (g_testFnPass) \
 			{ \
-				printf("%s: %s[%d](%s) PASSED\n", g_szName, #test_name, g_iDataExtraIdx, g_szDataExtraName); \
+				if (false == g_testHidePass) printf("%s: %s[%d](%s) PASSED\n", g_szName, #test_name, g_iDataExtraIdx, g_szDataExtraName); \
 			} \
 			else \
 			{ \
@@ -139,6 +141,10 @@ static void _TestCompareStr(const char *lhs, const char *pszLhs,
 #define TEST_INIT() \
 	int main(int argc, char **argv) \
 	{ \
+		if (const char *pszEnv = getenv("NEO_TEST_HIDE_PASS")) \
+		{ \
+			g_testHidePass = (0 == V_strcmp(pszEnv, "1")); \
+		} \
 		const char *szBasename1 = V_strrchr(argv[0], '\\'); \
 		g_szName = (szBasename1) ? szBasename1 + 1 : nullptr; \
 		if (!g_szName) \
@@ -152,6 +158,10 @@ static void _TestCompareStr(const char *lhs, const char *pszLhs,
 #define TEST_INIT() \
 	int main(int argc, char **argv) \
 	{ \
+		if (const char *pszEnv = getenv("NEO_TEST_HIDE_PASS")) \
+		{ \
+			g_testHidePass = (0 == V_strcmp(pszEnv, "1")); \
+		} \
 		const char *szBasename = V_strrchr(argv[0], '/'); \
 		g_szName = (szBasename) ? szBasename + 1 : argv[0];
 


### PR DESCRIPTION




## Description
<!--
Put in description here...
-->
Do an additional step of running the unit test in the build process which will fail it if there's any unit test failure.test_util.h gained `NEO_TEST_HIDE_PASS` environment variable where if set to "1" will only print out test failures making the log easier to read especially on Github workflow logs.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
- Linux GCC Distro Native
- Linux GCC 10 Sniper 3.0

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
* fixes #1848

