### PR TITLE
Fixup FF crosshair being shown in hipfire when hipfire off

### DIFF
--- a/src/game/client/hud_crosshair.cpp
+++ b/src/game/client/hud_crosshair.cpp
@@ -618,19 +618,19 @@ void CHudCrosshair::Paint( void )
 			}
 		}
 	}
-	else if (showFriendlyFireCrosshair)
-	{
-		vgui::surface()->DrawSetTexture(m_iTexIFFId);
-		int iTexWide, iTexTall;
-		vgui::surface()->DrawGetTextureSize(m_iTexIFFId, iTexWide, iTexTall);
-		iTexWide >>= 2;
-		iTexTall >>= 2;
-		vgui::surface()->DrawSetColor(COLOR_RED);
-		vgui::surface()->DrawTexturedRect(iX - iTexWide, iY - iTexTall, iX + iTexWide, iY + iTexTall);
-	}
 	else if (!bHideCrosshair)
 	{
-		if (iTexXHId > 0)
+		if (showFriendlyFireCrosshair)
+		{
+			vgui::surface()->DrawSetTexture(m_iTexIFFId);
+			int iTexWide, iTexTall;
+			vgui::surface()->DrawGetTextureSize(m_iTexIFFId, iTexWide, iTexTall);
+			iTexWide >>= 2;
+			iTexTall >>= 2;
+			vgui::surface()->DrawSetColor(COLOR_RED);
+			vgui::surface()->DrawTexturedRect(iX - iTexWide, iY - iTexTall, iX + iTexWide, iY + iTexTall);
+		}
+		else if (iTexXHId > 0)
 		{
 			vgui::surface()->DrawSetTexture(iTexXHId);
 			int iTexWide, iTexTall;


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Just move the logic to under if show crosshair bool so it only shows when there's would be a (non-FF) crosshair to show.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native GCC 16 Arch


