### PR TITLE
Fix neo_npc_targetsystem crashing the game

### DIFF
--- a/src/game/shared/baseentity_shared.cpp
+++ b/src/game/shared/baseentity_shared.cpp
@@ -2120,8 +2120,8 @@ void CBaseEntity::FireBullets( const FireBulletsInfo_t &info )
 		}
 		// Only draw tracers if we haven't yet penetrated, because the penetration logic is reentrant
 		// and would otherwise draw multiple tracers per shot.
-		Assert(neoWeapon);
-		if (neoWeapon->GetPenetration() == info.m_flPenetration)
+		// NEO TODO DG: Find a solution to this problem for everything, not just neoweapons
+		if ((neoWeapon && neoWeapon->GetPenetration() == info.m_flPenetration) || !neoWeapon)
 		{
 #endif
 		if ( ( info.m_iTracerFreq != 0 ) && ( tracerCount++ % info.m_iTracerFreq ) == 0 && ( bHitGlass == false ) )

--- a/src/game/shared/baseentity_shared.cpp
+++ b/src/game/shared/baseentity_shared.cpp
@@ -2111,19 +2111,6 @@ void CBaseEntity::FireBullets( const FireBulletsInfo_t &info )
 		}
 #endif // NEO
 
-#ifdef NEO
-		// The below penetration value check relies an all possible surfaces
-		// incurring a non-zero cost to m_flPenetration.
-		for (int i = 0; i < ARRAYSIZE(PENETRATION_RESISTANCE); ++i)
-		{
-			Assert(PENETRATION_RESISTANCE[i] > 0);
-		}
-		// Only draw tracers if we haven't yet penetrated, because the penetration logic is reentrant
-		// and would otherwise draw multiple tracers per shot.
-		// NEO TODO DG: Find a solution to this problem for everything, not just neoweapons
-		if ((neoWeapon && neoWeapon->GetPenetration() == info.m_flPenetration) || !neoWeapon)
-		{
-#endif
 		if ( ( info.m_iTracerFreq != 0 ) && ( tracerCount++ % info.m_iTracerFreq ) == 0 && ( bHitGlass == false ) )
 		{
 			if ( bDoServerEffects == true )
@@ -2174,9 +2161,6 @@ void CBaseEntity::FireBullets( const FireBulletsInfo_t &info )
 			}
 #endif
 		}
-#ifdef NEO
-		}
-#endif
 
 		//NOTENOTE: We could expand this to a more general solution for various material penetration types (wood, thin metal, etc)
 
@@ -2376,7 +2360,9 @@ void CBaseEntity::HandleShotPenetration(const FireBulletsInfo_t& info,
 	behindMaterialInfo.m_vecSpread = vec3_origin;
 	behindMaterialInfo.m_flDistance = info.m_flDistance * (1.0f - tr.fraction);
 	behindMaterialInfo.m_iAmmoType = info.m_iAmmoType;
-	behindMaterialInfo.m_iTracerFreq = info.m_iTracerFreq;
+	// Only draw tracers if we haven't yet penetrated, because the penetration logic is reentrant
+	// and would otherwise draw multiple tracers per shot.
+	behindMaterialInfo.m_iTracerFreq = 0;
 	behindMaterialInfo.m_flDamage = info.m_flDamage * Max(0.25f, (1.f - (penUsed / info.m_flPenetration)));
 	behindMaterialInfo.m_pAttacker = info.m_pAttacker ? info.m_pAttacker : this;
 	behindMaterialInfo.m_nFlags = info.m_nFlags;


### PR DESCRIPTION
## Description
Caused by #1895

Rather than trying to see what penetration started as and try to decide based on that, just explicitly set tracers to not be created when FireBullets is used for penetration

## Toolchain
- Windows MSVC VS2022


