### PR TITLE
Assisted suicides also by world and indicate assists in kill feed.

### DIFF
--- a/src/game/client/neo/ui/neo_hud_deathnotice.cpp
+++ b/src/game/client/neo/ui/neo_hud_deathnotice.cpp
@@ -384,35 +384,35 @@ void CNEOHud_DeathNotice::SetDeathNoticeItemDimensions(DeathNoticeItem* deathNot
 	}
 	else
 	{	// Player killed message
-		if (deathNoticeItem->Killer.iEntIndex != 0 && !deathNoticeItem->bSuicide)
+		if (!deathNoticeItem->bSuicide && deathNoticeItem->Killer.iEntIndex != 0)
 		{
 			surface()->GetTextSize(g_hFontKillfeed, deathNoticeItem->Killer.szName, width, height);
 			totalWidth += width;
 		}
-		if (deathNoticeItem->Assist.iEntIndex != 0 && !deathNoticeItem->bSuicide)
+		if (deathNoticeItem->Assist.iEntIndex != 0)
 		{
-			surface()->GetTextSize(g_hFontKillfeed, deathNoticeItem->Assist.szName, width, height);
-			totalWidth += width;
+			if (deathNoticeItem->bSuicide && deathNoticeItem->Victim.iEntIndex != 0)
+			{
+				surface()->GetTextSize(g_hFontKillfeed, deathNoticeItem->Victim.szName, width, height);
+				totalWidth += width;
+			}
 			surface()->GetTextSize(g_hFontKillfeed, ASSIST_SEPARATOR, width, height);
 			totalWidth += width;
-		}
-		if (deathNoticeItem->Victim.iEntIndex != 0)
-		{
-			surface()->GetTextSize(g_hFontKillfeed, deathNoticeItem->Victim.szName, width, height);
+			surface()->GetTextSize(g_hFontKillfeed, deathNoticeItem->Assist.szName, width, height);
 			totalWidth += width;
-			if (!deathNoticeItem->bSuicide)
-			{
-				totalWidth += spaceLength;
-			}
 		}
 		if (deathNoticeItem->bSuicide)
 		{
+			if (deathNoticeItem->Assist.iEntIndex != 0)
+			{
+				totalWidth += spaceLength;
+			}
 			totalWidth += surface()->GetCharacterWidth(g_hFontKillfeedIcons, NEO_HUD_DEATHNOTICEICON_SHORTBUS) + spaceLength;
 		}
 		else
 		{
 			surface()->GetTextSize(g_hFontKillfeedIcons, deathNoticeItem->szDeathIcon, width, height);
-			totalWidth += width + spaceLength;
+			totalWidth += width + spaceLength + spaceLength;
 			if (deathNoticeItem->bExplosive)
 			{
 				totalWidth += surface()->GetCharacterWidth(g_hFontKillfeedIcons, NEO_HUD_DEATHNOTICEICON_EXPLODE) + spaceLength;
@@ -422,9 +422,14 @@ void CNEOHud_DeathNotice::SetDeathNoticeItemDimensions(DeathNoticeItem* deathNot
 				totalWidth += surface()->GetCharacterWidth(g_hFontKillfeedIcons, NEO_HUD_DEATHNOTICEICON_HEADSHOT) + spaceLength;
 			}
 		}
+		if (deathNoticeItem->Victim.iEntIndex != 0)
+		{
+			surface()->GetTextSize(g_hFontKillfeed, deathNoticeItem->Victim.szName, width, height);
+			totalWidth += width;
+		}
 		if (deathNoticeItem->bWasCarryingGhost)
 		{
-			totalWidth += surface()->GetCharacterWidth(g_hFontKillfeedIcons, NEO_HUD_DEATHNOTICEICON_GHOST) + spaceLength + spaceLength;
+			totalWidth += surface()->GetCharacterWidth(g_hFontKillfeedIcons, NEO_HUD_DEATHNOTICEICON_GHOST) + spaceLength;
 		}
 	}
 	deathNoticeItem->iLength = totalWidth;
@@ -459,27 +464,35 @@ void CNEOHud_DeathNotice::DrawPlayerDeath(int i)
 {
 	DrawCommon(i);
 
+	// Killer
+	if (!m_DeathNotices[i].bSuicide && m_DeathNotices[i].Killer.iEntIndex != 0)
+	{
+		SetColorForNoticePlayer(m_DeathNotices[i].Killer.iTeam);
+		surface()->DrawSetTextFont(g_hFontKillfeed);
+		surface()->DrawPrintText(m_DeathNotices[i].Killer.szName, m_DeathNotices[i].Killer.iNameLength);
+	}
+
+	// Assister
+	if (m_DeathNotices[i].Assist.iEntIndex != 0)
+	{
+		if (m_DeathNotices[i].bSuicide && m_DeathNotices[i].Victim.iEntIndex != 0)
+		{
+			// Victim in killer position if suicide and there's an assister
+			SetColorForNoticePlayer(m_DeathNotices[i].Victim.iTeam);
+			surface()->DrawSetTextFont(g_hFontKillfeed);
+			surface()->DrawPrintText(m_DeathNotices[i].Victim.szName, m_DeathNotices[i].Victim.iNameLength);
+		}
+
+		surface()->DrawSetTextColor(COLOR_NEO_WHITE);
+		surface()->DrawPrintText(ASSIST_SEPARATOR, ASSIST_SEPARATOR_LENGTH - 1);
+
+		SetColorForNoticePlayer(m_DeathNotices[i].Assist.iTeam);
+		surface()->DrawSetTextFont(g_hFontKillfeed);
+		surface()->DrawPrintText(m_DeathNotices[i].Assist.szName, m_DeathNotices[i].Assist.iNameLength);
+	}
+
 	if (!m_DeathNotices[i].bSuicide)
 	{
-		// Killer
-		if (m_DeathNotices[i].Killer.iEntIndex != 0)
-		{
-			SetColorForNoticePlayer(m_DeathNotices[i].Killer.iTeam);
-			surface()->DrawSetTextFont(g_hFontKillfeed);
-			surface()->DrawPrintText(m_DeathNotices[i].Killer.szName, m_DeathNotices[i].Killer.iNameLength);
-		}
-
-		// Assister
-		if (m_DeathNotices[i].Assist.iEntIndex != 0)
-		{
-			surface()->DrawSetTextColor(COLOR_NEO_WHITE);
-			surface()->DrawPrintText(ASSIST_SEPARATOR, ASSIST_SEPARATOR_LENGTH - 1);
-
-			SetColorForNoticePlayer(m_DeathNotices[i].Assist.iTeam);
-			surface()->DrawSetTextFont(g_hFontKillfeed);
-			surface()->DrawPrintText(m_DeathNotices[i].Assist.szName, m_DeathNotices[i].Assist.iNameLength);
-		}
-
 		// Icons
 		surface()->DrawSetTextFont(g_hFontKillfeed);
 		surface()->DrawPrintText(L" ", 1);
@@ -503,39 +516,38 @@ void CNEOHud_DeathNotice::DrawPlayerDeath(int i)
 			surface()->DrawPrintText(&icon, 1);
 		}
 	}
-
-	// Victim
-	if (m_DeathNotices[i].Victim.iEntIndex != 0)
+	else
 	{
-		surface()->DrawSetTextFont(g_hFontKillfeed);
-		if (!m_DeathNotices[i].bSuicide)
+		// Suicide Icon
+		if (m_DeathNotices[i].Assist.iEntIndex != 0)
 		{
+			surface()->DrawSetTextFont(g_hFontKillfeed);
 			surface()->DrawPrintText(L" ", 1);
 		}
-		SetColorForNoticePlayer(m_DeathNotices[i].Victim.iTeam);
-		surface()->DrawPrintText(m_DeathNotices[i].Victim.szName, m_DeathNotices[i].Victim.iNameLength);
-	}
-
-	// Victim Ghoster Icon
-	if (m_DeathNotices[i].bWasCarryingGhost)
-	{
-		surface()->DrawSetTextFont(g_hFontKillfeed);
-		surface()->DrawPrintText(L" ", 1);
-		surface()->DrawSetTextFont(g_hFontKillfeedIcons);
-		surface()->DrawSetTextColor(COLOR_NEO_WHITE);
-		wchar_t icon = NEO_HUD_DEATHNOTICEICON_GHOST;
-		surface()->DrawPrintText(&icon, 1);
-	}
-
-	// Suicide Icon
-	if (m_DeathNotices[i].bSuicide)
-	{
-		surface()->DrawSetTextFont(g_hFontKillfeed);
-		surface()->DrawPrintText(L" ", 1);
 		surface()->DrawSetTextFont(g_hFontKillfeedIcons);
 		surface()->DrawSetTextColor(COLOR_NEO_ORANGE);
 		wchar_t icon = NEO_HUD_DEATHNOTICEICON_SHORTBUS;
 		surface()->DrawPrintText(&icon, 1);
+	}
+
+	// Victim
+	if (m_DeathNotices[i].Victim.iEntIndex != 0)
+	{
+		SetColorForNoticePlayer(m_DeathNotices[i].Victim.iTeam);
+		surface()->DrawSetTextFont(g_hFontKillfeed);
+		surface()->DrawPrintText(L" ", 1);
+		surface()->DrawPrintText(m_DeathNotices[i].Victim.szName, m_DeathNotices[i].Victim.iNameLength);
+
+		// Victim Ghoster Icon
+		if (m_DeathNotices[i].bWasCarryingGhost)
+		{
+			surface()->DrawSetTextFont(g_hFontKillfeed);
+			surface()->DrawPrintText(L" ", 1);
+			surface()->DrawSetTextFont(g_hFontKillfeedIcons);
+			surface()->DrawSetTextColor(COLOR_NEO_WHITE);
+			wchar_t icon = NEO_HUD_DEATHNOTICEICON_GHOST;
+			surface()->DrawPrintText(&icon, 1);
+		}
 	}
 }
 

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -385,8 +385,8 @@ const NeoGameTypeSettings NEO_GAME_TYPE_SETTINGS[NEO_GAME_TYPE__TOTAL] = {
 	}
 
 	BEGIN_RECV_TABLE( CNEOGameRulesProxy, DT_NEOGameRulesProxy )
