### PR TITLE
Hitbox group pen

### DIFF
--- a/src/game/client/neo/c_neo_player.h
+++ b/src/game/client/neo/c_neo_player.h
@@ -61,6 +61,7 @@ public:
 	virtual float GetFOV( void );
 	virtual CStudioHdr *OnNewModel( void );
 	virtual void TraceAttack( const CTakeDamageInfo &info, const Vector &vecDir, trace_t *ptr, CDmgAccumulator *pAccumulator );
+	virtual bool TestHitboxes(const Ray_t &ray, unsigned int fContentsMask, trace_t &tr) override;
 	virtual void ItemPreFrame( void );
 	virtual void ItemPostFrame( void );
 	virtual float GetMinFOV()	const;

--- a/src/game/server/neo/neo_player.h
+++ b/src/game/server/neo/neo_player.h
@@ -101,6 +101,7 @@ public:
 	virtual CBaseEntity* FindUseEntity() override;
 
 	virtual void InitVCollision(const Vector& vecAbsOrigin, const Vector& vecAbsVelocity) OVERRIDE;
+	virtual bool TestHitboxes(const Ray_t &ray, unsigned int fContentsMask, trace_t &tr) override;
 
 	virtual void ModifyFireBulletsDamage(CTakeDamageInfo* dmgInfo) OVERRIDE;
 

--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -755,28 +755,31 @@ bool CNEO_Player::TestHitboxes(const Ray_t& ray, unsigned int fContentsMask, tra
 		tr.surface.flags = SURF_HITBOX;
 		tr.surface.surfaceProps = physprops->GetSurfaceIndex( pBone->pszSurfaceProp() );
 		
-		switch (tr.hitgroup)
+		if (fContentsMask & CONTENTS_HITBOX)
 		{
-			case HITGROUP_LEFTARM:
-			case HITGROUP_RIGHTARM:
-			case HITGROUP_LEFTLEG:
-			case HITGROUP_RIGHTLEG:
-			case HITGROUP_GEAR:
-				trace_t secondTrace;
-				unsigned int fHitboxGroupMask = UINT_MAX;
-				fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_LEFTARM);
-				fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_RIGHTARM);
-				fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_LEFTLEG);
-				fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_RIGHTLEG);
-				fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_GEAR);
-#ifdef GAME_DLL
-				if (TraceToStudio(physprops, ray, pStudioHdr, set, hitboxbones, fContentsMask, GetAbsOrigin(), GetModelScale(), secondTrace, fHitboxGroupMask))
-#else
-				if (TraceToStudio(physprops, ray, pStudioHdr, set, hitboxbones, fContentsMask, GetRenderOrigin(), GetModelScale(), secondTrace, fHitboxGroupMask))
-#endif // GAME_DLL
-				{
-					tr.hitgroup = secondTrace.hitgroup;
-				}
+			switch (tr.hitgroup)
+			{
+				case HITGROUP_LEFTARM:
+				case HITGROUP_RIGHTARM:
+				case HITGROUP_LEFTLEG:
+				case HITGROUP_RIGHTLEG:
+				case HITGROUP_GEAR:
+					trace_t secondTrace;
+					unsigned int fHitboxGroupMask = UINT_MAX;
+					fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_LEFTARM);
+					fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_RIGHTARM);
+					fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_LEFTLEG);
+					fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_RIGHTLEG);
+					fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_GEAR);
+	#ifdef GAME_DLL
+					if (TraceToStudio(physprops, ray, pStudioHdr, set, hitboxbones, fContentsMask, GetAbsOrigin(), GetModelScale(), secondTrace, fHitboxGroupMask))
+	#else
+					if (TraceToStudio(physprops, ray, pStudioHdr, set, hitboxbones, fContentsMask, GetRenderOrigin(), GetModelScale(), secondTrace, fHitboxGroupMask))
+	#endif // GAME_DLL
+					{
+						tr.hitgroup = secondTrace.hitgroup;
+					}
+			}
 		}
 
 #ifdef CLIENT_DLL

--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -16,6 +16,7 @@
 #include "c_neo_player.h"
 #include "c_playerresource.h"
 #include "ui/neo_hud_context_hint.h"
+#include "vprof.h"
 #define CNEO_Player C_NEO_Player
 #else
 #include "neo_player.h"
@@ -41,6 +42,8 @@
 #else
 #include "c_te_effect_dispatch.h"
 #endif // GAME_DLL
+
+#include "bone_setup.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -707,4 +710,87 @@ CBaseEntity *CNEO_Player::FindUseEntity()
 	}
 
 	return pNearest;
