### PR TITLE
Fix not initialized m_pFilterPanel pointer

### DIFF
--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -661,6 +661,8 @@ CBaseHudChat::CBaseHudChat( const char *pElementName )
 	}
 
 	m_pChatHistory = new CHudChatHistory( this, "HudChatHistory" );
+	
+	m_pFilterPanel = NULL;
 
 	CreateChatLines();
 	CreateChatInputLine();

--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -662,8 +662,10 @@ CBaseHudChat::CBaseHudChat( const char *pElementName )
 
 	m_pChatHistory = new CHudChatHistory( this, "HudChatHistory" );
 	
+#ifdef NEO
 	m_pFilterPanel = NULL;
-
+#endif
+	
 	CreateChatLines();
 	CreateChatInputLine();
 	GetChatFilterPanel();


### PR DESCRIPTION
## Description
`m_pFilterPanel` pointer is not initialized by default, which can skip memory allocation under `if ( m_pFilterPanel == NULL )` check, and then we use it in `m_pFilterPanel->SetVisible( false );`

## Toolchain
- Linux GCC Distro Native [Arch Linux, g++ (GCC) 16.1.1 20260430]

## Linked Issues
- fixes #1977 

