### PR TITLE
Make `prop_physics_override` use `CPhysicsPropMultiplayer`

### DIFF
--- a/src/game/server/props.cpp
+++ b/src/game/server/props.cpp
@@ -2404,7 +2404,9 @@ void COrnamentProp::InputDetach( inputdata_t &inputdata )
 //=============================================================================
 LINK_ENTITY_TO_CLASS( physics_prop, CPhysicsProp );
 LINK_ENTITY_TO_CLASS( prop_physics, CPhysicsProp );	
+#ifndef NEO
 LINK_ENTITY_TO_CLASS( prop_physics_override, CPhysicsProp );	
+#endif
 
 BEGIN_DATADESC( CPhysicsProp )
 
@@ -5709,6 +5711,9 @@ private:
 };
 
 LINK_ENTITY_TO_CLASS( prop_physics_multiplayer, CPhysicsPropMultiplayer );
+#ifdef NEO
+LINK_ENTITY_TO_CLASS( prop_physics_override, CPhysicsPropMultiplayer );
+#endif
 
 BEGIN_DATADESC( CPhysicsPropMultiplayer )
 	DEFINE_KEYFIELD( m_iPhysicsMode, FIELD_INTEGER, "physicsmode" ),


### PR DESCRIPTION
## Description
This is a somewhat blind attempt to fix the issue where players will be teleported when touching `prop_physics_override` props. I couldn't replicate the issue in testing.
The reasoning behind this change is that almost all physics props in the game are, or should be `prop_physics_multiplayer`. This is because this entity class handles physics differently to avoid issues in multiplayer. `prop_physics_override` doesn't have this, and therefore I believe it's the reason we see issues with them but not other props.

I can't think of any scenarios that exist currently where a `prop_physics_override` would need to be a `CPhysicsProp` to function correctly. The game is multiplayer at it's core so I don't think this change will have any major negative impact.

## Toolchain
- Windows MSVC VS2022