+}
+
+bool CNEO_Player::TestHitboxes(const Ray_t& ray, unsigned int fContentsMask, trace_t& tr)
+{
+#ifdef CLIENT_DLL
+	VPROF( "C_BaseAnimating::TestHitboxes" );
+
+	MDLCACHE_CRITICAL_SECTION();
+#endif // CLIENT_DLL
+
+	CStudioHdr *pStudioHdr = GetModelPtr();
+	if (!pStudioHdr)
+		return false;
+
+	mstudiohitboxset_t *set = pStudioHdr->pHitboxSet( m_nHitboxSet );
+	if ( !set || !set->numhitboxes )
+		return false;
+
+	// Use vcollide for box traces.
+	if ( !ray.m_IsRay )
+		return false;
+
+	// This *has* to be true for the existing code to function correctly.
+	Assert( ray.m_StartOffset == vec3_origin );
+
+#ifdef GAME_DLL
+	CBoneCache *pCache = GetBoneCache( );
+#else
+	CBoneCache *pCache = GetBoneCache( pStudioHdr );
+#endif // GAME_DLL
+	matrix3x4_t *hitboxbones[MAXSTUDIOBONES];
+	pCache->ReadCachedBonePointers( hitboxbones, pStudioHdr->numbones() );
+
+#ifdef GAME_DLL
+	if ( TraceToStudio( physprops, ray, pStudioHdr, set, hitboxbones, fContentsMask, GetAbsOrigin(), GetModelScale(), tr ) )
+#else
+	if ( TraceToStudio( physprops, ray, pStudioHdr, set, hitboxbones, fContentsMask, GetRenderOrigin(), GetModelScale(), tr ) )
+#endif // GAME_DLL
+	{
+		mstudiobbox_t *pbox = set->pHitbox( tr.hitbox );
+		mstudiobone_t *pBone = pStudioHdr->pBone(pbox->bone);
+		tr.surface.name = "**studio**";
+		tr.surface.flags = SURF_HITBOX;
+		tr.surface.surfaceProps = physprops->GetSurfaceIndex( pBone->pszSurfaceProp() );
+		
+		switch (tr.hitgroup)
+		{
+			case HITGROUP_LEFTARM:
+			case HITGROUP_RIGHTARM:
+			case HITGROUP_LEFTLEG:
+			case HITGROUP_RIGHTLEG:
+			case HITGROUP_GEAR:
+				trace_t secondTrace;
+				unsigned int fHitboxGroupMask = UINT_MAX;
+				fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_LEFTARM);
+				fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_RIGHTARM);
+				fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_LEFTLEG);
+				fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_RIGHTLEG);
+				fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_GEAR);
+#ifdef GAME_DLL
+				if (TraceToStudio(physprops, ray, pStudioHdr, set, hitboxbones, fContentsMask, GetAbsOrigin(), GetModelScale(), secondTrace, fHitboxGroupMask))
+#else
+				if (TraceToStudio(physprops, ray, pStudioHdr, set, hitboxbones, fContentsMask, GetRenderOrigin(), GetModelScale(), secondTrace, fHitboxGroupMask))
+#endif // GAME_DLL
+				{
+					tr.hitgroup = secondTrace.hitgroup;
+				}
+		}
+
+#ifdef CLIENT_DLL
+		if ( IsRagdoll() )
+		{
+			IPhysicsObject *pReplace = m_pRagdoll->GetElement( tr.physicsbone );
+			if ( pReplace )
+			{
+				VPhysicsSetObject( NULL );
+				VPhysicsSetObject( pReplace );
+			}
+		}
+#endif // CLIENT_DLL
+	}
+
+	return true;
 }

--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -764,14 +764,11 @@ bool CNEO_Player::TestHitboxes(const Ray_t& ray, unsigned int fContentsMask, tra
 				case HITGROUP_RIGHTARM:
 				case HITGROUP_LEFTLEG:
 				case HITGROUP_RIGHTLEG:
-				case HITGROUP_GEAR:
 					trace_t secondTrace;
-					unsigned int fHitboxGroupMask = UINT_MAX;
-					fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_LEFTARM);
-					fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_RIGHTARM);
-					fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_LEFTLEG);
-					fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_RIGHTLEG);
-					fHitboxGroupMask = fHitboxGroupMask & ~(1 << HITGROUP_GEAR);
+					unsigned int fHitboxGroupMask = UINT_MAX & ~((1 << HITGROUP_LEFTARM) | 
+																(1 << HITGROUP_RIGHTARM) | 
+																(1 << HITGROUP_LEFTLEG) | 
+																(1 << HITGROUP_RIGHTLEG));
 	#ifdef GAME_DLL
 					if (TraceToStudio(physprops, ray, pStudioHdr, set, hitboxbones, fContentsMask, GetAbsOrigin(), GetModelScale(), secondTrace, fHitboxGroupMask))
 	#else

