### PR TITLE
Enable free roaming in demos while paused

### DIFF
--- a/src/game/client/c_baseentity.cpp
+++ b/src/game/client/c_baseentity.cpp
@@ -3246,7 +3246,11 @@ void C_BaseEntity::InterpolateServerEntities()
 	s_bInterpolate = cl_interpolate.GetBool();
 
 	// Don't interpolate during timedemo playback
+#ifdef NEO
+	if ( engine->IsPlayingTimeDemo() )
+#else
 	if ( engine->IsPlayingTimeDemo() || engine->IsPaused() )
+#endif // NEO
 	{										 
 		s_bInterpolate = false;
 	}
@@ -3277,7 +3281,11 @@ void C_BaseEntity::InterpolateServerEntities()
 	// Enable extrapolation?
 	CInterpolationContext context;
 	context.SetLastTimeStamp( engine->GetLastTimeStamp() );
+#ifdef NEO
+	if ( cl_extrapolate.GetBool() )
+#else
 	if ( cl_extrapolate.GetBool() && !engine->IsPaused() )
+#endif // NEO
 	{
 		context.EnableExtrapolation( true );
 	}

--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -2658,6 +2658,29 @@ void OnRenderStart()
 	MDLCACHE_CRITICAL_SECTION();
 	MDLCACHE_COARSE_LOCK();
 
+#ifdef NEO
+	if (engine->IsPaused())
+	{
+		Rope_ResetCounters();
+
+		{
+			PREDICTION_TRACKVALUECHANGESCOPE( "interpolation" );
+			C_BaseEntity::InterpolateServerEntities();
+		}
+
+		{
+			C_BaseAnimating::PushAllowBoneAccess( true, false, "OnRenderStart->CViewRender::SetUpView" ); // pops in CViewRender::SetUpView
+		}
+
+		input->CAM_Think();
+		view->OnRenderStart();
+		
+		RopeManager()->OnRenderStart();
+		
+		return;
+	}
+#endif // NEO
+
 #ifdef PORTAL
 	g_pPortalRender->UpdatePortalPixelVisibility(); //updating this one or two lines before querying again just isn't cutting it. Update as soon as it's cheap to do so.
 #endif

--- a/src/game/client/hltvcamera.cpp
+++ b/src/game/client/hltvcamera.cpp
@@ -441,11 +441,7 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 
 		AngleVectors ( m_LastCmd.viewangles, &forward, &right, &up);  // Determine movement angles
 
-#ifdef NEO
-		if ( m_LastCmd.buttons & IN_SPEED && !bUsePausedMovement)
-#else
 		if ( m_LastCmd.buttons & IN_SPEED )
-#endif // NEO
 		{
 			factor /= 2.0f;
 		}
@@ -453,9 +449,6 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		// Copy movement amounts
 		float fmove = m_LastCmd.forwardmove * factor;
 		float smove = m_LastCmd.sidemove * factor;
-#ifdef NEO
-		float umove = m_LastCmd.upmove * factor;
-#endif
 
 		const bool bDroneMove = m_LastCmd.buttons & IN_WALK;
 		if (bDroneMove)
@@ -475,11 +468,7 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 
 		for (int i=0 ; i<3 ; i++)       // Determine x and y parts of velocity
 			wishvel[i] = forward[i]*fmove + right[i]*smove;
-#ifdef NEO
-		wishvel[2] += umove;
-#else
 		wishvel[2] += m_LastCmd.upmove * factor;
-#endif // NEO
 
 		VectorCopy (wishvel, wishdir);   // Determine magnitude of speed of move
 		wishspeed = VectorNormalize(wishdir);

--- a/src/game/client/hltvcamera.cpp
+++ b/src/game/client/hltvcamera.cpp
@@ -26,9 +26,7 @@
 #include "neo_gamerules.h"
 #include "c_neo_player.h"
 #include "shareddefs.h"
