### PR TITLE
Sparse neoAssets checkout and NEO_EXTRA_ASSETS_ALT_PATH

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -63,6 +63,18 @@ jobs:
 
     # Libraries
 
+    - name: Sparse fetch neoAssets
+      uses: actions/checkout@v6
+      with:
+        repository: NeotokyoRebuild/neoAssets
+        path: neoAssets
+        sparse-checkout:
+          neo/detail.vbsp
+          neo/lights.rad
+          neo/resource/
+          neo/shaders/fxc/
+          neo/rebuild.fgd
+
     - name: CMake configure libraries build
       working-directory: ${{ env.source_dir }}
       run: >
@@ -75,6 +87,7 @@ jobs:
         -DNEO_USE_SEPARATE_BUILD_INFO=ON
         -DNEO_INSTALL_LIBRARIES=ON
         -DNEO_INSTALL_RESOURCES=OFF
+        -DNEO_EXTRA_ASSETS_ALT_PATH=${{ github.workspace }}/neoAssets
 
     - name: CMake libraries build
       working-directory: ${{ env.source_dir }}
@@ -205,6 +218,18 @@ jobs:
 
     # Libraries
 
+    - name: Sparse fetch neoAssets
+      uses: actions/checkout@v6
+      with:
+        repository: NeotokyoRebuild/neoAssets
+        path: neoAssets
+        sparse-checkout:
+          neo/detail.vbsp
+          neo/lights.rad
+          neo/resource/
+          neo/shaders/fxc/
+          neo/rebuild.fgd
+
     - name: CMake configure libraries build
       working-directory: ${{ env.source_dir }}
       run: >
@@ -217,6 +242,7 @@ jobs:
         -DNEO_USE_SEPARATE_BUILD_INFO=ON
         -DNEO_INSTALL_LIBRARIES=ON
         -DNEO_INSTALL_RESOURCES=OFF
+        -DNEO_EXTRA_ASSETS_ALT_PATH=${{ github.workspace }}/neoAssets
 
     - name: CMake libraries build
       working-directory: ${{ env.source_dir }}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ option(NEO_BUILD_MATHLIB "Build mathlib library" ON)
 option(NEO_BUILD_VGUI_CONTROLS "Build vgui_controls library" ON)
 option(NEO_COPY_LIBRARIES "Copy libraries to bin directory by default" ON)
 option(NEO_EXTRA_ASSETS "Copy extra assets into game/neo" ON)
+option(NEO_EXTRA_ASSETS_ALT_PATH "Alternate location to fetch the extra assets" "")
 if (OS_LINUX)
     set(NEO_OUTPUT_LIBRARY_PATH "${CMAKE_SOURCE_DIR}/../game/neo/bin/linux64" CACHE PATH "Directory for output libraries (linux64)")
 else ()
@@ -67,6 +68,7 @@ message(STATUS "Build mathlib library: ${NEO_BUILD_MATHLIB}")
 message(STATUS "Build vgui_controls library: ${NEO_BUILD_VGUI_CONTROLS}")
 message(STATUS "Copy libraries to bin directory by default: ${NEO_COPY_LIBRARIES}")
 message(STATUS "Copy extra assets into game/neo: ${NEO_EXTRA_ASSETS}")
+message(STATUS "Alternate location to fetch the extra assets: ${NEO_EXTRA_ASSETS_ALT_PATH}")
 message(STATUS "Directory for output libraries: ${NEO_OUTPUT_LIBRARY_PATH}")
 message(STATUS "Install game libraries: ${NEO_INSTALL_LIBRARIES}")
 message(STATUS "Install game resources: ${NEO_INSTALL_RESOURCES}")
@@ -593,23 +595,30 @@ if(NEO_INSTALL_RESOURCES)
 endif()
 
 if(NEO_EXTRA_ASSETS)
-    include(FetchContent) # once in the project to include the module
+    if(NEO_EXTRA_ASSETS_ALT_PATH)
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                "${NEO_EXTRA_ASSETS_ALT_PATH}/neo"
+                "${CMAKE_SOURCE_DIR}/../game/neo")
+    else()
+        include(FetchContent) # once in the project to include the module
 
