### PR TITLE
Silence leaf shadow count assert spam

### DIFF
--- a/src/game/client/clientleafsystem.cpp
+++ b/src/game/client/clientleafsystem.cpp
@@ -1020,7 +1020,12 @@ void CClientLeafSystem::AddShadowToLeaf( int leaf, ClientLeafShadowHandle_t shad
 			info.m_EnumCount = m_ShadowEnum;
 		}
 
+#ifdef NEO
+		// don't nuke dev build perf by spamming the assert every frame
+		AssertOnce(m_ShadowsInLeaf.NumAllocated() < 2000);
+#else
 		Assert(m_ShadowsInLeaf.NumAllocated() < 2000);
+#endif
 
 		i = m_RenderablesInLeaf.NextElement(i);
 	}

--- a/src/game/client/clientleafsystem.cpp
+++ b/src/game/client/clientleafsystem.cpp
@@ -1004,20 +1004,6 @@ void CClientLeafSystem::RemoveShadowFromRenderables( ClientLeafShadowHandle_t ha
 //-----------------------------------------------------------------------------
 void CClientLeafSystem::AddShadowToLeaf( int leaf, ClientLeafShadowHandle_t shadow )
 {
-#if defined(DEBUG) && defined(NEO)
-	static constexpr const char *ASSERT_MAPS_TO_IGNORE[] = {
-		"ntre_engage_ctg", "ntre_skyline_ctg", "ntre_rise_ctg"
-	};
-	bool bIgnoreAssert = false;
-	for (const char *pszMapCmp : ASSERT_MAPS_TO_IGNORE)
-	{
-		if (FStrEq(MapName(), pszMapCmp))
-		{
-			bIgnoreAssert = true;
-			break;
-		}
-	}
-#endif // defined(DEBUG) && defined(NEO)
 	m_ShadowsInLeaf.AddElementToBucket( leaf, shadow ); 
 
 	// Add the shadow exactly once to all renderables in the leaf
@@ -1034,16 +1020,7 @@ void CClientLeafSystem::AddShadowToLeaf( int leaf, ClientLeafShadowHandle_t shad
 			info.m_EnumCount = m_ShadowEnum;
 		}
 
-#ifdef DEBUG
-#ifdef NEO
-		// Few maps will happily blows past this limit, but it seems to be fine.
-		// Just ignoring this specific case in debug.
-		if (!bIgnoreAssert)
-#endif
-		{
-			Assert(m_ShadowsInLeaf.NumAllocated() < 2000);
-		}
-#endif
+		Assert(m_ShadowsInLeaf.NumAllocated() < 2000);
 
 		i = m_RenderablesInLeaf.NextElement(i);
 	}


### PR DESCRIPTION
## Description
Silence the assertion spam that would trigger for every frame on debug builds when `m_ShadowsInLeaf > 2000`, tanking dev build performance.

We previously had a clunky per-map check in place to try and silence the warning, but the map list wasn't comprehensive, and also completely hiding the issue wasn't too great either. So instead just assert once, until we can either fix the shadow counts or decide to bump the shadow count upper bound for the assertion.

## Toolchain
- Windows MSVC VS2022

## Linked Issues

