### PR TITLE
Don't sort cloaked players with translucent entities when they're drawn opaque in thermals

### DIFF
--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -688,12 +688,12 @@ int C_NEO_Player::DrawModel(int flags)
 	bool inThermalVision = pTargetPlayer ? (pTargetPlayer->IsInVision() && pTargetPlayer->GetClass() == NEO_CLASS_SUPPORT) : false;
 
 	int ret = 0;
-	if (!m_bInThermOpticCamo || inThermalVision)
+	if (!IsCloaked() || inThermalVision)
 	{
 		ret |= BaseClass::DrawModel(flags);
 	}
 
-	if (m_bInThermOpticCamo && !inThermalVision)
+	if (IsCloaked() && !inThermalVision)
 	{
 		IMaterial* pass = materials->FindMaterial("models/player/toc", TEXTURE_GROUP_CLIENT_EFFECTS);
 		modelrender->ForcedMaterialOverride(pass);
@@ -701,7 +701,7 @@ int C_NEO_Player::DrawModel(int flags)
 		modelrender->ForcedMaterialOverride(nullptr);
 	}
 
-	else if (inThermalVision && !m_bInThermOpticCamo)
+	else if (inThermalVision && !IsCloaked())
 	{
 		IMaterial* pass = materials->FindMaterial(NEO_THERMAL_MODEL_MATERIAL, TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
@@ -749,21 +749,24 @@ void C_NEO_Player::AddPoints(int score, bool bAllowNegativeScore, bool bIgnorePl
 	//pl.frags = m_iFrags; NEO TODO (Adam) Is this actually used anywhere? should we include a xp field in CPlayerState?
 }
 
-bool C_NEO_Player::IsCloaked() const
+bool C_NEO_Player::IsDrawnTransparent() const
 {
 	auto pTargetPlayer = C_NEO_Player::GetVisionTargetNEOPlayer();
 	if (!pTargetPlayer)
 	{
-		return m_bInThermOpticCamo;
+		return IsCloaked();
 	}
 	
 	bool inThermalVision = pTargetPlayer->IsInVision() && pTargetPlayer->GetClass() == NEO_CLASS_SUPPORT;
-	return m_bInThermOpticCamo && !inThermalVision;
+	return IsCloaked() && !inThermalVision;
 }
 
 ShadowType_t C_NEO_Player::ShadowCastType( void ) 
 {
-	if (m_bInThermOpticCamo)
+	// NEO TODO (Adam) should cloaked players cast shadows in thermals? If they are drawn opaque, it follows that cloaked players block light on a 
+	// spectrum that thermals can see, so light in that same spectrum would be absent where the shadow would be, hence the shadow should be drawn
+	// if so, replace IsCloaked() with IsDrawnTransparent()
+	if (IsCloaked())
 	{
 		return SHADOWS_NONE;
 	}
@@ -782,12 +785,12 @@ const QAngle& C_NEO_Player::GetRenderAngles()
 
 RenderGroup_t C_NEO_Player::GetRenderGroup()
 {
-	return IsCloaked() ? RENDER_GROUP_TRANSLUCENT_ENTITY : RENDER_GROUP_OPAQUE_ENTITY;
+	return IsDrawnTransparent() ? RENDER_GROUP_TRANSLUCENT_ENTITY : RENDER_GROUP_OPAQUE_ENTITY;
 }
 
 bool C_NEO_Player::UsesPowerOfTwoFrameBufferTexture()
 {
-	return IsCloaked();
+	return IsDrawnTransparent();
 }
 
 bool C_NEO_Player::ShouldDraw( void )

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -763,7 +763,7 @@ bool C_NEO_Player::IsCloaked() const
 
 ShadowType_t C_NEO_Player::ShadowCastType( void ) 
 {
-	if (IsCloaked())
+	if (m_bInThermOpticCamo)
 	{
 		return SHADOWS_NONE;
 	}

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -688,12 +688,12 @@ int C_NEO_Player::DrawModel(int flags)
 	bool inThermalVision = pTargetPlayer ? (pTargetPlayer->IsInVision() && pTargetPlayer->GetClass() == NEO_CLASS_SUPPORT) : false;
 
 	int ret = 0;
-	if (!IsCloaked() || inThermalVision)
+	if (!m_bInThermOpticCamo || inThermalVision)
 	{
 		ret |= BaseClass::DrawModel(flags);
 	}
 
-	if (IsCloaked() && !inThermalVision)
+	if (m_bInThermOpticCamo && !inThermalVision)
 	{
 		IMaterial* pass = materials->FindMaterial("models/player/toc", TEXTURE_GROUP_CLIENT_EFFECTS);
 		modelrender->ForcedMaterialOverride(pass);
@@ -701,7 +701,7 @@ int C_NEO_Player::DrawModel(int flags)
 		modelrender->ForcedMaterialOverride(nullptr);
 	}
 
-	else if (inThermalVision && !IsCloaked())
+	else if (inThermalVision && !m_bInThermOpticCamo)
 	{
 		IMaterial* pass = materials->FindMaterial(NEO_THERMAL_MODEL_MATERIAL, TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
@@ -747,6 +747,18 @@ void C_NEO_Player::AddPoints(int score, bool bAllowNegativeScore, bool bIgnorePl
 
 	m_iXP += score;
 	//pl.frags = m_iFrags; NEO TODO (Adam) Is this actually used anywhere? should we include a xp field in CPlayerState?
+}
+
+bool C_NEO_Player::IsCloaked() const
+{
+	auto pTargetPlayer = C_NEO_Player::GetVisionTargetNEOPlayer();
+	if (!pTargetPlayer)
+	{
+		return m_bInThermOpticCamo;
+	}
+	
+	bool inThermalVision = pTargetPlayer->IsInVision() && pTargetPlayer->GetClass() == NEO_CLASS_SUPPORT;
+	return m_bInThermOpticCamo && !inThermalVision;
 }
 
 ShadowType_t C_NEO_Player::ShadowCastType( void ) 

--- a/src/game/client/neo/c_neo_player.h
+++ b/src/game/client/neo/c_neo_player.h
@@ -162,7 +162,7 @@ public:
 
 	C_NEOPredictedViewModel *GetNEOViewModel() { return static_cast<C_NEOPredictedViewModel*>(GetViewModel()); }
 
-	bool IsCloaked() const { return m_bInThermOpticCamo; }
+	bool IsCloaked() const;
 	float GetCloakFactor() const { return m_flTocFactor; }
 	bool IsAirborne() const { return (!(GetFlags() & FL_ONGROUND)); }
 	bool IsInVision() const { return m_bInVision; }

--- a/src/game/client/neo/c_neo_player.h
+++ b/src/game/client/neo/c_neo_player.h
@@ -162,7 +162,8 @@ public:
 
 	C_NEOPredictedViewModel *GetNEOViewModel() { return static_cast<C_NEOPredictedViewModel*>(GetViewModel()); }
 
-	bool IsCloaked() const;
+	inline bool IsCloaked() const { return m_bInThermOpticCamo; }
+	bool IsDrawnTransparent() const;
 	float GetCloakFactor() const { return m_flTocFactor; }
 	bool IsAirborne() const { return (!(GetFlags() & FL_ONGROUND)); }
 	bool IsInVision() const { return m_bInVision; }

--- a/src/game/client/neo/neo_mp3player.cpp
+++ b/src/game/client/neo/neo_mp3player.cpp
@@ -157,8 +157,7 @@ public:
 			}
 
 			float flVol =
-					(cvr_snd_mute_losefocus.GetBool() && 
-						false == engine->IsActiveApp())
+					(cvr_snd_mute_losefocus.GetBool() && false == engine->IsActiveApp())
 						? 0.0f
 						: (cl_neo_radio_volume_separate_ingame.GetBool() && IsInGame())
 							? cl_neo_radio_volume_ingame.GetFloat()

--- a/src/game/client/neo/neo_mp3player.cpp
+++ b/src/game/client/neo/neo_mp3player.cpp
@@ -157,7 +157,8 @@ public:
 			}
 
 			float flVol =
-					(cvr_snd_mute_losefocus.GetBool() && false == engine->IsActiveApp())
+					(cvr_snd_mute_losefocus.GetBool() && 
+						false == engine->IsActiveApp())
 						? 0.0f
 						: (cl_neo_radio_volume_separate_ingame.GetBool() && IsInGame())
 							? cl_neo_radio_volume_ingame.GetFloat()

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -231,6 +231,9 @@ ConVar sv_neo_bot_cloak_detection_bonus_lighting("sv_neo_bot_cloak_detection_bon
 	"Bot cloak detection bonus for target being in a well lit area (scaled by light intensity ratio 0.0-1.0)", true, 0, true, 100);
 
 
+ConVar sv_neo_infinite_cloak("sv_neo_infinite_cloak", "0", FCVAR_CHEAT | FCVAR_REPLICATED, "Don't drain cloak", true, 0, true, 1);
+
+
 void CNEO_Player::RequestSetClass(int newClass)
 {
 	if (newClass < 0 || newClass >= NEO_CLASS_ENUM_COUNT)
@@ -3702,6 +3705,12 @@ void CNEO_Player::CloakPower_Update(void)
 
 bool CNEO_Player::CloakPower_Drain(float flPower)
 {
+	// NEO TODO (Adam) predict client side
+	if (sv_neo_infinite_cloak.GetBool())
+	{
+		return true;
+	}
+
 	m_HL2Local.m_cloakPower -= flPower;
 
 	if (m_HL2Local.m_cloakPower < 0.0)

--- a/src/game/shared/neo/neo_predicted_viewmodel.cpp
+++ b/src/game/shared/neo/neo_predicted_viewmodel.cpp
@@ -626,10 +626,9 @@ void CNEOPredictedViewModel::ProcessMuzzleFlashEvent()
 
 RenderGroup_t CNEOPredictedViewModel::GetRenderGroup()
 {
-	auto pPlayer = static_cast<C_NEO_Player*>(GetOwner());
-	if (pPlayer)
+	if (auto pPlayer = static_cast<C_NEO_Player*>(GetOwner()))
 	{
-		return pPlayer->IsCloaked() ? RENDER_GROUP_VIEW_MODEL_TRANSLUCENT : RENDER_GROUP_VIEW_MODEL_OPAQUE;
+		return pPlayer->IsDrawnTransparent() ? RENDER_GROUP_VIEW_MODEL_TRANSLUCENT : RENDER_GROUP_VIEW_MODEL_OPAQUE;
 	}
 
 	return BaseClass::GetRenderGroup();
@@ -637,10 +636,9 @@ RenderGroup_t CNEOPredictedViewModel::GetRenderGroup()
 
 bool CNEOPredictedViewModel::UsesPowerOfTwoFrameBufferTexture()
 {
-	auto pPlayer = static_cast<C_NEO_Player*>(GetOwner());
-	if (pPlayer)
+	if (auto pPlayer = static_cast<C_NEO_Player*>(GetOwner()))
 	{
-		return pPlayer->IsCloaked() ? true : false;
+		return pPlayer->IsDrawnTransparent() ? true : false;
 	}
 
 	return BaseClass::UsesPowerOfTwoFrameBufferTexture();

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -1293,7 +1293,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 	bool inThermalVision = pTargetPlayer->IsInVision() && pTargetPlayer->GetClass() == NEO_CLASS_SUPPORT;
 	int ret = 0;
 
-	if (inThermalVision && (!pOwner || (pOwner && !pOwner->m_bInThermOpticCamo)))
+	if (inThermalVision && (!pOwner || (pOwner && !pOwner->IsCloaked())))
 	{
 		IMaterial* pass = materials->FindMaterial("dev/thermal_weapon_model", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
@@ -1302,7 +1302,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 		return ret;
 	}
 
-	if ((pOwner && pOwner->m_bInThermOpticCamo) && !inThermalVision)
+	if ((pOwner && pOwner->IsCloaked()) && !inThermalVision)
 	{
 		IMaterial* pass = materials->FindMaterial("models/player/toc", TEXTURE_GROUP_CLIENT_EFFECTS);
 		modelrender->ForcedMaterialOverride(pass);
@@ -1318,10 +1318,9 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 
 RenderGroup_t CNEOBaseCombatWeapon::GetRenderGroup()
 {
-	auto pPlayer = static_cast<C_NEO_Player*>(GetOwner());
-	if (pPlayer)
+	if (auto pPlayer = static_cast<C_NEO_Player*>(GetOwner()))
 	{
-		return pPlayer->IsCloaked() ? RENDER_GROUP_TRANSLUCENT_ENTITY : RENDER_GROUP_OPAQUE_ENTITY;
+		return pPlayer->IsDrawnTransparent() ? RENDER_GROUP_TRANSLUCENT_ENTITY : RENDER_GROUP_OPAQUE_ENTITY;
 	}
 
 	return BaseClass::GetRenderGroup();
@@ -1329,10 +1328,9 @@ RenderGroup_t CNEOBaseCombatWeapon::GetRenderGroup()
 
 bool CNEOBaseCombatWeapon::UsesPowerOfTwoFrameBufferTexture()
 {
-	auto pPlayer = static_cast<C_NEO_Player*>(GetOwner());
-	if (pPlayer)
+	if (auto pPlayer = static_cast<C_NEO_Player*>(GetOwner()))
 	{
-		return pPlayer->IsCloaked();
+		return pPlayer->IsDrawnTransparent();
 	}
 
 	return BaseClass::UsesPowerOfTwoFrameBufferTexture();

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -1293,7 +1293,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 	bool inThermalVision = pTargetPlayer->IsInVision() && pTargetPlayer->GetClass() == NEO_CLASS_SUPPORT;
 	int ret = 0;
 
-	if (inThermalVision && (!pOwner || (pOwner && !pOwner->IsCloaked())))
+	if (inThermalVision && (!pOwner || (pOwner && !pOwner->m_bInThermOpticCamo)))
 	{
 		IMaterial* pass = materials->FindMaterial("dev/thermal_weapon_model", TEXTURE_GROUP_MODEL);
 		modelrender->ForcedMaterialOverride(pass);
@@ -1302,7 +1302,7 @@ int CNEOBaseCombatWeapon::DrawModel(int flags)
 		return ret;
 	}
 
-	if ((pOwner && pOwner->IsCloaked()) && !inThermalVision)
+	if ((pOwner && pOwner->m_bInThermOpticCamo) && !inThermalVision)
 	{
 		IMaterial* pass = materials->FindMaterial("models/player/toc", TEXTURE_GROUP_CLIENT_EFFECTS);
 		modelrender->ForcedMaterialOverride(pass);


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

This PR was made to address the following problem
https://discord.com/channels/1235346473827434517/1235349179296120946/1505292044963156141
however I'm struggling to replicate it on master now. Either way it doesn't make sense to render cloaked players with other translucent entities when they're not actually using the cloaked material override

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

