### PR TITLE
Shadows on water surfaces

### DIFF
--- a/src/materialsystem/stdshaders/CMakeLists.txt
+++ b/src/materialsystem/stdshaders/CMakeLists.txt
@@ -82,6 +82,7 @@ target_sources_grouped(
     example_model_dx9_helper.cpp
     lightmappedgeneric_dx9.cpp
     lightmappedgeneric_dx9_helper.cpp
+    water.cpp
     screenspace_general.cpp
 )
 
@@ -106,6 +107,7 @@ target_sources_grouped(
     common_vs_fxc.h
     example_model_dx9_helper.h
     lightmappedgeneric_dx9_helper.h
+    water_ps2x_helper.h
     shader_constant_register_map.h
 )
 

--- a/src/materialsystem/stdshaders/Water_vs20.fxc
+++ b/src/materialsystem/stdshaders/Water_vs20.fxc
@@ -25,7 +25,7 @@ struct VS_OUTPUT
 #if !defined( _X360 )
 	float  vFog						: FOG;
 #endif
-	float2 vBumpTexCoord			: TEXCOORD0;
+	float4 vBumpTexCoordlightmapTexCoord3	: TEXCOORD0;
 	float3 vTangentEyeVect			: TEXCOORD1;
 	float4 vReflectXY_vRefractYX	: TEXCOORD2;
 	float4 vWorldPos_projPosW		: TEXCOORD3;
@@ -34,10 +34,7 @@ struct VS_OUTPUT
 #if MULTITEXTURE
 	float4 vExtraBumpTexCoord       : TEXCOORD6;
 #endif
-#if BASETEXTURE
-	HALF4 lightmapTexCoord1And2		: TEXCOORD6;
-	HALF4 lightmapTexCoord3			: TEXCOORD7;
-#endif
+	HALF4 lightmapTexCoord1And2		: TEXCOORD7;
 	float4 fogFactorW				: COLOR1;
 };
 
@@ -88,8 +85,8 @@ VS_OUTPUT main( const VS_INPUT v )
 	o.vTangentEyeVect.z = dot( vWorldEyeVect, vObjNormal );
 
 	// Tranform bump coordinates
-	o.vBumpTexCoord.x = dot( v.vBaseTexCoord, cBumpTexCoordTransform[0] );
-	o.vBumpTexCoord.y = dot( v.vBaseTexCoord, cBumpTexCoordTransform[1] );
+	o.vBumpTexCoordlightmapTexCoord3.x = dot( v.vBaseTexCoord, cBumpTexCoordTransform[0] );
+	o.vBumpTexCoordlightmapTexCoord3.y = dot( v.vBaseTexCoord, cBumpTexCoordTransform[1] );
 	float f45x=v.vBaseTexCoord.x+v.vBaseTexCoord.y;
 	float f45y=v.vBaseTexCoord.y-v.vBaseTexCoord.x;
 #if MULTITEXTURE
@@ -99,7 +96,6 @@ VS_OUTPUT main( const VS_INPUT v )
 	o.vExtraBumpTexCoord.w=v.vBaseTexCoord.x*0.45+TexOffsets.w;
 #endif
 
-#if BASETEXTURE
 	o.lightmapTexCoord1And2.xy = v.vLightmapTexCoord + v.vLightmapTexCoordOffset;
 
 	float2 lightmapTexCoord2 = o.lightmapTexCoord1And2.xy + v.vLightmapTexCoordOffset;
@@ -109,8 +105,7 @@ VS_OUTPUT main( const VS_INPUT v )
 	o.lightmapTexCoord1And2.w = lightmapTexCoord2.x;
 	o.lightmapTexCoord1And2.z = lightmapTexCoord2.y;
 
-	o.lightmapTexCoord3.xy = lightmapTexCoord3;
-#endif
+	o.vBumpTexCoordlightmapTexCoord3.zw = lightmapTexCoord3;
 
 	return o;
 }

--- a/src/materialsystem/stdshaders/Water_vs20.fxc
+++ b/src/materialsystem/stdshaders/Water_vs20.fxc
@@ -1,5 +1,6 @@
 // STATIC: "BASETEXTURE"				"0..1"
 // STATIC: "MULTITEXTURE"				"0..1"
+// STATIC: "LIGHTMAPWATERFOG"			"0..1"
 
 // SKIP: $MULTITEXTURE && $BASETEXTURE
 
@@ -25,7 +26,11 @@ struct VS_OUTPUT
 #if !defined( _X360 )
 	float  vFog						: FOG;
 #endif
+#if LIGHTMAPWATERFOG
 	float4 vBumpTexCoordlightmapTexCoord3	: TEXCOORD0;
+#else
+	float2 vBumpTexCoord			: TEXCOORD0;
+#endif
 	float3 vTangentEyeVect			: TEXCOORD1;
 	float4 vReflectXY_vRefractYX	: TEXCOORD2;
 	float4 vWorldPos_projPosW		: TEXCOORD3;
@@ -34,7 +39,14 @@ struct VS_OUTPUT
 #if MULTITEXTURE
 	float4 vExtraBumpTexCoord       : TEXCOORD6;
 #endif
+#if LIGHTMAPWATERFOG
 	HALF4 lightmapTexCoord1And2		: TEXCOORD7;
