### PR TITLE
Scoreboard - Fix popup not checking ShowAvatar, move setting to HUD

### DIFF
--- a/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/src/game/client/neo/ui/neo_root_settings.cpp
@@ -444,7 +444,6 @@ void NeoSettingsRestore(NeoSettings *ns, const NeoSettings::Keys::Flags flagsKey
 		pGeneral->bAutoDetectOBS = cvr->cl_neo_streamermode_autodetect_obs.GetBool();
 		pGeneral->bTachiFullAutoPreferred = cvr->cl_neo_tachi_prefer_auto.GetBool();
 		pGeneral->bTakingDamageSounds = cvr->cl_neo_taking_damage_sounds.GetBool();
-		pGeneral->iScoreboardPadding = cvr->cl_neo_hud_scoreboard_padding.GetInt();
 		pGeneral->iBackground = clamp(cvr->sv_unlockedchapters.GetInt(), 0, ns->iCBListSize - 1);
 		NeoSettingsBackgroundWrite(ns);
 		NeoUI::ResetTextures();
@@ -691,6 +690,7 @@ void NeoSettingsRestore(NeoSettings *ns, const NeoSettings::Keys::Flags flagsKey
 		pHUD->bEnableRangeFinder = cvr->cl_neo_hud_rangefinder_enabled.GetBool();
 		pHUD->iExtendedKillfeed = cvr->cl_neo_hud_extended_killfeed.GetInt();
 		pHUD->iKdinfoToggletype = cvr->cl_neo_kdinfo_toggletype.GetInt();
+		pHUD->iScoreboardPadding = cvr->cl_neo_hud_scoreboard_padding.GetInt();
 		pHUD->bShowHudContextHints = cvr->cl_neo_hud_context_hint_enabled.GetBool();
 		pHUD->bShowHudContextHintPlayerTakeover = cvr->cl_neo_hud_context_hint_show_player_takeover_hint.GetBool();
 		pHUD->bShowHudContextHintObjectInteract = cvr->cl_neo_hud_context_hint_show_object_interact_hint.GetBool();
@@ -803,7 +803,6 @@ void NeoSettingsSave(const NeoSettings *ns)
 		cvr->cl_neo_tachi_prefer_auto.SetValue(pGeneral->bTachiFullAutoPreferred);
 		cvr->sv_unlockedchapters.SetValue(pGeneral->iBackground);
 		cvr->cl_neo_taking_damage_sounds.SetValue(pGeneral->bTakingDamageSounds);
-		cvr->cl_neo_hud_scoreboard_padding.SetValue(pGeneral->iScoreboardPadding);
 		NeoSettingsBackgroundWrite(ns);
 	}
 	{
@@ -959,6 +958,7 @@ void NeoSettingsSave(const NeoSettings *ns)
 		cvr->cl_neo_hud_rangefinder_enabled.SetValue(pHUD->bEnableRangeFinder);
 		cvr->cl_neo_hud_extended_killfeed.SetValue(pHUD->iExtendedKillfeed);
 		cvr->cl_neo_kdinfo_toggletype.SetValue(pHUD->iKdinfoToggletype);
+		cvr->cl_neo_hud_scoreboard_padding.SetValue(pHUD->iScoreboardPadding);
 		cvr->cl_neo_hud_context_hint_enabled.SetValue(pHUD->bShowHudContextHints);
 		cvr->cl_neo_hud_context_hint_show_player_takeover_hint.SetValue(pHUD->bShowHudContextHintPlayerTakeover);
 		cvr->cl_neo_hud_context_hint_show_object_interact_hint.SetValue(pHUD->bShowHudContextHintObjectInteract);
@@ -1108,12 +1108,6 @@ FORCEINLINE void VarTrimmer(wchar_t (&input)[maxlen])
 	}
 }
 