--- a/src/game/shared/neo/neo_player_shared.cpp
+++ b/src/game/shared/neo/neo_player_shared.cpp
@@ -712,6 +712,7 @@ CBaseEntity *CNEO_Player::FindUseEntity()
 	return pNearest;
 }
 
+ConVar sv_neo_hitboxgroup_pen("sv_neo_hitboxgroup_pen", "0", FCVAR_REPLICATED, "When hitting outer limbs, do a second trace against head, chest and stomach", true, 0.f, true, 1.f); // NEO TODO (Adam) remove this and pick one
 bool CNEO_Player::TestHitboxes(const Ray_t& ray, unsigned int fContentsMask, trace_t& tr)
 {
 #ifdef CLIENT_DLL
@@ -755,7 +756,7 @@ bool CNEO_Player::TestHitboxes(const Ray_t& ray, unsigned int fContentsMask, tra
 		tr.surface.flags = SURF_HITBOX;
 		tr.surface.surfaceProps = physprops->GetSurfaceIndex( pBone->pszSurfaceProp() );
 		
-		if (fContentsMask & CONTENTS_HITBOX)
+		if (fContentsMask & CONTENTS_HITBOX && sv_neo_hitboxgroup_pen.GetBool())
 		{
 			switch (tr.hitgroup)
 			{

--- a/src/public/bone_setup.cpp
+++ b/src/public/bone_setup.cpp
@@ -5380,8 +5380,12 @@ bool SweepBoxToStudio( IPhysicsSurfaceProps *pProps, const Ray_t& ray, CStudioHd
 //-----------------------------------------------------------------------------
 // Purpose:
 //-----------------------------------------------------------------------------
-bool TraceToStudio( IPhysicsSurfaceProps *pProps, const Ray_t& ray, CStudioHdr *pStudioHdr, mstudiohitboxset_t *set, 
+bool TraceToStudio( IPhysicsSurfaceProps *pProps, const Ray_t& ray, CStudioHdr *pStudioHdr, mstudiohitboxset_t *set,
+#ifdef NEO
+				   matrix3x4_t **hitboxbones, int fContentsMask, const Vector &vecOrigin, float flScale, trace_t &tr, unsigned int fHitboxGroupMask )
+#else
 				   matrix3x4_t **hitboxbones, int fContentsMask, const Vector &vecOrigin, float flScale, trace_t &tr )
+#endif // NEO
 {
 	if ( !ray.m_IsRay )
 	{
@@ -5399,6 +5403,11 @@ bool TraceToStudio( IPhysicsSurfaceProps *pProps, const Ray_t& ray, CStudioHdr *
 	for ( int i = 0; i < set->numhitboxes; i++ )
 	{
 		mstudiobbox_t *pbox = set->pHitbox(i);
+
+#ifdef NEO
+		if ((fHitboxGroupMask & (1 << pbox->group)) == 0)
+			continue;
+#endif // NEO
 
 		// Filter based on contents mask
 		int fBoneContents = pStudioHdr->pBone( pbox->bone )->contents;

--- a/src/public/bone_setup.h
+++ b/src/public/bone_setup.h
@@ -462,7 +462,11 @@ void Studio_DestroyBoneCache( memhandle_t cacheHandle );
 void Studio_InvalidateBoneCache( memhandle_t cacheHandle );
 
 // Given a ray, trace for an intersection with this studiomodel.  Get the array of bones from StudioSetupHitboxBones
+#ifdef NEO
+bool TraceToStudio( class IPhysicsSurfaceProps *pProps, const Ray_t& ray, CStudioHdr *pStudioHdr, mstudiohitboxset_t *set, matrix3x4_t **hitboxbones, int fContentsMask, const Vector &vecOrigin, float flScale, trace_t &trace, unsigned int fHitboxGroupMask = UINT_MAX );
+#else
 bool TraceToStudio( class IPhysicsSurfaceProps *pProps, const Ray_t& ray, CStudioHdr *pStudioHdr, mstudiohitboxset_t *set, matrix3x4_t **hitboxbones, int fContentsMask, const Vector &vecOrigin, float flScale, trace_t &trace );
+#endif // NEO
 
 void QuaternionSM( float s, const Quaternion &p, const Quaternion &q, Quaternion &qt );
 void QuaternionMA( const Quaternion &p, float s, const Quaternion &q, Quaternion &qt );


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Any bullet that hits a player model extremity now does a second check where it hit a player while ignoring those hitbox groups, generally decreasing the ttk as for example arms no longer block shots to the chest.

Currently stops shots that would have gibbed a model from doing so if the shot ends up hitting a main hitbox behind it, I'm going to say that's fine for now? My explanation for that is uhh the limb has something to brace against so it doesn't pop off as easily.

Might need to ask the community what they think.

Shotguns are very scary now.

Tbh even an srm shreds now.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022