+#else
+#if BASETEXTURE
+	HALF4 lightmapTexCoord1And2		: TEXCOORD6;
+	HALF4 lightmapTexCoord3			: TEXCOORD7;
+#endif
+#endif
 	float4 fogFactorW				: COLOR1;
 };
 
@@ -85,8 +97,13 @@ VS_OUTPUT main( const VS_INPUT v )
 	o.vTangentEyeVect.z = dot( vWorldEyeVect, vObjNormal );
 
 	// Tranform bump coordinates
+#if LIGHTMAPWATERFOG
 	o.vBumpTexCoordlightmapTexCoord3.x = dot( v.vBaseTexCoord, cBumpTexCoordTransform[0] );
 	o.vBumpTexCoordlightmapTexCoord3.y = dot( v.vBaseTexCoord, cBumpTexCoordTransform[1] );
+#else
+	o.vBumpTexCoord.x = dot( v.vBaseTexCoord, cBumpTexCoordTransform[0] );
+	o.vBumpTexCoord.y = dot( v.vBaseTexCoord, cBumpTexCoordTransform[1] );
+#endif
 	float f45x=v.vBaseTexCoord.x+v.vBaseTexCoord.y;
 	float f45y=v.vBaseTexCoord.y-v.vBaseTexCoord.x;
 #if MULTITEXTURE
@@ -96,6 +113,7 @@ VS_OUTPUT main( const VS_INPUT v )
 	o.vExtraBumpTexCoord.w=v.vBaseTexCoord.x*0.45+TexOffsets.w;
 #endif
 
+#if BASETEXTURE || LIGHTMAPWATERFOG
 	o.lightmapTexCoord1And2.xy = v.vLightmapTexCoord + v.vLightmapTexCoordOffset;
 
 	float2 lightmapTexCoord2 = o.lightmapTexCoord1And2.xy + v.vLightmapTexCoordOffset;
@@ -105,7 +123,12 @@ VS_OUTPUT main( const VS_INPUT v )
 	o.lightmapTexCoord1And2.w = lightmapTexCoord2.x;
 	o.lightmapTexCoord1And2.z = lightmapTexCoord2.y;
 
+#if LIGHTMAPWATERFOG
 	o.vBumpTexCoordlightmapTexCoord3.zw = lightmapTexCoord3;
+#else
+	o.lightmapTexCoord3.xy = lightmapTexCoord3;
+#endif
+#endif
 
 	return o;
 }

--- a/src/materialsystem/stdshaders/include/Water_vs20.inc
+++ b/src/materialsystem/stdshaders/include/Water_vs20.inc
@@ -8,9 +8,11 @@ class water_vs20_Static_Index
 {
 	unsigned int m_nBASETEXTURE : 2;
 	unsigned int m_nMULTITEXTURE : 2;
+	unsigned int m_nLIGHTMAPWATERFOG : 2;
 #ifdef _DEBUG
 	bool m_bBASETEXTURE : 1;
 	bool m_bMULTITEXTURE : 1;
+	bool m_bLIGHTMAPWATERFOG : 1;
 #endif	// _DEBUG
 public:
 	void SetBASETEXTURE( int i )
@@ -31,25 +33,36 @@ public:
 #endif	// _DEBUG
 	}
 
+	void SetLIGHTMAPWATERFOG( int i )
+	{
+		Assert( i >= 0 && i <= 1 );
+		m_nLIGHTMAPWATERFOG = i;
+#ifdef _DEBUG
+		m_bLIGHTMAPWATERFOG = true;
+#endif	// _DEBUG
+	}
+
 	water_vs20_Static_Index(  )
 	{
 		m_nBASETEXTURE = 0;
 		m_nMULTITEXTURE = 0;
+		m_nLIGHTMAPWATERFOG = 0;
 #ifdef _DEBUG
 		m_bBASETEXTURE = false;
 		m_bMULTITEXTURE = false;
+		m_bLIGHTMAPWATERFOG = false;
 #endif	// _DEBUG
 	}
 
 	int GetIndex() const
 	{
-		Assert( m_bBASETEXTURE && m_bMULTITEXTURE );
+		Assert( m_bBASETEXTURE && m_bMULTITEXTURE && m_bLIGHTMAPWATERFOG );
 		AssertMsg( !( m_nMULTITEXTURE && m_nBASETEXTURE ), "Invalid combo combination ( MULTITEXTURE && BASETEXTURE )" );
-		return ( 1 * m_nBASETEXTURE ) + ( 2 * m_nMULTITEXTURE ) + 0;
+		return ( 1 * m_nBASETEXTURE ) + ( 2 * m_nMULTITEXTURE ) + ( 4 * m_nLIGHTMAPWATERFOG ) + 0;
 	}
 };
 
-#define shaderStaticTest_water_vs20 vsh_forgot_to_set_static_BASETEXTURE + vsh_forgot_to_set_static_MULTITEXTURE
+#define shaderStaticTest_water_vs20 vsh_forgot_to_set_static_BASETEXTURE + vsh_forgot_to_set_static_MULTITEXTURE + vsh_forgot_to_set_static_LIGHTMAPWATERFOG
 
 
 class water_vs20_Dynamic_Index

--- a/src/materialsystem/stdshaders/include/water_ps20b.inc
+++ b/src/materialsystem/stdshaders/include/water_ps20b.inc
@@ -20,6 +20,7 @@ class water_ps20b_Static_Index
 	unsigned int m_nABOVEWATER : 2;
 	unsigned int m_nBLURRY_REFRACT : 2;
 	unsigned int m_nNORMAL_DECODE_MODE : 1;
