### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# Community Code of Conduct
+
+## Our Philosophy
+
+### The Core Principle
+
+The NT;RE community comes from a diverse set of experiences, backgrounds, and mindsets.
+Everyone participating is expected to take this into account when interacting with the community.
+We believe that hurting any part of the community hurts the community as a whole.
+This code of conduct exists to help us cultivate an environment where anyone feels empowered to contribute.
+
+### Why We Moderate
+
+Research has [consistently shown](https://assets.amazon.science/e4/44/abde3a4b49d080718dee91247285/a-social-ecological-approach-to-modeling-sense-of-virtual-community-sovc-in-livestreaming-communities.pdf)
+how moderation can prevent a community from being [hollowed out](https://dl.acm.org/doi/pdf/10.1145/3710960) 
+until [only the most toxic elements](https://dl.acm.org/doi/pdf/10.1145/3476057) (and those who can stand them) remain.
+An offensive joke or a throwaway insult acts as gatekeeping by attrition,
+driving away contributors who don't find "growing thicker skin" as a requirement to stick around to be an acceptable premise. 
+We choose to build a community built on mutual respect where this doesn't have to be a concern for any participant.
+
+### Shared Responsibility
+
+Fostering a welcoming environment is a shared responsibility.
+We encourage [active bystanders](https://www.breakingthesilence.cam.ac.uk/prevention-support/be-active-bystander#:~:text=Being%20an%20active%20bystander%20means,friend%20or%20someone%20in%20authority)
+to make it clear to other community members that inappropriate behavior is not only a punishable offense but is not socially tolerated. We all take part in making our spaces approachable.
+
+---
+
+## Code of Conduct
+
+### 1. Scope and Standards
+
+This code applies within all project spaces and when an individual is officially representing the project in public spaces. We expect contributors to uphold the following standards:
+
+- **Demonstrate Empathy:** Treat others with kindness and prioritize the health of the community.
+- **Focus on Ideas:** Disagreement is a natural part of development. Keep feedback focused on the code, the logic, or the contribution, never the individual.
+- **Respect Privacy:** Publishing others' private information (doxing), such as physical or email addresses, without explicit permission is strictly prohibited.
+
+### 2. Unacceptable Behavior
+
+The following behaviors is a non-exhaustive list of violations of our standards:
+
+- **Discrimination:** Use of language or imagery related to race, religion, gender identity/expression, sexual orientation, disability, age, etc.
+- **Harassment:** Unwanted sexual advances, threats, stalking, or repeated, or other abusive behavior intended to intimidate.
+- **Bad Faith Conduct:** Repeatedly accusing others of conduct violations without basis as a tactic to silence or harass them.
+
+### 3. Enforcement & Technical Consequences
+
+Developers and paperworkers are responsible for upholding our standards of acceptable behavior.
+
+- **Technical Sanctions:** Any Pull Requests (PRs), commits, or issues that contain language or content violating these guidelines will be closed or reverted without being considered for merge.
+- **Account Sanctions:** Instances of abusive, harassing, or otherwise unacceptable behavior may be met with temporary or permanent bans from the project’s digital spaces.
+
+### 4. Reporting Process
+
+If you experience or witness behavior that violates this Code of Conduct, please report it to:
+
+> **[codeofconduct@neotokyorebuild.com](mailto:codeofconduct@neotokyorebuild.com)**
+
+All reports will be reviewed and investigated. We are committed to maintaining the confidentiality of the reporter and will take all necessary steps to ensure they are protected from retaliation.
+If you have specific accomodations in mind with regards to this, please let us know and we'll doour best to make you comfortable.


### PR DESCRIPTION
Initial draft for a CoC
Partially inspired by the contributor covenant, but mostly based on research articles from the ACM on moderation. 

First section is bascially a "why", to save people time if a discussion/argument about policy comes up, just point whoever has questions to that instead of wasting time on back and forth on things we've already agreed to, the second section is a bit more "how".