### PR TITLE
Don't copy takeover bot's class loadout choice

### DIFF
--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -2051,8 +2051,6 @@ void C_NEO_Player::CSpectatorTakeoverPlayerUpdate(C_NEO_Player* pPlayerTakeoverT
 
 	m_nSkin = pPlayerTakeoverTarget->m_iNeoSkin;
 	m_iNeoClass = pPlayerTakeoverTarget->m_iNeoClass;
-	m_iLoadoutWepChoice = pPlayerTakeoverTarget->m_iLoadoutWepChoice;
-	m_iNextSpawnClassChoice = pPlayerTakeoverTarget->m_iNextSpawnClassChoice;
 
 	m_bInThermOpticCamo = pPlayerTakeoverTarget->m_bInThermOpticCamo;
 	m_bInVision = pPlayerTakeoverTarget->m_bInVision;

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -4177,7 +4177,6 @@ void CNEO_Player::SpectatorTakeoverPlayerPreThink()
 			SetArmorValue(pPlayerTakeoverTarget->ArmorValue());
 			m_HL2Local.m_cloakPower = pPlayerTakeoverTarget->m_HL2Local.m_cloakPower;
 			m_HL2Local.m_flSuitPower = pPlayerTakeoverTarget->m_HL2Local.m_flSuitPower;
-			m_iLoadoutWepChoice = pPlayerTakeoverTarget->m_iLoadoutWepChoice;
 
 			m_bInThermOpticCamo = pPlayerTakeoverTarget->m_bInThermOpticCamo;
 			m_bHasBeenAirborneForTooLongToSuperJump = pPlayerTakeoverTarget->m_bHasBeenAirborneForTooLongToSuperJump;
@@ -4185,8 +4184,6 @@ void CNEO_Player::SpectatorTakeoverPlayerPreThink()
 			Weapon_SetZoom(pPlayerTakeoverTarget->m_bInAim);
 			m_bCarryingGhost = pPlayerTakeoverTarget->m_bCarryingGhost;
 			m_bInLean = pPlayerTakeoverTarget->m_bInLean;
-			m_iLoadoutWepChoice = pPlayerTakeoverTarget->m_iLoadoutWepChoice;
-			m_iNextSpawnClassChoice = pPlayerTakeoverTarget->m_iNextSpawnClassChoice;
 			m_flCamoAuxLastTime = pPlayerTakeoverTarget->m_flCamoAuxLastTime;
 			m_flLastAirborneJumpOkTime = pPlayerTakeoverTarget->m_flLastAirborneJumpOkTime;
 			m_flLastSuperJumpTime = pPlayerTakeoverTarget->m_flLastSuperJumpTime;


### PR DESCRIPTION
## Description
Do not overwrite player's class/loadout choices when they take over a bot.

## Toolchain
- Windows MSVC VS2022

