### PR TITLE
Fix GCC v16.1.1 release compiler error

### DIFF
--- a/src/public/steam/matchmakingtypes.h
+++ b/src/public/steam/matchmakingtypes.h
@@ -223,7 +223,11 @@ inline const char* gameserveritem_t::GetName() const
 
 inline void gameserveritem_t::SetName( const char *pName )
 {
+#ifdef NEO
+	V_strcpy_safe(m_szServerName, pName);
+#else
 	strncpy( m_szServerName, pName, sizeof( m_szServerName ) );
+#endif
 	m_szServerName[ sizeof( m_szServerName ) - 1 ] = '\0';
 }
 


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Just ifdef NEO and switch to V_strcpy_safe to fixup GCC v16 release mode compiler error.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Arch/GCC 16