-    FetchContent_Declare(
-        neo_assets
-        GIT_REPOSITORY https://github.com/NeotokyoRebuild/neoAssets.git
-        GIT_TAG master # Replace with a commit hash or other tag to select a specific version of the assets, remove GIT_SHALLOW if using commit hash
-        GIT_SHALLOW 1
-        GIT_PROGRESS TRUE
-        USES_TERMINAL_DOWNLOAD TRUE
-    )
+        FetchContent_Declare(
+            neo_assets
+            GIT_REPOSITORY https://github.com/NeotokyoRebuild/neoAssets.git
+            GIT_TAG master # Replace with a commit hash or other tag to select a specific version of the assets, remove GIT_SHALLOW if using commit hash
+            GIT_SHALLOW 1
+            GIT_PROGRESS TRUE
+            USES_TERMINAL_DOWNLOAD TRUE
+        )
 
-    FetchContent_MakeAvailable(neo_assets)
+        FetchContent_MakeAvailable(neo_assets)
 
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            "${neo_assets_SOURCE_DIR}/neo"
-            "${CMAKE_SOURCE_DIR}/../game/neo")
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                "${neo_assets_SOURCE_DIR}/neo"
+                "${CMAKE_SOURCE_DIR}/../game/neo")
+    endif()
 endif()
 
 add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ option(NEO_BUILD_MATHLIB "Build mathlib library" ON)
 option(NEO_BUILD_VGUI_CONTROLS "Build vgui_controls library" ON)
 option(NEO_COPY_LIBRARIES "Copy libraries to bin directory by default" ON)
 option(NEO_EXTRA_ASSETS "Copy extra assets into game/neo" ON)
-option(NEO_EXTRA_ASSETS_ALT_PATH "Alternate location to fetch the extra assets" "")
+set(NEO_EXTRA_ASSETS_ALT_PATH "" CACHE PATH "Alternate location to fetch the extra assets")
 if (OS_LINUX)
     set(NEO_OUTPUT_LIBRARY_PATH "${CMAKE_SOURCE_DIR}/../game/neo/bin/linux64" CACHE PATH "Directory for output libraries (linux64)")
 else ()
@@ -601,12 +601,12 @@ if(NEO_EXTRA_ASSETS)
                 "${NEO_EXTRA_ASSETS_ALT_PATH}/neo"
                 "${CMAKE_SOURCE_DIR}/../game/neo")
     else()
-        include(FetchContent) # once in the project to include the module
+        include(FetchContent)
 
         FetchContent_Declare(
             neo_assets
             GIT_REPOSITORY https://github.com/NeotokyoRebuild/neoAssets.git
-            GIT_TAG master # Replace with a commit hash or other tag to select a specific version of the assets, remove GIT_SHALLOW if using commit hash
+            GIT_TAG master
             GIT_SHALLOW 1
             GIT_PROGRESS TRUE
             USES_TERMINAL_DOWNLOAD TRUE


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
In the CMake add NEO_EXTRA_ASSETS_ALT_PATH option as an alternate neoAssets path to use rather than going through FetchContent. This is used mainly for the CI build to first sparse fetch the neoAssets files as it doesn't need all the files especially since some files are very large and not even used in the build process. This cuts down the overall time to do the whole process. This can also be useful for devs if they prefer to juse fetch it from their already checkedout neoAssets.

* Comparisons:
    * Non-unity, full: https://github.com/NeotokyoRebuild/neo/actions/runs/27134842462
    * Unity, full: https://github.com/NeotokyoRebuild/neo/actions/runs/27227387768
    * Unity, sparse: https://github.com/NeotokyoRebuild/neo/actions/runs/27379727581
* Times:
    * Linux debug github runner: 16m16s -> 5m27s -> 3m45s (4.33x speedup from non-unity, full)
    * Linux release github runner: 18m16s -> 9m41s -> 6m42s (2.72x)
    * Windows debug github runner: 14m17s -> 4m58s -> 2m48s (5.1x)
    * Windows release github runner: 14m45s -> 6m5s -> 3m40s (4.0x)

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Arch/GCC 16

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #1991