-#include "vgui/IInput.h"
-#include "ienginevgui.h"
-#include "IGameUIFuncs.h"
+#include "input.h"
 #endif // NEO
 
 ConVar spec_autodirector( "spec_autodirector", "1", FCVAR_CLIENTDLL | FCVAR_CLIENTCMD_CAN_EXECUTE, "Auto-director chooses best view modes while spectating" );
@@ -418,35 +416,16 @@ void C_HLTVCamera::Accelerate( Vector& wishdir, float wishspeed, float accel )
 
 #ifdef NEO
 extern ConVar neo_fov;
-extern IGameUIFuncs *gameuifuncs;
 #endif // NEO
 // movement code is a copy of CGameMovement::FullNoClipMove()
 void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov)
 {
 #ifdef NEO
-	// NEO HACK (sm90x): set movement bindings memory on first call
-	if ( !m_bcForward )
-	{
-		m_bcForward = gameuifuncs->GetButtonCodeForBind( "+forward" );
-		m_bcBackward = gameuifuncs->GetButtonCodeForBind( "+back" );
-		m_bcMoveLeft = gameuifuncs->GetButtonCodeForBind( "+moveleft" );
-		m_bcMoveRight = gameuifuncs->GetButtonCodeForBind( "+moveright" );
-	}
-
-	if ( m_flLastRealTime == 0 )
-	{
-		m_flLastRealTime = gpGlobals->realtime;
-	}
-
 	const float flDeltaTime = gpGlobals->realtime - m_flLastRealTime;
-	m_flLastRealTime = gpGlobals->realtime;
 
-	const bool bUsePausedMovement = engine->IsPlayingDemo() && engine->IsPaused() && !enginevgui->IsGameUIVisible();
-
-	// clears last command to prevent movement with an ui open if demo is paused while key down
-	if ( enginevgui->IsGameUIVisible() )
+	// if (engine->IsPaused()) // When running a demo back at very slow speeds, movement is delayed, just do this always
 	{
-		m_LastCmd.Reset();
+		input->CreateMove(m_LastCmd.command_number, flDeltaTime, true); // or false and use sv_noclipduringpause, default it to true?
 	}
 #endif // NEO
 
@@ -460,11 +439,7 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		float factor = sv_specspeed.GetFloat();
 		float maxspeed = sv_maxspeed.GetFloat() * factor;
 
-#ifdef NEO
-		AngleVectors ( m_aCamAngle, &forward, &right, &up );  // Determine movement angles
-#else
 		AngleVectors ( m_LastCmd.viewangles, &forward, &right, &up);  // Determine movement angles
-#endif // NEO
 
 		if ( m_LastCmd.buttons & IN_SPEED )
 		{
@@ -474,32 +449,6 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		// Copy movement amounts
 		float fmove = m_LastCmd.forwardmove * factor;
 		float smove = m_LastCmd.sidemove * factor;
-
-#ifdef NEO
-		// If demo is paused and not using UI, use VGUI to detect movement keys presses
-		if ( bUsePausedMovement )
-		{
-			fmove = 0.0f;
-			smove = 0.0f;
-
-			if ( vgui::input()->IsKeyDown( m_bcForward ) )
-			{
-				fmove = factor * maxspeed;
-			}
-			else if ( vgui::input()->IsKeyDown( m_bcBackward ) )
-			{
-				fmove = -factor * maxspeed;
-			}
-
-			if ( vgui::input()->IsKeyDown( m_bcMoveLeft ) )
-			{
-				smove = -factor * maxspeed;
-			}
-			else if ( vgui::input()->IsKeyDown( m_bcMoveRight ) )
-			{
-				smove = factor * maxspeed;
-			}
-		}
 
 		const bool bDroneMove = m_LastCmd.buttons & IN_WALK;
 		if (bDroneMove)
@@ -514,7 +463,6 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 				smove *= absSMove / moveMagnitude;
 			}
 		}
