### PR TITLE
Update developer "getting started" docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,11 @@ See [README.md](README.md) in this repo for setting up your build environment (c
 To be safe and avoid problems with VAC, it's recommended to add a [-insecure](https://developer.valvesoftware.com/wiki/Command_Line_Options) launch flag before attaching your debugger.
 
 #### VS2022 + CMake (Windows)
+
+> [!NOTE]
+> We do *not* officially support Visual Studio 2026 at this time! If you run into issues, please consider downgrading to VS 2022 for now.
+> 
+
 In the CMake Target View, right-click "client (shared library)" and click on "Add Debug Configuration". This should generate the `src/.vs/launch.vs.json` config file.
 
 Modify the config to fix the directory paths; an example is provided below:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,13 @@ Modify the config to fix the directory paths; an example is provided below:
 ```
 
 #### Qt Creator (Linux)
-On the sidebar, click "Projects" then under your current kit, click "Run". Set the following:
+On the sidebar, click "Projects" then under your current kit, click "Run".
+
+By default, you may have one of the test configurations chosen as the currently active run configuration (`test_neo_crosshair`, etc).
+To create a new configuration, press "Add" and choose "Custom executable" (tested on Qt Creator 13.0.0, but the exact menus and wording
+may depend on your Qt Creator version).
+
+Once you have a fresh *Run configuration* created, set the following properties for it:
 
 | Property | Example value |
 | :---------------------------------- | :------------ |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To see the Table of Contents, please use the "Outline" feature on GitHub by clic
 
 * Windows: [Visual Studio 2022 (MSVC v143)](https://visualstudio.microsoft.com/downloads/)
     * Make sure to include C++ development environment, C++ MFC Library, Windows 10/11 SDK, and CMake during installation
+    * Please note that we do not currently officially support Visual Studio 2026
 * Linux: [Steam Runtime 3 "Sniper"](https://gitlab.steamos.cloud/steamrt/sniper/sdk)
     * GCC/G++ 10 toolchain
     * Compiled in the sniper's Docker/Podman/Toolbx container, schroot, or systemd-nspawn


### PR DESCRIPTION
## Description
* Add note about there being no VS 2026 support currently (since that's what Microsoft will currently encourage people to use), to avoid confusion. For more info on the support status, see #1984.
* Add more info about configuring the Qt Creator run configurations, since we now have some test configurations that may be default-populated as the initial option in the Qt Creator configuration menus.

## Toolchain
N/A

## Linked Issues
- related #1984 
- related #1804