-		RecvPropDataTable( "neo_gamerules_data", 0, 0,	
-			&REFERENCE_RECV_TABLE( DT_NEORules ), 
+		RecvPropDataTable( "neo_gamerules_data", 0, 0,
+			&REFERENCE_RECV_TABLE( DT_NEORules ),
 			RecvProxy_NEORules )
 	END_RECV_TABLE()
 #else
@@ -1379,7 +1379,7 @@ void CNEORules::Think(void)
 		}
 		else if (GetGameType() == NEO_GAME_TYPE_JGR)
 		{
-			if ((!m_pJuggernautPlayer && m_pJuggernautItem && !m_pJuggernautItem->IsBeingActivatedByLosingTeam()) || 
+			if ((!m_pJuggernautPlayer && m_pJuggernautItem && !m_pJuggernautItem->IsBeingActivatedByLosingTeam()) ||
 				(!m_pJuggernautPlayer && !m_pJuggernautItem)) // Juggernaut is absent entirely
 			{
 				if (GetGlobalTeam(TEAM_JINRAI)->GetScore() > GetGlobalTeam(TEAM_NSF)->GetScore())
@@ -1474,7 +1474,7 @@ void CNEORules::Think(void)
 					{
 						Assert(false);
 						continue;
-					}	
+					}
 					pGhostCap->SetActive(false);
 				}
 
@@ -3940,10 +3940,13 @@ void CNEORules::SetWinningTeam(int team, int iWinReason, bool bForceMapReset, bo
 static CNEO_Player* FetchAssists(CNEO_Player* attacker, CNEO_Player* victim)
 {
 	// Non-CNEO_Player, return NULL
-	if (!attacker || !victim)
+	if (!victim)
 	{
 		return NULL;
 	}
+
+	// If it's a suicide, use the victim as the attacker
+	attacker = attacker ? attacker : victim;
 
 	// Check for assistance (> 50 dmg, not final attacker)
 	CNEO_Player* pImpersonated = attacker->GetSpectatorTakeoverPlayerTarget();


### PR DESCRIPTION
## Description
#1851 fixed awarding assists when suiciding by your own grenade, but missed the case where the killer is worldspawn. This PR should handle that. I also added the assist indicator to the kill feed.

Note that the kill feed text will sometimes overflow the container but I haven't been able to figure out why. Pretty sure this was a problem before as well though. I restructured the space calculation and text rendering so they're closer and easier to follow but that didn't help me narrow it down. I think we can leave it until someone decides to rewrite the feed using NeoUI.

Without assist:
<img width="90" height="34" alt="image" src="https://github.com/user-attachments/assets/3e9f406a-3d55-4af6-9444-483b45c59eca" />
With assist:
<img width="290" height="38" alt="image" src="https://github.com/user-attachments/assets/586b045e-e31a-45c7-a717-9a9fa5c05f85" />

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Linux GCC Distro Native - CachyOS - gcc version 16.1.1 20260625 (GCC)

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