-#endif // NEO
 		VectorNormalize (forward);  // Normalize remainder of vectors
 		VectorNormalize (right);    // 
 
@@ -680,6 +628,9 @@ void C_HLTVCamera::CalcView(Vector& origin, QAngle& angles, float& fov)
 		case OBS_MODE_CHASE		:	CalcChaseCamView( origin, angles, fov  );
 									break;
 	}
+#ifdef NEO
+	m_flLastRealTime = gpGlobals->realtime;
+#endif // NEO
 }
 
 #ifdef NEO
@@ -697,6 +648,17 @@ void C_HLTVCamera::SetMode(int iMode)
 	m_nCameraMode = iMode;
 
 #ifdef NEO
+	// If we pause demo playback while in eye view, the observer target will be invisible when switching observer mode because we also pause simulation etc, update visibility here
+	if (iOldMode == OBS_MODE_IN_EYE && engine->IsPaused())
+	{
+		C_BaseEntity* target = ClientEntityList().GetEnt( m_iTraget1 );
+		if ( target && target->IsPlayer())
+		{
+			target->UpdateVisibility();
+			target->CreateShadow(); // Iterate through all children to update their shadows too?
+		}
+	}
+
 	if (cl_neo_hltvcamera_spectate_next_target_on_set_mode.GetBool() && (iMode == OBS_MODE_IN_EYE || iMode == OBS_MODE_CHASE) && !GetPrimaryTarget())
 	{
 		bAllowChangingModeWhenSettingPrimaryTarget = false;

--- a/src/game/client/hltvcamera.cpp
+++ b/src/game/client/hltvcamera.cpp
@@ -418,6 +418,10 @@ void C_HLTVCamera::Accelerate( Vector& wishdir, float wishspeed, float accel )
 
 #ifdef NEO
 extern ConVar neo_fov;
+extern ConVar cl_forwardspeed;
+extern ConVar cl_backspeed;
+extern ConVar cl_sidespeed;
+extern ConVar cl_upspeed;
 extern IGameUIFuncs *gameuifuncs;
 #endif // NEO
 // movement code is a copy of CGameMovement::FullNoClipMove()
@@ -431,6 +435,10 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		m_bcBackward = gameuifuncs->GetButtonCodeForBind( "+back" );
 		m_bcMoveLeft = gameuifuncs->GetButtonCodeForBind( "+moveleft" );
 		m_bcMoveRight = gameuifuncs->GetButtonCodeForBind( "+moveright" );
+		m_bcMoveUp = gameuifuncs->GetButtonCodeForBind( "+moveup" );
+		m_bcMoveDown = gameuifuncs->GetButtonCodeForBind( "+movedown" );
+		m_bcWalk = gameuifuncs->GetButtonCodeForBind( "+walk" );
+		m_bcSprint = gameuifuncs->GetButtonCodeForBind( "+sprint" );
 	}
 
 	if ( m_flLastRealTime == 0 )
@@ -466,7 +474,11 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		AngleVectors ( m_LastCmd.viewangles, &forward, &right, &up);  // Determine movement angles
 #endif // NEO
 
+#ifdef NEO
+		if ( m_LastCmd.buttons & IN_SPEED && !bUsePausedMovement)
+#else
 		if ( m_LastCmd.buttons & IN_SPEED )
+#endif // NEO
 		{
 			factor /= 2.0f;
 		}
@@ -474,6 +486,9 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		// Copy movement amounts
 		float fmove = m_LastCmd.forwardmove * factor;
 		float smove = m_LastCmd.sidemove * factor;
+#ifdef NEO
+		float umove = m_LastCmd.upmove * factor;
+#endif
 
 #ifdef NEO
 		// If demo is paused and not using UI, use VGUI to detect movement keys presses
