### PR TITLE
Bots that cannot capture ghost will patrol around area

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_capture.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_capture.cpp
@@ -56,7 +56,9 @@ ActionResult<CNEOBot> CNEOBotCtgCapture::Update( CNEOBot *me, float interval )
 	{
 		if ( !CNEOBotPathCompute( me, m_path, m_hObjective->GetAbsOrigin(), FASTEST_ROUTE ) )
 		{
-			return Done( "Unable to find a path to the ghost capture target" );
+			// Something has gone wrong if we can't path to a ghost that we by convention started close to
+			// Transition to search around the ghost behavior to avoid cycle of ghost search failure and retry attempts
+			return ChangeTo( new CNEOBotCtgLoneWolf(), "Unable to find a path to the ghost capture target, searching around nearest areas" );
 		}
 		m_repathTimer.Start( RandomFloat( 0.3f, 0.6f ) );
 	}
@@ -84,7 +86,9 @@ ActionResult<CNEOBot> CNEOBotCtgCapture::Update( CNEOBot *me, float interval )
 	
 	if ( m_captureAttemptTimer.IsElapsed() )
 	{
-		return ChangeTo( new CNEOBotSeekWeapon, "Failed to capture ghost in time" );
+		// If the bot fails to capture the ghost, it's sometimes because the ghost is lodged into an awkward position
+		// Have the bot search around the location instead, to avoid cycle of failing to pick up ghost and retrying
+		return ChangeTo( new CNEOBotCtgLoneWolf(), "Failed to pick up ghost in time, searching around nearest areas" );
 	}
 
 	return Continue();

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_lone_wolf.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_lone_wolf.cpp
@@ -2,6 +2,8 @@
 #include "neo_player.h"
 #include "bot/neo_bot.h"
 #include "bot/behavior/neo_bot_attack.h"
+#include "bot/behavior/neo_bot_ctg_enemy.h"
+#include "bot/behavior/neo_bot_ctg_escort.h"
 #include "bot/behavior/neo_bot_ctg_lone_wolf.h"
 #include "bot/behavior/neo_bot_ctg_lone_wolf_ambush.h"
 #include "bot/behavior/neo_bot_ctg_lone_wolf_seek.h"
@@ -23,6 +25,12 @@ ActionResult< CNEOBot >	CNEOBotCtgLoneWolf::OnStart( CNEOBot *me, Action< CNEOBo
 //---------------------------------------------------------------------------------------------
 ActionResult< CNEOBot >	CNEOBotCtgLoneWolf::Update( CNEOBot *me, float interval )
 {
+	ActionResult< CNEOBot > result = ConsiderGhostCaptureTransition( me );
+	if ( result.IsRequestingChange() )
+	{
+		return result;
+	}
+
 	if ( me->DropGhost() )
 	{
 		return Continue(); // ghost drop in progress
@@ -136,6 +144,39 @@ ActionResult< CNEOBot > CNEOBotCtgLoneWolf::ConsiderGhostVisualCheck( CNEOBot *m
 		{
 			m_path.Update( me );
 		}
+	}
+
+	return Continue();
+}
+
+
+//---------------------------------------------------------------------------------------------
+ActionResult< CNEOBot > CNEOBotCtgLoneWolf::ConsiderGhostCaptureTransition( CNEOBot *me )
+{
+	if (NEORules()->GhostExists())
+	{
+		int iGhosterPlayer = NEORules()->GetGhosterPlayer();
+		if (iGhosterPlayer > 0 && iGhosterPlayer <= gpGlobals->maxClients)
+		{
+			CNEO_Player* pGhostCarrier = ToNEOPlayer(UTIL_PlayerByIndex(iGhosterPlayer));
+			if (pGhostCarrier && pGhostCarrier != me)
+			{
+				// We sometimes flow into CNEOBotCtgLoneWolf if this bot failed to get the ghost
+				// Use ChangeTo to reset scenario evaluation after reacting to ghost pickup
+				if (pGhostCarrier->GetTeamNumber() == me->GetTeamNumber())
+				{
+					return ChangeTo(new CNEOBotCtgEscort, "Protect teammate that had better luck capturing ghost");
+				}
+				else
+				{
+					return ChangeTo(new CNEOBotCtgEnemy, "Intercepting the ghost carrier!");
+				}
+			}
+		}
+	}
+	else
+	{
+		return Done("No ghost exists, exiting behavior to reevaluate situation.");
 	}
 
 	return Continue();

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_lone_wolf.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_lone_wolf.h
@@ -20,6 +20,7 @@ public:
 protected:
 	virtual ActionResult< CNEOBot > ConsiderGhostInterception( CNEOBot *me, const CBaseCombatCharacter *pGhostOwner = nullptr );
 	virtual ActionResult< CNEOBot > ConsiderGhostVisualCheck( CNEOBot *me );
+	virtual ActionResult< CNEOBot > ConsiderGhostCaptureTransition( CNEOBot *me );
 
 	Vector GetNearestEnemyCapPoint( CNEOBot *me ) const;
 

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_lone_wolf_ambush.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_lone_wolf_ambush.cpp
@@ -29,6 +29,12 @@ ActionResult< CNEOBot >	CNEOBotCtgLoneWolfAmbush::OnStart( CNEOBot *me, Action< 
 //---------------------------------------------------------------------------------------------
 ActionResult< CNEOBot >	CNEOBotCtgLoneWolfAmbush::Update( CNEOBot *me, float interval )
 {
+	ActionResult< CNEOBot > result = ConsiderGhostCaptureTransition( me );
+	if ( result.IsRequestingChange() )
+	{
+		return result;
+	}
+
 	CWeaponGhost *pGhost = NEORules()->m_pGhost;
 	if ( !pGhost )
 	{

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_lone_wolf_seek.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_lone_wolf_seek.cpp
@@ -106,6 +106,12 @@ ActionResult< CNEOBot >	CNEOBotCtgLoneWolfSeek::OnStart( CNEOBot *me, Action< CN
 //---------------------------------------------------------------------------------------------
 ActionResult< CNEOBot >	CNEOBotCtgLoneWolfSeek::Update( CNEOBot *me, float interval )
 {
+	ActionResult< CNEOBot > result = ConsiderGhostCaptureTransition( me );
+	if ( result.IsRequestingChange() )
+	{
+		return result;
+	}
+
 	me->PressCrouchButton( 0.2f ); // Keep a lower profile
 
 	if ( !NEORules()->GhostExists() || !NEORules()->m_pGhost )

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_seek.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_seek.cpp
@@ -89,7 +89,7 @@ ActionResult< CNEOBot > CNEOBotCtgSeek::Update( CNEOBot *me, float interval )
 				}
 				else
 				{
-					return Done("Capture target was not a ghost");
+					return SuspendFor(new CNEOBotCtgLoneWolf, "Capture target is blocked by some other entity, searching around the nearest areas");
 				}
 			}
 		}


### PR DESCRIPTION
## Description
Bots that cannot capture the ghost will transition into the area patrolling behavior.
This is intended to address situations when the ghost is moved into an awkward area where the bots cannot pick up the ghost.
This prevents the bots from entering a cycle where they fail to pick up the ghost and then immediately retry their attempt.

## Toolchain
- Windows MSVC VS2022

