### PR TITLE
Fix bots not being able to see ghoster behind smoke

### DIFF
--- a/src/game/server/NextBot/NextBotVisionInterface.cpp
+++ b/src/game/server/NextBot/NextBotVisionInterface.cpp
@@ -723,13 +723,22 @@ bool IVision::IsLineOfSightClear( const Vector &pos ) const
 bool IVision::IsLineOfSightClearToEntity( const CBaseEntity *subject, Vector *visibleSpot ) const
 {
 #ifdef NEO
-	// Special case for Support-class bots to see through smoke
-	bool isSupport = false;
+	bool canSeeThroughSmoke = false;
 	if (auto player = ToNEOPlayer(GetBot()->GetEntity()))
 	{
-		isSupport = (player->GetClass() == NEO_CLASS_SUPPORT);
+		// Bot has thermal vision as a Support class
+		canSeeThroughSmoke = (player->GetClass() == NEO_CLASS_SUPPORT);
 	}
-	ScopedSmokeLOS smokeGuard(isSupport);
+	if (!canSeeThroughSmoke)
+	{
+		const auto *pSubjectPlayer = ToNEOPlayer(subject);
+		if (pSubjectPlayer && pSubjectPlayer->IsCarryingGhost())
+		{
+			// Ghoster is always visible through smoke
+			canSeeThroughSmoke = true;
+		}
+	}
+	ScopedSmokeLOS smokeGuard(canSeeThroughSmoke);
 #endif
 
 #ifdef TERROR

--- a/src/game/server/neo/neo_player.h
+++ b/src/game/server/neo/neo_player.h
@@ -377,4 +377,13 @@ inline CNEO_Player *ToNEOPlayer(CBaseEntity *pEntity)
 	return assert_cast<CNEO_Player*>(pEntity);
 }
 
+inline const CNEO_Player *ToNEOPlayer(const CBaseEntity *pEntity)
+{
+	if (!pEntity || !pEntity->IsPlayer())
+	{
+		return nullptr;
+	}
+	return assert_cast<const CNEO_Player*>(pEntity);
+}
+
 #endif // NEO_PLAYER_H


### PR DESCRIPTION
## Description
Fixes bots not being able to see a ghost carrier from behind smoke despite the apparent glowing beacon visible by human players.

## Toolchain
- Windows MSVC VS2022