@@ -481,27 +496,42 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		{
 			fmove = 0.0f;
 			smove = 0.0f;
+			umove = 0.0f;
+
+			if ( vgui::input()->IsKeyDown( m_bcSprint ) )
+			{
+				factor /= 2.0f;
+			}
 
 			if ( vgui::input()->IsKeyDown( m_bcForward ) )
 			{
-				fmove = factor * maxspeed;
+				fmove = factor * cl_forwardspeed.GetFloat();
 			}
 			else if ( vgui::input()->IsKeyDown( m_bcBackward ) )
 			{
-				fmove = -factor * maxspeed;
+				fmove = -factor * cl_backspeed.GetFloat();
 			}
 
 			if ( vgui::input()->IsKeyDown( m_bcMoveLeft ) )
 			{
-				smove = -factor * maxspeed;
+				smove = -factor * cl_sidespeed.GetFloat();
 			}
 			else if ( vgui::input()->IsKeyDown( m_bcMoveRight ) )
 			{
-				smove = factor * maxspeed;
+				smove = factor * cl_sidespeed.GetFloat();
+			}
+
+			if ( vgui::input()->IsKeyDown( m_bcMoveUp ) )
+			{
+				umove = factor * cl_upspeed.GetFloat();
+			}
+			else if ( vgui::input()->IsKeyDown( m_bcMoveDown ) )
+			{
+				umove = -factor * cl_upspeed.GetFloat();
 			}
 		}
 
-		const bool bDroneMove = m_LastCmd.buttons & IN_WALK;
+		const bool bDroneMove = ( m_LastCmd.buttons & IN_WALK ) || ( bUsePausedMovement && vgui::input()->IsKeyDown( m_bcWalk ) );
 		if (bDroneMove)
 		{
 			forward.z = 0;
@@ -520,7 +550,11 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 
 		for (int i=0 ; i<3 ; i++)       // Determine x and y parts of velocity
 			wishvel[i] = forward[i]*fmove + right[i]*smove;
+#ifdef NEO
+		wishvel[2] += umove;
+#else
 		wishvel[2] += m_LastCmd.upmove * factor;
+#endif // NEO
 
 		VectorCopy (wishvel, wishdir);   // Determine magnitude of speed of move
 		wishspeed = VectorNormalize(wishdir);

--- a/src/game/client/hltvcamera.cpp
+++ b/src/game/client/hltvcamera.cpp
@@ -450,6 +450,7 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		float fmove = m_LastCmd.forwardmove * factor;
 		float smove = m_LastCmd.sidemove * factor;
 
+#ifdef NEO
 		const bool bDroneMove = m_LastCmd.buttons & IN_WALK;
 		if (bDroneMove)
 		{
@@ -463,6 +464,7 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 				smove *= absSMove / moveMagnitude;
 			}
 		}
+#endif // NEO
 		VectorNormalize (forward);  // Normalize remainder of vectors
 		VectorNormalize (right);    // 
 
