### PR TITLE
Fix bots choosing empty weapon slots

### DIFF
--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -601,52 +601,17 @@ CNEOBot::~CNEOBot()
 void CNEOBot::Spawn()
 {
 	// CNEOBot do m_iNeoClass a bit earlier
-	if ((m_iNextSpawnClassChoice != NEO_CLASS_RANDOM) && (m_iNeoClass != m_iNextSpawnClassChoice))
+	// so that we get correct loadout choices for the class
+	if (m_iNextSpawnClassChoice == NEO_CLASS_RANDOM) 
+	{
+		m_iNeoClass = ChooseRandomClass();
+	}
+	else if (m_iNeoClass != m_iNextSpawnClassChoice)
 	{
 		RequestSetClass(m_iNextSpawnClassChoice);
 	}
 
-	const ENeoRank eRank = static_cast<ENeoRank>(GetRank(m_iXP) - 1);
-	if (eRank == NEO_RANK_RANKLESS_DOG || (false == IN_BETWEEN_EQ(NEO_CLASS_RECON, m_iNeoClass, NEO_CLASS_VIP)))
-	{
-		m_iLoadoutWepChoice = 0;
-	}
-	else
-	{
-		const NEO_WEP_BITS_UNDERLYING_TYPE wepPrefsForCurRank = m_profile.flagsWepPrefs[m_iNeoClass][eRank];
-
-		int iChosenWeps[MAX_WEAPON_LOADOUTS] = {};
-		int iChosenWepsSize = 0;
-		for (int i = 0; i < MAX_WEAPON_LOADOUTS; ++i)
-		{
-			if (wepPrefsForCurRank & CNEOWeaponLoadout::s_LoadoutWeapons[m_iNeoClass][i].info.m_iWepBit)
-			{
-				iChosenWeps[iChosenWepsSize++] = i;
-			}
-		}
-
-		if (iChosenWepsSize == 0)
-		{
-			// Generally shouldn't happen, but if so, just pick from any under the XP limit
-			for (int i = 0; i < MAX_WEAPON_LOADOUTS; ++i)
-			{
-				if (CNEOWeaponLoadout::s_LoadoutWeapons[m_iNeoClass][i].m_iWeaponPrice > m_iXP)
-				{
-					break;
-				}
-				iChosenWeps[iChosenWepsSize++] = i;
-			}
-		}
-
-		if (iChosenWepsSize == 1)
-		{
-			m_iLoadoutWepChoice = iChosenWeps[0];
-		}
-		else
-		{
-			m_iLoadoutWepChoice = iChosenWeps[RandomInt(0, iChosenWepsSize - 1)];
-		}
-	}
+	ChooseRandomWeapon();
 
 	BaseClass::Spawn();
 
@@ -673,6 +638,53 @@ void CNEOBot::Spawn()
 
 	m_bWantsRespawn = false;
 	m_bRespawnCopyCorpse = false;
+}
+
+int CNEOBot::ChooseRandomWeaponIndex() const
+{
+    const ENeoRank eRank = static_cast<ENeoRank>(GetRank(m_iXP) - 1);
+    if (eRank == NEO_RANK_RANKLESS_DOG || (false == IN_BETWEEN_EQ(NEO_CLASS_RECON, m_iNeoClass, NEO_CLASS_VIP)))
+    {
+        return 0;
+    }
+    const NEO_WEP_BITS_UNDERLYING_TYPE wepPrefsForCurRank = m_profile.flagsWepPrefs[m_iNeoClass][eRank];
+
+    int iChosenWeps[MAX_WEAPON_LOADOUTS] = {};
+    int iChosenWepsSize = 0;
+    for (int i = 0; i < MAX_WEAPON_LOADOUTS; ++i)
+    {
+        if (wepPrefsForCurRank & CNEOWeaponLoadout::s_LoadoutWeapons[m_iNeoClass][i].info.m_iWepBit)
+        {
+            iChosenWeps[iChosenWepsSize++] = i;
+        }
+    }
+
+    if (iChosenWepsSize == 0)
+    {
+		// Generally shouldn't happen, but if so, just pick from any under the XP limit
+        for (int i = 0; i < MAX_WEAPON_LOADOUTS; ++i)
+        {
+            if (CNEOWeaponLoadout::s_LoadoutWeapons[m_iNeoClass][i].m_iWeaponPrice > m_iXP)
+            {
+                break;
+            }
+            iChosenWeps[iChosenWepsSize++] = i;
+        }
+    }
+
+    if (iChosenWepsSize == 1)
+    {
+        return iChosenWeps[0];
+    }
+    else
+    {
+        return iChosenWeps[RandomInt(0, iChosenWepsSize - 1)];
+    }
+}
+
+void CNEOBot::ChooseRandomWeapon()
+{
+	m_iLoadoutWepChoice = ChooseRandomWeaponIndex();
 }
 
 

--- a/src/game/server/neo/bot/neo_bot.h
+++ b/src/game/server/neo/bot/neo_bot.h
@@ -438,6 +438,8 @@ public:
 
 	CNEOBotProfile m_profile = {};
 	NeoClass ChooseRandomClass() const;
+	void ChooseRandomWeapon();
+	int ChooseRandomWeaponIndex() const;
 	int m_iIntendTeam = 0;
 	int m_iProfileIdx = -1;
 

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -697,9 +697,15 @@ void CNEO_Player::Spawn(void)
 		if (forcedBotClass == NEO_CLASS_RANDOM)
 		{
 			if (auto* thisBot = ToNEOBot(this))
+			{
 				m_iNextSpawnClassChoice = thisBot->ChooseRandomClass();
+				m_iNeoClass = m_iNextSpawnClassChoice;
+				m_iLoadoutWepChoice = thisBot->ChooseRandomWeaponIndex();
+			}
 			else
+			{
 				AssertMsg(false, "this IsBot() but can't convert to NEO bot!?");
+			}
 		}
 		else
 		{


### PR DESCRIPTION
## Description
Fix bots choosing empty weapon slots after they choose a different class, where they previously selected a weapon with a selection index that would be an invalid/empty weapon slot with their new class.

## Toolchain
- Windows MSVC VS2022

## Related
- fixes: #1619