+	unsigned int m_nLIGHTMAPWATERFOG : 2;
 #ifdef _DEBUG
 	bool m_bBASETEXTURE : 1;
 	bool m_bMULTITEXTURE : 1;
@@ -28,6 +29,7 @@ class water_ps20b_Static_Index
 	bool m_bABOVEWATER : 1;
 	bool m_bBLURRY_REFRACT : 1;
 	bool m_bNORMAL_DECODE_MODE : 1;
+	bool m_bLIGHTMAPWATERFOG : 1;
 #endif	// _DEBUG
 public:
 	void SetCONVERT_TO_SRGB( int i )
@@ -99,6 +101,15 @@ public:
 #endif	// _DEBUG
 	}
 
+	void SetLIGHTMAPWATERFOG( int i )
+	{
+		Assert( i >= 0 && i <= 1 );
+		m_nLIGHTMAPWATERFOG = i;
+#ifdef _DEBUG
+		m_bLIGHTMAPWATERFOG = true;
+#endif	// _DEBUG
+	}
+
 	water_ps20b_Static_Index(  )
 	{
 		m_nCONVERT_TO_SRGB = g_pHardwareConfig->NeedsShaderSRGBConversion();
@@ -109,6 +120,7 @@ public:
 		m_nABOVEWATER = 0;
 		m_nBLURRY_REFRACT = 0;
 		m_nNORMAL_DECODE_MODE = 0;
+		m_nLIGHTMAPWATERFOG = 0;
 #ifdef _DEBUG
 		m_bBASETEXTURE = false;
 		m_bMULTITEXTURE = false;
@@ -117,18 +129,19 @@ public:
 		m_bABOVEWATER = false;
 		m_bBLURRY_REFRACT = false;
 		m_bNORMAL_DECODE_MODE = false;
+		m_bLIGHTMAPWATERFOG = false;
 #endif	// _DEBUG
 	}
 
 	int GetIndex() const
 	{
-		Assert( m_bBASETEXTURE && m_bMULTITEXTURE && m_bREFLECT && m_bREFRACT && m_bABOVEWATER && m_bBLURRY_REFRACT && m_bNORMAL_DECODE_MODE );
+		Assert( m_bBASETEXTURE && m_bMULTITEXTURE && m_bREFLECT && m_bREFRACT && m_bABOVEWATER && m_bBLURRY_REFRACT && m_bNORMAL_DECODE_MODE && m_bLIGHTMAPWATERFOG );
 		AssertMsg( !( m_nMULTITEXTURE && m_nBASETEXTURE ), "Invalid combo combination ( MULTITEXTURE && BASETEXTURE )" );
-		return ( 6 * m_nCONVERT_TO_SRGB ) + ( 12 * m_nBASETEXTURE ) + ( 24 * m_nMULTITEXTURE ) + ( 48 * m_nREFLECT ) + ( 96 * m_nREFRACT ) + ( 192 * m_nABOVEWATER ) + ( 384 * m_nBLURRY_REFRACT ) + ( 768 * m_nNORMAL_DECODE_MODE ) + 0;
+		return ( 6 * m_nCONVERT_TO_SRGB ) + ( 12 * m_nBASETEXTURE ) + ( 24 * m_nMULTITEXTURE ) + ( 48 * m_nREFLECT ) + ( 96 * m_nREFRACT ) + ( 192 * m_nABOVEWATER ) + ( 384 * m_nBLURRY_REFRACT ) + ( 768 * m_nNORMAL_DECODE_MODE ) + ( 768 * m_nLIGHTMAPWATERFOG ) + 0;
 	}
 };
 
-#define shaderStaticTest_water_ps20b psh_forgot_to_set_static_BASETEXTURE + psh_forgot_to_set_static_MULTITEXTURE + psh_forgot_to_set_static_REFLECT + psh_forgot_to_set_static_REFRACT + psh_forgot_to_set_static_ABOVEWATER + psh_forgot_to_set_static_BLURRY_REFRACT + psh_forgot_to_set_static_NORMAL_DECODE_MODE
+#define shaderStaticTest_water_ps20b psh_forgot_to_set_static_BASETEXTURE + psh_forgot_to_set_static_MULTITEXTURE + psh_forgot_to_set_static_REFLECT + psh_forgot_to_set_static_REFRACT + psh_forgot_to_set_static_ABOVEWATER + psh_forgot_to_set_static_BLURRY_REFRACT + psh_forgot_to_set_static_NORMAL_DECODE_MODE + psh_forgot_to_set_static_LIGHTMAPWATERFOG
 
 
 class water_ps20b_Dynamic_Index