@@ -651,8 +653,7 @@ void C_HLTVCamera::SetMode(int iMode)
 	// If we pause demo playback while in eye view, the observer target will be invisible when switching observer mode because we also pause simulation etc, update visibility here
 	if (iOldMode == OBS_MODE_IN_EYE && engine->IsPaused())
 	{
-		C_BaseEntity* target = ClientEntityList().GetEnt( m_iTraget1 );
-		if ( target && target->IsPlayer())
+		if ( C_BaseEntity* target = ClientEntityList().GetEnt( m_iTraget1 ) )
 		{
 			target->UpdateVisibility();
 			target->CreateShadow(); // Iterate through all children to update their shadows too?

--- a/src/game/client/hltvcamera.cpp
+++ b/src/game/client/hltvcamera.cpp
@@ -26,6 +26,9 @@
 #include "neo_gamerules.h"
 #include "c_neo_player.h"
 #include "shareddefs.h"
+#include "vgui/IInput.h"
+#include "ienginevgui.h"
+#include "IGameUIFuncs.h"
 #endif // NEO
 
 ConVar spec_autodirector( "spec_autodirector", "1", FCVAR_CLIENTDLL | FCVAR_CLIENTCMD_CAN_EXECUTE, "Auto-director chooses best view modes while spectating" );
@@ -105,6 +108,10 @@ void C_HLTVCamera::Reset()
 	m_flTheta = 0;
 	m_flOffset = 0;
 	m_bEntityPacketReceived = false;
+
+#ifdef NEO
+	m_flLastRealTime = 0;
+#endif // NEO
 
 	m_vCamOrigin.Init();
 	m_aCamAngle.Init();
@@ -372,7 +379,11 @@ void C_HLTVCamera::CalcInEyeCamView( Vector& eyeOrigin, QAngle& eyeAngles, float
 	}
 }
 
+#ifdef NEO
+void C_HLTVCamera::Accelerate( Vector& wishdir, float wishspeed, float accel, float flDeltaTime )
+#else
 void C_HLTVCamera::Accelerate( Vector& wishdir, float wishspeed, float accel )
+#endif // NEO
 {
 	float addspeed, accelspeed, currentspeed;
 
@@ -387,7 +398,11 @@ void C_HLTVCamera::Accelerate( Vector& wishdir, float wishspeed, float accel )
 		return;
 
 	// Determine amount of acceleration.
+#ifdef NEO
+	accelspeed = accel * flDeltaTime * wishspeed;
+#else
 	accelspeed = accel * gpGlobals->frametime * wishspeed;
+#endif // NEO
 
 	// Cap at addspeed
 	if (accelspeed > addspeed)
@@ -403,14 +418,41 @@ void C_HLTVCamera::Accelerate( Vector& wishdir, float wishspeed, float accel )
 
 #ifdef NEO
 extern ConVar neo_fov;
+extern IGameUIFuncs *gameuifuncs;
 #endif // NEO
 // movement code is a copy of CGameMovement::FullNoClipMove()
 void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov)
 {
+#ifdef NEO
+	// NEO HACK (sm90x): set movement bindings memory on first call
+	if ( !m_bcForward )
+	{
+		m_bcForward = gameuifuncs->GetButtonCodeForBind( "+forward" );
+		m_bcBackward = gameuifuncs->GetButtonCodeForBind( "+back" );
+		m_bcMoveLeft = gameuifuncs->GetButtonCodeForBind( "+moveleft" );
+		m_bcMoveRight = gameuifuncs->GetButtonCodeForBind( "+moveright" );
+	}
+
+	if ( m_flLastRealTime == 0 )
+	{
+		m_flLastRealTime = gpGlobals->realtime;
+	}
+
+	const float flDeltaTime = gpGlobals->realtime - m_flLastRealTime;
+	m_flLastRealTime = gpGlobals->realtime;
+
+	const bool bUsePausedMovement = engine->IsPlayingDemo() && engine->IsPaused() && !enginevgui->IsGameUIVisible();
+
+	// clears last command to prevent movement with an ui open if demo is paused while key down
+	if ( enginevgui->IsGameUIVisible() )
+	{
+		m_LastCmd.Reset();
+	}
+#endif // NEO
+
 	// only if PVS isn't locked by auto-director
 	if ( !IsPVSLocked() )
 	{
-
 		Vector wishvel;
 		Vector forward, right, up;
 		Vector wishdir;
@@ -418,7 +460,11 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		float factor = sv_specspeed.GetFloat();
 		float maxspeed = sv_maxspeed.GetFloat() * factor;
 
+#ifdef NEO
+		AngleVectors ( m_aCamAngle, &forward, &right, &up );  // Determine movement angles
+#else
 		AngleVectors ( m_LastCmd.viewangles, &forward, &right, &up);  // Determine movement angles
+#endif // NEO
 
 		if ( m_LastCmd.buttons & IN_SPEED )
 		{
@@ -428,8 +474,33 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		// Copy movement amounts
 		float fmove = m_LastCmd.forwardmove * factor;
 		float smove = m_LastCmd.sidemove * factor;
-		
+
 #ifdef NEO
+		// If demo is paused and not using UI, use VGUI to detect movement keys presses
+		if ( bUsePausedMovement )
+		{
+			fmove = 0.0f;
+			smove = 0.0f;
+
+			if ( vgui::input()->IsKeyDown( m_bcForward ) )
+			{
+				fmove = factor * maxspeed;
+			}
+			else if ( vgui::input()->IsKeyDown( m_bcBackward ) )
+			{
+				fmove = -factor * maxspeed;
+			}
+
+			if ( vgui::input()->IsKeyDown( m_bcMoveLeft ) )
+			{
+				smove = -factor * maxspeed;
+			}
+			else if ( vgui::input()->IsKeyDown( m_bcMoveRight ) )
+			{
+				smove = factor * maxspeed;
+			}
+		}
+
 		const bool bDroneMove = m_LastCmd.buttons & IN_WALK;
 		if (bDroneMove)
 		{
@@ -466,7 +537,11 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		if ( sv_specaccelerate.GetFloat() > 0.0 )
 		{
 			// Set move velocity
+#ifdef NEO
+			Accelerate ( wishdir, wishspeed, sv_specaccelerate.GetFloat(), flDeltaTime );
+#else
 			Accelerate ( wishdir, wishspeed, sv_specaccelerate.GetFloat() );
+#endif // NEO
 
 			float spd = VectorLength( m_vecVelocity );
 			if (spd < 1.0f)
@@ -482,7 +557,11 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 				float friction = sv_friction.GetFloat();
 
 				// Add the amount to the drop amount.
+#ifdef NEO
+				float drop = control * friction * flDeltaTime;
+#else
 				float drop = control * friction * gpGlobals->frametime;
+#endif // NEO
 
 				// scale the velocity
 				float newspeed = spd - drop;
@@ -500,8 +579,12 @@ void C_HLTVCamera::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& 
 		}
 
 		// Just move ( don't clip or anything )
+#ifdef NEO
+		VectorMA( m_vCamOrigin, flDeltaTime, m_vecVelocity, m_vCamOrigin );
+#else
 		VectorMA( m_vCamOrigin, gpGlobals->frametime, m_vecVelocity, m_vCamOrigin );
-		
+#endif // NEO
+
 		// get camera angle directly from engine
 		 engine->GetViewAngles( m_aCamAngle );
 

--- a/src/game/client/hltvcamera.h
+++ b/src/game/client/hltvcamera.h
@@ -85,11 +85,7 @@ protected:
 	CUserCmd	m_LastCmd;
 	Vector		m_vecVelocity;
 #ifdef NEO
-	float			m_flLastRealTime; // use realtime instead of frametime to process movement even while paused
-	ButtonCode_t	m_bcForward;
-	ButtonCode_t	m_bcBackward;
-	ButtonCode_t	m_bcMoveLeft;
-	ButtonCode_t	m_bcMoveRight;
+	float		m_flLastRealTime = 0; // use realtime instead of frametime to process movement even while paused
 #endif
 };
 

--- a/src/game/client/hltvcamera.h
+++ b/src/game/client/hltvcamera.h
@@ -90,6 +90,10 @@ protected:
 	ButtonCode_t	m_bcBackward;
 	ButtonCode_t	m_bcMoveLeft;
 	ButtonCode_t	m_bcMoveRight;
+	ButtonCode_t	m_bcMoveUp;
+	ButtonCode_t	m_bcMoveDown;
+	ButtonCode_t	m_bcWalk;
+	ButtonCode_t	m_bcSprint;
 #endif
 };
 

--- a/src/game/client/hltvcamera.h
+++ b/src/game/client/hltvcamera.h
@@ -59,7 +59,11 @@ protected:
 
 	void SmoothCameraAngle( QAngle& targetAngle );
 	void SetCameraAngle( QAngle& targetAngle );
+#ifdef NEO
+	void Accelerate( Vector& wishdir, float wishspeed, float accel, float flDeltaTime );
+#else
 	void Accelerate( Vector& wishdir, float wishspeed, float accel );
+#endif
 
 	int			m_nCameraMode; // current camera mode
 	int			m_iCameraMan; // camera man entindex or 0
@@ -80,6 +84,13 @@ protected:
 	char		m_szTitleText[64];
 	CUserCmd	m_LastCmd;
 	Vector		m_vecVelocity;
+#ifdef NEO
+	float			m_flLastRealTime; // use realtime instead of frametime to process movement even while paused
+	ButtonCode_t	m_bcForward;
+	ButtonCode_t	m_bcBackward;
+	ButtonCode_t	m_bcMoveLeft;
+	ButtonCode_t	m_bcMoveRight;
+#endif
 };
 
 

--- a/src/game/client/neo/ui/neo_hud_childelement.h
+++ b/src/game/client/neo/ui/neo_hud_childelement.h
@@ -75,14 +75,14 @@ protected:
 		}
 		else if (frequency > 0)
 		{
-			const float deltaTime = gpGlobals->curtime - m_flLastUpdateTime;
+			const float deltaTime = gpGlobals->realtime - m_flLastUpdateTime;
 			if ((m_flLastUpdateTime > 0.0f) && (deltaTime < frequency))
 			{
 				return false;
 			}
 			else
 			{
-				m_flLastUpdateTime = gpGlobals->curtime;
+				m_flLastUpdateTime = gpGlobals->realtime;
 				return true;
 			}
 		}

--- a/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_marker.cpp
@@ -16,6 +16,7 @@
 #include "ienginevgui.h"
 #include "prediction.h"
 #include "weapon_ghost.h"
+#include "view.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "neo_hud_worldpos_marker.h"
@@ -99,7 +100,7 @@ void CNEOHud_GhostMarker::UpdateStateForNeoHudElementDraw()
 	{
 		if (!NEORules()->GetGhosterPlayer())
 		{
-			const float flDistMeters = METERS_PER_INCH * C_NEO_Player::GetLocalPlayer()->GetAbsOrigin().DistTo(NEORules()->GetGhostPos());
+			const float flDistMeters = METERS_PER_INCH * MainViewOrigin().DistTo(NEORules()->GetGhostPos());
 			if (cl_neo_hud_worldpos_verbose.GetBool())
 			{
 				V_snwprintf(m_wszMarkerTextUnicode, ARRAYSIZE(m_wszMarkerTextUnicode), L"GHOST DISTANCE: %.0fm", flDistMeters);
@@ -114,7 +115,7 @@ void CNEOHud_GhostMarker::UpdateStateForNeoHudElementDraw()
 	{
 		if (!NEORules()->GetJuggernautPlayer())
 		{
-			const float flDistMeters = METERS_PER_INCH * C_NEO_Player::GetLocalPlayer()->GetAbsOrigin().DistTo(NEORules()->GetJuggernautMarkerPos());
+			const float flDistMeters = METERS_PER_INCH * MainViewOrigin().DistTo(NEORules()->GetJuggernautMarkerPos());
 			if (cl_neo_hud_worldpos_verbose.GetBool())
 			{
 				V_snwprintf(m_wszMarkerTextUnicode, ARRAYSIZE(m_wszMarkerTextUnicode), L"JUGGERNAUT DISTANCE: %.0fm", flDistMeters);


### PR DESCRIPTION
## Description

Enables moving around with roaming view in paused demos.

The two impediments to do this were 1) the movement using frametime, which I guess stops when the engine pauses the game, and 2) when paused the engine stops processing in-game inputs so pressing to move forward would do nothing.

Changed the roaming view to use realtime instead of frametime, and added a hacky way to detect movement button presses while paused using vgui.

## Toolchain
- Linux GCC 10 Sniper 3.0