### PR TITLE
Downgrade to windows-2022 to keep using VS2022

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -169,7 +169,7 @@ jobs:
 
       matrix:
         platform:
-        - { display_name: 'Windows Native Libraries', os: windows-2025, preset_os: windows }
+        - { display_name: 'Windows Native Libraries', os: windows-2022, preset_os: windows }
 
         preset_build_type:
         - { display_name: 'Debug', name: debug }
@@ -292,7 +292,7 @@ jobs:
   pack-resources:
     name: Windows Native Resources
 
-    runs-on: windows-2025
+    runs-on: windows-2022
 
     defaults:
       run:


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
See: https://github.com/actions/runner-images/issues/14017

As it stands, if we keep on using windows-2025 every builds from now on will end up using VS2026 and it's hard crashing at the moment:
https://developercommunity.visualstudio.com/t/MSVC-v1451-Linker-Crash-in-IncrCalcPtrs/11090307

2026-06-10 main branch build run:
https://github.com/NeotokyoRebuild/neo/actions/runs/27300329689

This crash may only be for a short duration and VS2026 updates but still I think VS2026 is too new and isn't ready yet.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0
-->
- Windows MSVC VS2022
- Windows MSVC VS2026


