### PR TITLE
Propagate area avoidance penalties to OnStuck/OnMoveToFailure through CNEOBotIntention inheritance chain

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_attack.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_attack.cpp
@@ -406,7 +406,6 @@ EventDesiredResult< CNEOBot > CNEOBotAttack::OnStuck( CNEOBot *me )
 {
 	m_path.Invalidate();
 	m_attackCoverArea = nullptr;
-	CNEOBotPathReservations()->IncrementAreaAvoidPenalty(me->GetLastKnownArea()->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat());
 	return TryContinue();
 }
 
@@ -423,7 +422,6 @@ EventDesiredResult< CNEOBot > CNEOBotAttack::OnMoveToFailure( CNEOBot *me, const
 {
 	m_path.Invalidate();
 	m_attackCoverArea = nullptr;
-	CNEOBotPathReservations()->IncrementAreaAvoidPenalty(me->GetLastKnownArea()->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat());
 	return TryContinue();
 }
 

--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -271,38 +271,6 @@ EventDesiredResult< CNEOBot > CNEOBotMainAction::OnStuck( CNEOBot *me )
 		me->PressRightButton();
 	}
 
-	// NEO Jank: For the current match, all bots share where they get stuck
-	// The reasoning is that bots on either team will get stuck in their respective half of the map
-	// so the overall fairness may balance out for both teams sharing common sticking points.
-	if ( const CNavArea *navArea = me->GetLastKnownArea() )
-	{
-		CNEOBotPathReservations()->IncrementAreaAvoidPenalty( navArea->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat() );
-	}
-	else
-	{
-		// Fallback if GetLastKnownArea is null, try finding nearest nav area
-		CNavArea *nearestArea = TheNavMesh->GetNearestNavArea( me->GetAbsOrigin() );
-		if ( nearestArea )
-		{
-			CNEOBotPathReservations()->IncrementAreaAvoidPenalty( nearestArea->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat() );
-		}
-	}
-
-	// Also penalize the immediate next nav area bot was trying to get to
-	if ( const PathFollower *path = me->GetCurrentPath() )
-	{
-		if ( const Path::Segment *currentGoal = path->GetCurrentGoal() )
-		{
-			if ( const Path::Segment *nextSegment = path->NextSegment( currentGoal ) )
-			{
-				if ( nextSegment->area )
-				{
-					CNEOBotPathReservations()->IncrementAreaAvoidPenalty( nextSegment->area->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat() );
-				}
-			}
-		}
-	}
-
 	return TryContinue();
 }
 

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -5,6 +5,7 @@
 #include "team_train_watcher.h"
 #include "neo_bot.h"
 #include "neo_bot_manager.h"
+#include "neo_bot_path_reservation.h"
 #include "neo_bot_vision.h"
 #include "trigger_area_capture.h"
 #include "GameEventListener.h"
@@ -2844,6 +2845,54 @@ CNEOBotIntention::CNEOBotIntention(CNEOBot *bot)
 CNEOBotIntention::~CNEOBotIntention()
 {
 	delete m_behavior;
+}
+
+static void CNEOBotApplyOnStuckAreaPenalty( CNEOBot *me )
+{
+	// NEO Jank: For the current match, all bots share where they get stuck.
+	// The reasoning is that bots on either team will get stuck in their respective half of the map
+	// so the overall fairness may balance out for both teams sharing common sticking points.
+	if ( const CNavArea *navArea = me->GetLastKnownArea() )
+	{
+		CNEOBotPathReservations()->IncrementAreaAvoidPenalty( navArea->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat() );
+	}
+	else
+	{
+		CNavArea *nearestArea = TheNavMesh->GetNearestNavArea( me->GetAbsOrigin() );
+		if ( nearestArea )
+		{
+			CNEOBotPathReservations()->IncrementAreaAvoidPenalty( nearestArea->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat() );
+		}
+	}
+
+	if ( const PathFollower *path = me->GetCurrentPath() )
+	{
+		if ( const Path::Segment *currentGoal = path->GetCurrentGoal() )
+		{
+			if ( const Path::Segment *nextSegment = path->NextSegment( currentGoal ) )
+			{
+				if ( nextSegment->area )
+				{
+					CNEOBotPathReservations()->IncrementAreaAvoidPenalty( nextSegment->area->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat() );
+				}
+			}
+		}
+	}
+}
+
+void CNEOBotIntention::OnStuck()
+{
+	CNEOBotApplyOnStuckAreaPenalty( static_cast<CNEOBot *>( GetBot() ) );
+	INextBotEventResponder::OnStuck();
+}
+
+void CNEOBotIntention::OnMoveToFailure( const Path *path, MoveToFailureType reason )
+{
+	if ( reason == FAIL_STUCK )
+	{
+		CNEOBotApplyOnStuckAreaPenalty( static_cast<CNEOBot *>( GetBot() ) );
+	}
+	INextBotEventResponder::OnMoveToFailure( path, reason );
 }
 
 void CNEOBotIntention::Reset()

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -2856,28 +2856,6 @@ static void CNEOBotApplyOnStuckAreaPenalty( CNEOBot *me )
 	{
 		CNEOBotPathReservations()->IncrementAreaAvoidPenalty( navArea->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat() );
 	}
-	else
-	{
-		CNavArea *nearestArea = TheNavMesh->GetNearestNavArea( me->GetAbsOrigin() );
-		if ( nearestArea )
-		{
-			CNEOBotPathReservations()->IncrementAreaAvoidPenalty( nearestArea->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat() );
-		}
-	}
-
-	if ( const PathFollower *path = me->GetCurrentPath() )
-	{
-		if ( const Path::Segment *currentGoal = path->GetCurrentGoal() )
-		{
-			if ( const Path::Segment *nextSegment = path->NextSegment( currentGoal ) )
-			{
-				if ( nextSegment->area )
-				{
-					CNEOBotPathReservations()->IncrementAreaAvoidPenalty( nextSegment->area->GetID(), neo_bot_path_reservation_onstuck_penalty.GetFloat() );
-				}
-			}
-		}
-	}
 }
 
 void CNEOBotIntention::OnStuck()

--- a/src/game/server/neo/bot/neo_bot.h
+++ b/src/game/server/neo/bot/neo_bot.h
@@ -56,6 +56,9 @@ public:
 	INextBotEventResponder *FirstContainedResponder() const override;
 	INextBotEventResponder *NextContainedResponder(INextBotEventResponder *current) const override;
 
+	void OnStuck() override;
+	void OnMoveToFailure( const Path *path, MoveToFailureType reason ) override;
+
 	QueryResultType ShouldWalk(const CNEOBot *me, const QueryResultType qShouldAimQuery) const final;
 	QueryResultType ShouldAim(const CNEOBot *me, const bool bWepHasClip) const final;
 


### PR DESCRIPTION
## Description
Centralize incrementing of area avoid penalty through inheritance chain of CNEOBotIntention

Also fix GetLastKnownArea() nullptr dereference in Attack behavior

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #2034
- related #1598 (original implementation)