--- a/src/materialsystem/stdshaders/water.cpp
+++ b/src/materialsystem/stdshaders/water.cpp
@@ -182,6 +182,7 @@ BEGIN_VS_SHADER( Water_DX90,
 	inline void DrawReflectionRefraction( IMaterialVar **params, IShaderShadow* pShaderShadow,
 		IShaderDynamicAPI* pShaderAPI, bool bReflection, bool bRefraction ) 
 	{
+		bool blightMapWaterFog = params[LIGHTMAPWATERFOG]->GetIntValue();
 		SHADOW_STATE
 		{
 			SetInitialShadowState( );
@@ -203,14 +204,12 @@ BEGIN_VS_SHADER( Water_DX90,
 					// BASETEXTURE
 					pShaderShadow->EnableTexture( SHADER_SAMPLER1, true );
 					pShaderShadow->EnableSRGBRead( SHADER_SAMPLER1, true );
-
 					// LIGHTMAP
 					pShaderShadow->EnableTexture( SHADER_SAMPLER3, true );
 					pShaderShadow->EnableSRGBRead( SHADER_SAMPLER3, true );
 				}
 			}
 #ifdef NEO
-			bool blightMapWaterFog = params[LIGHTMAPWATERFOG]->GetIntValue();
 			if (blightMapWaterFog)
 			{
 				// LIGHTMAP
@@ -311,7 +310,7 @@ BEGIN_VS_SHADER( Water_DX90,
 				pShaderAPI->BindStandardTexture( SHADER_SAMPLER3, TEXTURE_LIGHTMAP );
 			}
 #ifdef NEO
-			else
+			else if (blightMapWaterFog)
 			{
 				pShaderAPI->BindStandardTexture( SHADER_SAMPLER3, TEXTURE_LIGHTMAP );
 			}

--- a/src/materialsystem/stdshaders/water.cpp
+++ b/src/materialsystem/stdshaders/water.cpp
@@ -56,6 +56,9 @@ BEGIN_VS_SHADER( Water_DX90,
 		SHADER_PARAM( SCROLL1, SHADER_PARAM_TYPE_COLOR, "", "" )
 		SHADER_PARAM( SCROLL2, SHADER_PARAM_TYPE_COLOR, "", "" )
 		SHADER_PARAM( BLURREFRACT, SHADER_PARAM_TYPE_BOOL, "0", "Cause the refraction to be blurry on ps2b hardware" )
+#ifdef NEO
+		SHADER_PARAM( LIGHTMAPWATERFOG, SHADER_PARAM_TYPE_BOOL, "0", "Cast shadows onto the fog component of the water surface" )
+#endif // NEO
 	END_SHADER_PARAMS
 
 	SHADER_INIT_PARAMS()
@@ -200,17 +203,20 @@ BEGIN_VS_SHADER( Water_DX90,
 					// BASETEXTURE
 					pShaderShadow->EnableTexture( SHADER_SAMPLER1, true );
 					pShaderShadow->EnableSRGBRead( SHADER_SAMPLER1, true );
-#ifndef NEO
+
 					// LIGHTMAP
 					pShaderShadow->EnableTexture( SHADER_SAMPLER3, true );
 					pShaderShadow->EnableSRGBRead( SHADER_SAMPLER3, true );
-#endif // NEO
 				}
 			}
 #ifdef NEO
-			// LIGHTMAP
-			pShaderShadow->EnableTexture( SHADER_SAMPLER3, true );
-			pShaderShadow->EnableSRGBRead( SHADER_SAMPLER3, true );
+			bool blightMapWaterFog = params[LIGHTMAPWATERFOG]->GetIntValue();
+			if (blightMapWaterFog)
+			{
+				// LIGHTMAP
+				pShaderShadow->EnableTexture( SHADER_SAMPLER3, true );
+				pShaderShadow->EnableSRGBRead( SHADER_SAMPLER3, true );
+			}
 #endif // NEO
 
 			// normal map
@@ -224,7 +230,9 @@ BEGIN_VS_SHADER( Water_DX90,
 			// texcoord1 : lightmap texcoord
 			// texcoord2 : lightmap texcoord offset
 			int numTexCoords = 1;
-#ifndef NEO // NEO TODO (Adam) check fogparam instead also
+#ifdef NEO
+			if( params[BASETEXTURE]->IsTexture() || blightMapWaterFog )
+#else
 			if( params[BASETEXTURE]->IsTexture() )
 #endif // NEO
 			{
@@ -238,6 +246,11 @@ BEGIN_VS_SHADER( Water_DX90,
 			DECLARE_STATIC_VERTEX_SHADER( water_vs20 );
 			SET_STATIC_VERTEX_SHADER_COMBO( MULTITEXTURE,fabs(Scroll1.x) > 0.0);
 			SET_STATIC_VERTEX_SHADER_COMBO( BASETEXTURE, params[BASETEXTURE]->IsTexture() );
+#ifdef NEO
+			SET_STATIC_VERTEX_SHADER_COMBO(LIGHTMAPWATERFOG, blightMapWaterFog);
+#else // Still custom NEO code
+			SET_STATIC_VERTEX_SHADER_COMBO(LIGHTMAPWATERFOG, 0);
+#endif // NEO
 			SET_STATIC_VERTEX_SHADER( water_vs20 );
 
 			// "REFLECT" "0..1"
@@ -253,6 +266,11 @@ BEGIN_VS_SHADER( Water_DX90,
 				SET_STATIC_PIXEL_SHADER_COMBO( BASETEXTURE, params[BASETEXTURE]->IsTexture() );
 				SET_STATIC_PIXEL_SHADER_COMBO( BLURRY_REFRACT, params[BLURREFRACT]->GetIntValue() );
 				SET_STATIC_PIXEL_SHADER_COMBO( NORMAL_DECODE_MODE, (int) NORMAL_DECODE_NONE );
+#ifdef NEO
+				SET_STATIC_PIXEL_SHADER_COMBO(LIGHTMAPWATERFOG, blightMapWaterFog);
+#else // Still custom NEO code
+				SET_STATIC_PIXEL_SHADER_COMBO(LIGHTMAPWATERFOG, 0);
+#endif // NEO
 				SET_STATIC_PIXEL_SHADER( water_ps20b );
 			}
 			else

--- a/src/materialsystem/stdshaders/water.cpp
+++ b/src/materialsystem/stdshaders/water.cpp
@@ -200,11 +200,19 @@ BEGIN_VS_SHADER( Water_DX90,
 					// BASETEXTURE
 					pShaderShadow->EnableTexture( SHADER_SAMPLER1, true );
 					pShaderShadow->EnableSRGBRead( SHADER_SAMPLER1, true );
+#ifndef NEO
 					// LIGHTMAP
 					pShaderShadow->EnableTexture( SHADER_SAMPLER3, true );
 					pShaderShadow->EnableSRGBRead( SHADER_SAMPLER3, true );
+#endif // NEO
 				}
 			}
+#ifdef NEO
+			// LIGHTMAP
+			pShaderShadow->EnableTexture( SHADER_SAMPLER3, true );
+			pShaderShadow->EnableSRGBRead( SHADER_SAMPLER3, true );
+#endif // NEO
+
 			// normal map
 			pShaderShadow->EnableTexture( SHADER_SAMPLER4, true );
 			// Normalizing cube map
@@ -216,7 +224,9 @@ BEGIN_VS_SHADER( Water_DX90,
 			// texcoord1 : lightmap texcoord
 			// texcoord2 : lightmap texcoord offset
 			int numTexCoords = 1;
+#ifndef NEO // NEO TODO (Adam) check fogparam instead also
 			if( params[BASETEXTURE]->IsTexture() )
+#endif // NEO
 			{
 				numTexCoords = 3;
 			}
@@ -282,6 +292,12 @@ BEGIN_VS_SHADER( Water_DX90,
 				BindTexture( SHADER_SAMPLER1, BASETEXTURE, FRAME );
 				pShaderAPI->BindStandardTexture( SHADER_SAMPLER3, TEXTURE_LIGHTMAP );
 			}
+#ifdef NEO
+			else
+			{
+				pShaderAPI->BindStandardTexture( SHADER_SAMPLER3, TEXTURE_LIGHTMAP );
+			}
+#endif // NEO
 
 			pShaderAPI->BindStandardTexture( SHADER_SAMPLER5, TEXTURE_NORMALIZATION_CUBEMAP_SIGNED );
 			

--- a/src/materialsystem/stdshaders/water_ps2x.fxc
+++ b/src/materialsystem/stdshaders/water_ps2x.fxc
@@ -11,6 +11,8 @@
 // STATIC: "NORMAL_DECODE_MODE"				"0..0"	[XBOX]
 // STATIC: "NORMAL_DECODE_MODE"				"0..0"	[PC]
 
+// STATIC: "LIGHTMAPWATERFOG"				"0..1"
+
 // DYNAMIC: "PIXELFOGTYPE"					"0..2"
 // DYNAMIC: "WRITE_DEPTH_TO_DESTALPHA"		"0..1"	[ps20b] [PC]
 // DYNAMIC: "WRITE_DEPTH_TO_DESTALPHA"		"0..0"	[ps20b] [XBOX]
@@ -30,7 +32,9 @@ sampler RefractSampler			: register( s0 );
 sampler BaseTextureSampler		: register( s1 );
 #endif
 sampler ReflectSampler			: register( s2 );
+#if BASETEXTURE || LIGHTMAPWATERFOG
 sampler LightmapSampler			: register( s3 );
+#endif
 sampler NormalSampler			: register( s4 );
 
 const HALF4 vRefractTint			: register( c1 );
@@ -49,9 +53,11 @@ const float3 g_EyePos				: register( c9 );
 
 struct PS_INPUT
 {
+#if LIGHTMAPWATERFOG
 	float4 vBumpTexCoordlightmapTexCoord3	: TEXCOORD0;
-// CENTROID: TEXCOORD0.zw
-//	HALF2 lightmapTexCoord3			: TEXCOORD0.zw;
+#else
+	float2 vBumpTexCoord			: TEXCOORD0;
+#endif
 	half3 vTangentEyeVect			: TEXCOORD1;
 	float4 vReflectXY_vRefractYX	: TEXCOORD2;
 	float4 vWorldPos_projPosW		: TEXCOORD3;
@@ -60,8 +66,16 @@ struct PS_INPUT
 #if MULTITEXTURE
 	float4 vExtraBumpTexCoord		: TEXCOORD6;
 #endif
-// CENTROID: TEXCOORD6
+#if LIGHTMAPWATERFOG
 	HALF4 lightmapTexCoord1And2		: TEXCOORD7;
+#else
+#if BASETEXTURE
+	HALF4 lightmapTexCoord1And2		: TEXCOORD6;
+// CENTROID: TEXCOORD7
+	HALF4 lightmapTexCoord3			: TEXCOORD7;
+// CENTROID: TEXCOORD6
+#endif
+#endif
 
 	float4 fogFactorW				: COLOR1;
 };
@@ -70,7 +84,11 @@ float4 main( PS_INPUT i ) : COLOR
 {
 	DrawWater_params_t params;
 
+#if LIGHTMAPWATERFOG
 	params.vBumpTexCoord = i.vBumpTexCoordlightmapTexCoord3.xy;
+#else
+	params.vBumpTexCoord = i.vBumpTexCoord;
+#endif
 #if MULTITEXTURE
 	params.vExtraBumpTexCoord = i.vExtraBumpTexCoord;
 #endif
@@ -82,8 +100,14 @@ float4 main( PS_INPUT i ) : COLOR
 	params.vRefractTint = vRefractTint;
 	params.vTangentEyeVect = i.vTangentEyeVect;
 	params.waterFogColor = g_WaterFogColor;
+#if BASETEXTURE || LIGHTMAPWATERFOG
 	params.lightmapTexCoord1And2 = i.lightmapTexCoord1And2;
+#if LIGHTMAPWATERFOG
 	params.lightmapTexCoord3 = i.vBumpTexCoordlightmapTexCoord3.zw;
+#else
+	params.lightmapTexCoord3 = i.lightmapTexCoord3;
+#endif
+#endif
 	params.vProjPos = i.vProjPos;
 	params.pixelFogParams = g_PixelFogParams;
 	params.fWaterFogStart = g_WaterFogStart;
@@ -98,7 +122,9 @@ float4 main( PS_INPUT i ) : COLOR
 #if BASETEXTURE
 			   BaseTextureSampler,
 #endif
+#if BASETEXTURE || LIGHTMAPWATERFOG
 			   LightmapSampler,
+#endif
 			   NormalSampler, RefractSampler, ReflectSampler,
 			   result, fogFactor );
 

--- a/src/materialsystem/stdshaders/water_ps2x.fxc
+++ b/src/materialsystem/stdshaders/water_ps2x.fxc
@@ -70,10 +70,10 @@ struct PS_INPUT
 	HALF4 lightmapTexCoord1And2		: TEXCOORD7;
 #else
 #if BASETEXTURE
+// CENTROID: TEXCOORD6
 	HALF4 lightmapTexCoord1And2		: TEXCOORD6;
 // CENTROID: TEXCOORD7
 	HALF4 lightmapTexCoord3			: TEXCOORD7;
-// CENTROID: TEXCOORD6
 #endif
 #endif
 

--- a/src/materialsystem/stdshaders/water_ps2x.fxc
+++ b/src/materialsystem/stdshaders/water_ps2x.fxc
@@ -30,9 +30,7 @@ sampler RefractSampler			: register( s0 );
 sampler BaseTextureSampler		: register( s1 );
 #endif
 sampler ReflectSampler			: register( s2 );
-#if BASETEXTURE
 sampler LightmapSampler			: register( s3 );
-#endif
 sampler NormalSampler			: register( s4 );
 
 const HALF4 vRefractTint			: register( c1 );
@@ -51,7 +49,9 @@ const float3 g_EyePos				: register( c9 );
 
 struct PS_INPUT
 {
-	float2 vBumpTexCoord			: TEXCOORD0;
+	float4 vBumpTexCoordlightmapTexCoord3	: TEXCOORD0;
+// CENTROID: TEXCOORD0.zw
+//	HALF2 lightmapTexCoord3			: TEXCOORD0.zw;
 	half3 vTangentEyeVect			: TEXCOORD1;
 	float4 vReflectXY_vRefractYX	: TEXCOORD2;
 	float4 vWorldPos_projPosW		: TEXCOORD3;
@@ -60,12 +60,8 @@ struct PS_INPUT
 #if MULTITEXTURE
 	float4 vExtraBumpTexCoord		: TEXCOORD6;
 #endif
-#if BASETEXTURE
 // CENTROID: TEXCOORD6
-	HALF4 lightmapTexCoord1And2		: TEXCOORD6;
-// CENTROID: TEXCOORD7
-	HALF4 lightmapTexCoord3			: TEXCOORD7;
-#endif
+	HALF4 lightmapTexCoord1And2		: TEXCOORD7;
 
 	float4 fogFactorW				: COLOR1;
 };
@@ -74,7 +70,7 @@ float4 main( PS_INPUT i ) : COLOR
 {
 	DrawWater_params_t params;
 
-	params.vBumpTexCoord = i.vBumpTexCoord;
+	params.vBumpTexCoord = i.vBumpTexCoordlightmapTexCoord3.xy;
 #if MULTITEXTURE
 	params.vExtraBumpTexCoord = i.vExtraBumpTexCoord;
 #endif
@@ -86,10 +82,8 @@ float4 main( PS_INPUT i ) : COLOR
 	params.vRefractTint = vRefractTint;
 	params.vTangentEyeVect = i.vTangentEyeVect;
 	params.waterFogColor = g_WaterFogColor;
-#if BASETEXTURE
 	params.lightmapTexCoord1And2 = i.lightmapTexCoord1And2;
-	params.lightmapTexCoord3 = i.lightmapTexCoord3;
-#endif
+	params.lightmapTexCoord3 = i.vBumpTexCoordlightmapTexCoord3.zw;
 	params.vProjPos = i.vProjPos;
 	params.pixelFogParams = g_PixelFogParams;
 	params.fWaterFogStart = g_WaterFogStart;
@@ -102,9 +96,9 @@ float4 main( PS_INPUT i ) : COLOR
 	DrawWater( params, 
 			   // yay. . can't put sampler in a struct.
 #if BASETEXTURE
-			   BaseTextureSampler, 
-			   LightmapSampler, 
+			   BaseTextureSampler,
 #endif
+			   LightmapSampler,
 			   NormalSampler, RefractSampler, ReflectSampler,
 			   result, fogFactor );
 

--- a/src/materialsystem/stdshaders/water_ps2x_helper.h
+++ b/src/materialsystem/stdshaders/water_ps2x_helper.h
@@ -211,7 +211,7 @@ void DrawWater( in DrawWater_params_t i,
 
 	// blend between refraction and fog color.
 #if LIGHTMAPWATERFOG
-	// strictly increase fog brightness due to diffuselighting
+	// shift lightmap value by fog alpha
 	float4 waterFogColor = i.waterFogColor * float4(lerp(diffuseLighting, (255.f, 255.f, 255.f), i.waterFogColor.a), 1.f);
 #else
 	float4 waterFogColor = i.waterFogColor;

--- a/src/materialsystem/stdshaders/water_ps2x_helper.h
+++ b/src/materialsystem/stdshaders/water_ps2x_helper.h
@@ -15,8 +15,10 @@ struct DrawWater_params_t
 	float4 vRefractTint;
 	half3 vTangentEyeVect;
 	float4 waterFogColor;
+#if BASETEXTURE || LIGHTMAPWATERFOG
 	HALF4 lightmapTexCoord1And2;
 	HALF2 lightmapTexCoord3;
+#endif
 	float4 vProjPos;
 	float4 pixelFogParams;
 	float fWaterFogStart;
@@ -25,7 +27,7 @@ struct DrawWater_params_t
 	float3 vWorldPos;
 };
 
-void DrawWater( in DrawWater_params_t i,
+void DrawWater( in DrawWater_params_t i, 
 #if BASETEXTURE
 				in sampler BaseTextureSampler,
 #endif
@@ -209,6 +211,7 @@ void DrawWater( in DrawWater_params_t i,
 
 	// blend between refraction and fog color.
 #if LIGHTMAPWATERFOG
+	// strictly increase fog brightness due to diffuselighting
 	float4 waterFogColor = i.waterFogColor * float4(lerp(diffuseLighting, (255.f, 255.f, 255.f), i.waterFogColor.a), 1.f);
 #else
 	float4 waterFogColor = i.waterFogColor;
@@ -239,7 +242,7 @@ void DrawWater( in DrawWater_params_t i,
 	else
 	{
 		result = float4( 0.0f, 0.0f, 0.0f, 0.0f );
-	}	
+	}
 
 	fogFactor = CalcPixelFogFactor( PIXELFOGTYPE, i.pixelFogParams, i.vEyePos.xyz, i.vWorldPos.xyz, i.vProjPos.z );
 

--- a/src/materialsystem/stdshaders/water_ps2x_helper.h
+++ b/src/materialsystem/stdshaders/water_ps2x_helper.h
@@ -25,11 +25,13 @@ struct DrawWater_params_t
 	float3 vWorldPos;
 };
 
-void DrawWater( in DrawWater_params_t i, 
+void DrawWater( in DrawWater_params_t i,
 #if BASETEXTURE
 				in sampler BaseTextureSampler,
 #endif
+#if BASETEXTURE || LIGHTMAPWATERFOG
 			    in sampler LightmapSampler,
+#endif
 				in sampler NormalSampler,
 			    in sampler RefractSampler,
 			    in sampler ReflectSampler,
@@ -174,6 +176,10 @@ void DrawWater( in DrawWater_params_t i,
 	fFresnel *= saturate( ( waterFogDepthValue - 0.05f ) * 20.0f );
 #endif
 
+#if BASETEXTURE || LIGHTMAPWATERFOG
+#if BASETEXTURE
+	float4 baseSample = tex2D( BaseTextureSampler, i.vBumpTexCoord.xy );
+#endif
 	HALF2 bumpCoord1;
 	HALF2 bumpCoord2;
 	HALF2 bumpCoord3;
@@ -196,19 +202,22 @@ void DrawWater( in DrawWater_params_t i,
 		dp.z * lightmapColor3;
 	float sum = dot( dp, float3( 1.0f, 1.0f, 1.0f ) );
 	diffuseLighting *= LIGHT_MAP_SCALE / sum;
-
 #if BASETEXTURE
-	float4 baseSample = tex2D( BaseTextureSampler, i.vBumpTexCoord.xy );
 	HALF3 diffuseComponent = baseSample.rgb * diffuseLighting;
+#endif
 #endif
 
 	// blend between refraction and fog color.
-#if ABOVEWATER
-	float4 waterFogColor = float4(i.waterFogColor.rgb * diffuseLighting, i.waterFogColor.a * LIGHT_MAP_SCALE);
-	vRefractColor = lerp( vRefractColor, waterFogColor, saturate( waterFogDepthValue - 0.05f ) );
+#if LIGHTMAPWATERFOG
+	float4 waterFogColor = i.waterFogColor * float4(lerp(diffuseLighting, (255.f, 255.f, 255.f), i.waterFogColor.a), 1.f);
 #else
-	float waterFogFactor = saturate( ( i.vProjPos.z - i.fWaterFogStart ) / i.fWaterFogEndMinusStart );
-	vRefractColor = lerp( vRefractColor, i.waterFogColor * LINEAR_LIGHT_SCALE, waterFogFactor );
+	float4 waterFogColor = i.waterFogColor;
+#endif
+#if ABOVEWATER
+	vRefractColor = lerp( vRefractColor, waterFogColor * LINEAR_LIGHT_SCALE, saturate( waterFogDepthValue - 0.05f ) );
+#else
+	float waterFogFactor = saturate((i.vProjPos.z - i.fWaterFogStart) / i.fWaterFogEndMinusStart);
+	vRefractColor = lerp( vRefractColor, waterFogColor * LINEAR_LIGHT_SCALE, waterFogFactor );
 #endif
 
 	if( bReflect && bRefract )
@@ -230,7 +239,7 @@ void DrawWater( in DrawWater_params_t i,
 	else
 	{
 		result = float4( 0.0f, 0.0f, 0.0f, 0.0f );
-	}
+	}	
 
 	fogFactor = CalcPixelFogFactor( PIXELFOGTYPE, i.pixelFogParams, i.vEyePos.xyz, i.vWorldPos.xyz, i.vProjPos.z );
 

--- a/src/materialsystem/stdshaders/water_ps2x_helper.h
+++ b/src/materialsystem/stdshaders/water_ps2x_helper.h
@@ -15,10 +15,8 @@ struct DrawWater_params_t
 	float4 vRefractTint;
 	half3 vTangentEyeVect;
 	float4 waterFogColor;
-#if BASETEXTURE
 	HALF4 lightmapTexCoord1And2;
-	HALF4 lightmapTexCoord3;
-#endif
+	HALF2 lightmapTexCoord3;
 	float4 vProjPos;
 	float4 pixelFogParams;
 	float fWaterFogStart;
@@ -30,8 +28,8 @@ struct DrawWater_params_t
 void DrawWater( in DrawWater_params_t i, 
 #if BASETEXTURE
 				in sampler BaseTextureSampler,
-			    in sampler LightmapSampler,
 #endif
+			    in sampler LightmapSampler,
 				in sampler NormalSampler,
 			    in sampler RefractSampler,
 			    in sampler ReflectSampler,
@@ -176,17 +174,6 @@ void DrawWater( in DrawWater_params_t i,
 	fFresnel *= saturate( ( waterFogDepthValue - 0.05f ) * 20.0f );
 #endif
 
-
-	// blend between refraction and fog color.
-#if ABOVEWATER
-	vRefractColor = lerp( vRefractColor, i.waterFogColor * LINEAR_LIGHT_SCALE, saturate( waterFogDepthValue - 0.05f ) );
-#else
-	float waterFogFactor = saturate( ( i.vProjPos.z - i.fWaterFogStart ) / i.fWaterFogEndMinusStart );
-	vRefractColor = lerp( vRefractColor, i.waterFogColor * LINEAR_LIGHT_SCALE, waterFogFactor );
-#endif
-
-#if BASETEXTURE
-	float4 baseSample = tex2D( BaseTextureSampler, i.vBumpTexCoord.xy );
 	HALF2 bumpCoord1;
 	HALF2 bumpCoord2;
 	HALF2 bumpCoord3;
@@ -209,7 +196,19 @@ void DrawWater( in DrawWater_params_t i,
 		dp.z * lightmapColor3;
 	float sum = dot( dp, float3( 1.0f, 1.0f, 1.0f ) );
 	diffuseLighting *= LIGHT_MAP_SCALE / sum;
+
+#if BASETEXTURE
+	float4 baseSample = tex2D( BaseTextureSampler, i.vBumpTexCoord.xy );
 	HALF3 diffuseComponent = baseSample.rgb * diffuseLighting;
+#endif
+
+	// blend between refraction and fog color.
+#if ABOVEWATER
+	float4 waterFogColor = float4(i.waterFogColor.rgb * diffuseLighting, i.waterFogColor.a * LIGHT_MAP_SCALE);
+	vRefractColor = lerp( vRefractColor, waterFogColor, saturate( waterFogDepthValue - 0.05f ) );
+#else
+	float waterFogFactor = saturate( ( i.vProjPos.z - i.fWaterFogStart ) / i.fWaterFogEndMinusStart );
+	vRefractColor = lerp( vRefractColor, i.waterFogColor * LINEAR_LIGHT_SCALE, waterFogFactor );
 #endif
 
 	if( bReflect && bRefract )


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

neo assets pr https://github.com/NeotokyoRebuild/neoAssets/pull/120

Adds support for the $lightmapwaterfog water texture param used in games post l4d2. I wasn't able to get the scale to which the shadow is applied to the fog colour, so I made it depend on the alpha value of the water fog colour.

Keep in mind, water with this parameter needs to have a lightmap. Depending on the bsp compiler used, setting $lightmapwaterfog before compiling may be enough, or you may have to add a compiler flag like "%compileKeepLight". You can check if a water surface has a lightmap with the mat_luxels 1 command. If the surface is entirely filled in in blue, there is no lightmap. If instead you can see a square grid pattern corresponding to the lightmap resolution, the water has a lightmap.

Some example images
$lightmapwaterfog 0
<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/b2d7ba2e-4d33-44c6-951e-451e3e0c012c" />

$lightmapwaterfog 1 $fogcolor" "{52 49 44 0}
<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/dd5caad5-e8a0-453e-bed3-d2fd5eb2447a" />

$lightmapwaterfog 1 $fogcolor" "{52 49 44 1}
<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/0925d090-8f8c-4704-9b55-7feae3a1d085" />

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022
