### PR TITLE
Bots hear footsteps/cloaking player sounds

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.cpp
@@ -41,7 +41,7 @@ CSound* CNEOBotSeekAndDestroy::SearchGunfireSounds(CNEOBot* me, const Vector* cu
 			break;
 		}
 
-		if (!(pSound->SoundType() & SOUND_COMBAT))
+		if (!(pSound->SoundType() & (SOUND_COMBAT | SOUND_PLAYER)))
 		{
 			continue;
 		}
@@ -62,6 +62,13 @@ CSound* CNEOBotSeekAndDestroy::SearchGunfireSounds(CNEOBot* me, const Vector* cu
 
 		// Search for the closest gunfire sounds
 		float distSqr = vecMyOrigin.DistToSqr(pSound->GetSoundOrigin());
+
+		// Only consider sounds within hearing range
+		float hearingRangeSqr = Square((float)pSound->m_iVolume);
+		if (distSqr > hearingRangeSqr)
+		{
+			continue;
+		}
 
 		// Only consider sounds that are closer than the current goal
 		if (distSqr >= flGoalDistSqr)

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1243,6 +1243,9 @@ void CNEO_Player::PlayCloakSound(bool removeLocalPlayer)
 		// effect lasts 0.5 seconds, but allow 200-300ms leeway with GetFogObscuredRatio cache window
 		m_botThermOpticCamoDisruptedTimer.Start(0.2f);
 	}
+
+	// For bots to notice cloak sound
+	CSoundEnt::InsertSound(SOUND_COMBAT, GetAbsOrigin(), SOUNDENT_VOLUME_CLOAK, 0.5, this);
 }
 
 void CNEO_Player::SetCloakState(bool state)
@@ -3002,6 +3005,8 @@ void CNEO_Player::PlayStepSound( Vector &vecOrigin,
 	surfacedata_t *psurface, float fvol, bool force )
 {
 	BaseClass::PlayStepSound(vecOrigin, psurface, fvol, force);
+	// For bots to hear footsteps
+	CSoundEnt::InsertSound(SOUND_PLAYER | SOUND_COMBAT, GetAbsOrigin(), SOUNDENT_VOLUME_FOOTSTEP, 0.1, this);
 }
 
 bool CNEO_Player::IsCarryingGhost(void) const

--- a/src/game/server/soundent.h
+++ b/src/game/server/soundent.h
@@ -90,6 +90,28 @@ enum
 #define SOUNDENT_VOLUME_PISTOL		1500.0
 #define SOUNDENT_VOLUME_EMPTY		 500.0 // volume of the "CLICK" when you have no bullets
 
+#ifdef NEO
+// Bot hearing distances for CSoundEnt::InsertSound()
+// Despite the name, iVolume is commonly used as an AI hearing radius (in Hammer units).
+// While this is separate from client sound playback attenuation (CPASAttenuationFilter),
+// we use that system for reference of relative detection differences.
+//
+// BASELINE FROM EXISTING SOUNDENT_VOLUME_EMPTY VALUE:
+// weapon_milso.empty: SNDLVL_NORM (75dB), vol 1.0 [game_sounds_weapons.txt]
+//   Client hearing: (2 * SOUND_NORMAL_CLIP_DIST) / SNDLVL_TO_ATTN(75) = (2*10000)/0.8 = 25000 units
+//   AI value: SOUNDENT_VOLUME_EMPTY = 500.0
+//   AI-to-client ratio: 500 / 25000 = 0.02
+//
+// Footsteps (StepLeft/StepRight): SNDLVL_75dB, vol 1.0 [game_sounds_physics.txt]
+//   Client hearing: (2*10000)/0.8 * 1.0 = 25000 units
+//   Mathematical AI value: 25000 * 0.02 = 500 units
+#define SOUNDENT_VOLUME_FOOTSTEP 500
+// Cloak (ThermOpticOn/Off): SNDLVL_75dB, vol 0.7 [game_sounds_player.txt]
+//   Client hearing: (2*10000)/0.8 * 0.7 = 17500 units
+//   Mathematical AI value: 17500 * 0.02 = 350 units
+#define SOUNDENT_VOLUME_CLOAK    350
+#endif
+
 enum
 {
 	SOUND_PRIORITY_VERY_LOW = -2,


### PR DESCRIPTION
## Description
Emit sound entities for bots to detect player cloak/footstep sounds.  While existing EmitSound() calls play sounds for humans, bots did not detect those sounds.  Adding InsertSound entities allows bots to react to cloak and footsteps as additional significant sound emissions to react to.

The lack of bot reactivity to footsteps and cloak was made more apparent in PR #1795 where bots lay detpack traps.  Before this change, bots did not react to footsteps or cloak, but they did react to gunfire.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1795 