-static const wchar_t *NEOSCOREBOARDPADDING_LABELS[NEOSCOREBOARDPADDING__TOTAL] = {
-	L"Default",		// NEOSCOREBOARDPADDING_DEFAULT
-	L"Compact",		// NEOSCOREBOARDPADDING_COMPACT
-	L"Spacious",	// NEOSCOREBOARDPADDING_SPACIOUS
-};
-
 void NeoSettings_General(NeoSettings *ns)
 {
 	NeoSettings::General *pGeneral = &ns->general;
@@ -1125,7 +1119,6 @@ void NeoSettings_General(NeoSettings *ns)
 	NeoUI::RingBox(L"Utility slot equip priority", EQUIP_UTILITY_PRIORITY_LABELS, NeoSettings::EquipUtilityPriorityType::EQUIP_UTILITY_PRIORITY__TOTAL, &pGeneral->iEquipUtilityPriority);
 	NeoUI::RingBoxBool(L"Weapon fastswitch", &pGeneral->bWeaponFastSwitch);
 	NeoUI::RingBoxBool(L"Taking damage sounds", &pGeneral->bTakingDamageSounds);
-	NeoUI::RingBox(L"Scoreboard padding", NEOSCOREBOARDPADDING_LABELS, NEOSCOREBOARDPADDING__TOTAL, &pGeneral->iScoreboardPadding);
 
 	NeoUI::Divider(L"MAIN MENU");
 	NeoUI::RingBox(L"Selected Background", const_cast<const wchar_t **>(ns->p2WszCBList), ns->iCBListSize, &pGeneral->iBackground);
@@ -1673,6 +1666,12 @@ static const wchar_t *EXT_KILLFEED_LABELS[] = {
 	L"Objectives & rank-ups"
 };
 
+static const wchar_t *NEOSCOREBOARDPADDING_LABELS[NEOSCOREBOARDPADDING__TOTAL] = {
+	L"Default",		// NEOSCOREBOARDPADDING_DEFAULT
+	L"Compact",		// NEOSCOREBOARDPADDING_COMPACT
+	L"Spacious",	// NEOSCOREBOARDPADDING_SPACIOUS
+};
+
 void NeoSettings_HUD(NeoSettings *ns)
 {
 	NeoSettings::HUD *pHud = &ns->hud;
@@ -1686,6 +1685,7 @@ void NeoSettings_HUD(NeoSettings *ns)
 	NeoUI::RingBoxBool(L"Show rangefinder", &pHud->bEnableRangeFinder);
 	NeoUI::RingBox(L"Extended killfeed", EXT_KILLFEED_LABELS, ARRAYSIZE(EXT_KILLFEED_LABELS), &pHud->iExtendedKillfeed);
 	NeoUI::RingBox(L"Killer damage info auto show", KDMGINFO_TOGGLETYPE_LABELS, KDMGINFO_TOGGLETYPE__TOTAL, &pHud->iKdinfoToggletype);
+	NeoUI::RingBox(L"Scoreboard padding", NEOSCOREBOARDPADDING_LABELS, NEOSCOREBOARDPADDING__TOTAL, &pHud->iScoreboardPadding);
 
 	NeoUI::Divider(L"Contextual hints");
 	NeoUI::RingBoxBool(L"Show HUD contextual hints", &pHud->bShowHudContextHints);

--- a/src/game/client/neo/ui/neo_root_settings.h
+++ b/src/game/client/neo/ui/neo_root_settings.h
@@ -73,7 +73,6 @@ struct NeoSettings
 		bool bTachiFullAutoPreferred;
 		int iBackground;
 		bool bTakingDamageSounds;
-		int iScoreboardPadding;
 	};
 
 	struct Keys
@@ -213,6 +212,7 @@ struct NeoSettings
 		bool bShowHudContextHighlightObject;
 		bool bShowHudContextHighlightPlayer;
 		int iKdinfoToggletype;
+		int iScoreboardPadding;
 
 		// IFF Markers
 		int optionChosen;

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -1006,7 +1006,7 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 			NeoUI::Pad();
 
 			vgui::surface()->DrawSetTextPos(
-					m_uiCtx.dPanel.x + iAvatarOffset + (ShowAvatars() ? (iAvatarWT + iAvatarOffset) : 0),
+					m_uiCtx.dPanel.x + iAvatarOffset + (pAvatarImg ? (iAvatarWT + iAvatarOffset) : 0),
 					m_uiCtx.dPanel.y + iAvatarOffset);
 			if (m_playerPopup.wszClantag[0])
 			{
@@ -1017,7 +1017,7 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 				const auto *pFontI = &m_uiCtx.fonts[m_uiCtx.eFont];
 				const int iClantagTall = vgui::surface()->GetFontTall(pFontI->hdl);
 				vgui::surface()->DrawSetTextPos(
-						m_uiCtx.dPanel.x + iAvatarOffset + (ShowAvatars() ? (iAvatarWT + iAvatarOffset) : 0),
+						m_uiCtx.dPanel.x + iAvatarOffset + (pAvatarImg ? (iAvatarWT + iAvatarOffset) : 0),
 						m_uiCtx.dPanel.y + iAvatarOffset + iClantagTall + iAvatarOffset);
 			}
 			NeoUI::SwapFont(NeoUI::FONT_NTLARGE);

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -526,7 +526,7 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 	const int iPopupCardPerRowTallAvatarName = iPopupCardRowTallBase * 3;
 	const int iPopupCardPerRowTallButtons = iPopupCardRowTallBase * 2.25f;
 	const int iAvatarOffset = m_uiCtx.iMarginX;
-	const int iAvatarWT = iPopupCardPerRowTallAvatarName - (iAvatarOffset * 2);
+	const int iAvatarWT = ShowAvatars() ? (iPopupCardPerRowTallAvatarName - (iAvatarOffset * 2)) : 0;
 	const bool bShowReadyUp = sv_neo_readyup_lobby.GetBool()
 			&& NEORules()->m_nRoundStatus == NeoRoundStatus::Idle;
 	static CrosshairInfo staticXhairInfo = {};
@@ -820,7 +820,7 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 						const bool bHaveFriendReq = (SteamFriends()
 								&& k_EFriendRelationshipRequestInitiator == SteamFriends()->GetFriendRelationship(m_playerPopup.steamID));
 
-						const int iWidePopupCover = iAvatarWT + (2 * iAvatarOffset)
+						const int iWidePopupCover = iAvatarWT + ((1 + ShowAvatars()) * iAvatarOffset)
 								+ NeoUI::SuitableWideByWStr(
 										m_playerPopup.wszName,
 										NeoUI::SUITABLEWIDE_TABLE,
@@ -989,7 +989,7 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 		if (NeoUI::BeginPopup(NEOSCOREBOARDPOPUP_CARD))
 		{
 			CAvatarImage *pAvatarImg = nullptr;
-			if (m_playerPopup.avatar.i184Idx >= 0)
+			if (ShowAvatars() && m_playerPopup.avatar.i184Idx >= 0)
 			{
 				pAvatarImg = (CAvatarImage *)(m_pImageList->GetImage(m_playerPopup.avatar.i184Idx));
 			}
@@ -1006,7 +1006,7 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 			NeoUI::Pad();
 
 			vgui::surface()->DrawSetTextPos(
-					m_uiCtx.dPanel.x + iAvatarOffset + iAvatarWT + iAvatarOffset,
+					m_uiCtx.dPanel.x + iAvatarOffset + (ShowAvatars() ? (iAvatarWT + iAvatarOffset) : 0),
 					m_uiCtx.dPanel.y + iAvatarOffset);
 			if (m_playerPopup.wszClantag[0])
 			{
@@ -1017,7 +1017,7 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 				const auto *pFontI = &m_uiCtx.fonts[m_uiCtx.eFont];
 				const int iClantagTall = vgui::surface()->GetFontTall(pFontI->hdl);
 				vgui::surface()->DrawSetTextPos(
-						m_uiCtx.dPanel.x + iAvatarOffset + iAvatarWT + iAvatarOffset,
+						m_uiCtx.dPanel.x + iAvatarOffset + (ShowAvatars() ? (iAvatarWT + iAvatarOffset) : 0),
 						m_uiCtx.dPanel.y + iAvatarOffset + iClantagTall + iAvatarOffset);
 			}
 			NeoUI::SwapFont(NeoUI::FONT_NTLARGE);


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Just a check left out from the popup that should be there. Also moved the scoreboard padding setting to the HUD tab.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Arch/GCC 16

<!--
## Linked Issues

Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

- fixes #
- related #
-->

