### PR TITLE
Fix GCC 16 c_baseentity connect/disconnect game crash

### DIFF
--- a/src/game/client/c_baseentity.h
+++ b/src/game/client/c_baseentity.h
@@ -1646,9 +1646,15 @@ private:
 
 #if !defined( NO_ENTITY_PREDICTION )
 	// For storing prediction results and pristine network state
+#ifdef NEO
+	byte							*m_pIntermediateData[ MULTIPLAYER_BACKUP ] = {};
+	byte							*m_pOriginalData = nullptr;
+	int								m_nIntermediateDataCount = 0;
+#else
 	byte							*m_pIntermediateData[ MULTIPLAYER_BACKUP ];
 	byte							*m_pOriginalData;
 	int								m_nIntermediateDataCount;
+#endif
 
 	bool							m_bIsPlayerSimulated;
 #endif


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Just connect and disconnect local server game multiple of times. Without this fix it'll crash within 1st-4/5th time, seemly on uninit pointer on deinit. Happens Linux GCC 16+ release mode only.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
- Windows MSVC VS2022
- Linux GCC 10 Sniper 3.0
-->
- Linux GCC Distro Native Arch GCC 16

<!--
## Linked Issues

Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

- fixes #
- related #
-->

