### PR TITLE
Tweak contextual hint capitalisation & remove legacy juggernaut hint

### DIFF
--- a/src/game/client/neo/ui/neo_hud_context_hint.cpp
+++ b/src/game/client/neo/ui/neo_hud_context_hint.cpp
@@ -169,14 +169,14 @@ void CNEOHud_ContextHint::UpdateStateForNeoHudElementDraw()
 				// Ghost pickup hint
 				if (pNeoWeapon->GetNeoWepBits() & NEO_WEP_GHOST)
 				{
-					V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] pick up the Ghost", szUppercaseKeyBinding);
+					V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] Pick up the Ghost", szUppercaseKeyBinding);
 					m_flDisplayEndTime = gpGlobals->curtime + 1.f;
 					bPreviouslyCouldPickupWeapon = true;
 				}
 				// Weapon pickup hint
 				else if (pNeoWeapon->CanBePickedUpByClass(pLocalNeoPlayer->GetClass()))
 				{
-					V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] pick up %hs", szUppercaseKeyBinding, pNeoWeapon->GetPrintName());
+					V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] Pick up %hs", szUppercaseKeyBinding, pNeoWeapon->GetPrintName());
 					m_flDisplayEndTime = gpGlobals->curtime + 1.f;
 					bPreviouslyCouldPickupWeapon = true;
 				}
@@ -217,13 +217,13 @@ void CNEOHud_ContextHint::UpdateStateForNeoHudElementDraw()
 				}
 				else
 				{
-					V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"Hold [%hs] boot into JGR56", szUppercaseKeyBinding);
+					V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"Hold [%hs] Boot into JGR56", szUppercaseKeyBinding);
 				}
 			}
 			// Some other useable entity
 			else
 			{
-				V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] use", szUppercaseKeyBinding);
+				V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] Use", szUppercaseKeyBinding);
 				m_flDisplayEndTime = gpGlobals->curtime + 1.f;
 			}
 		}
@@ -247,11 +247,11 @@ void CNEOHud_ContextHint::UpdateStateForNeoHudElementDraw()
 					m_flDisplayEndTime = gpGlobals->curtime + 1.f;
 					if (sv_neo_bot_cmdr_enable.GetBool())
 					{
-						V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] %hs %hs", szUppercaseKeyBinding, pTargetPlayer->m_hCommandingPlayer.Get() == pLocalNeoPlayer ? "release" : "command", pTargetPlayer->GetNeoPlayerName());
+						V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] %hs %hs", szUppercaseKeyBinding, pTargetPlayer->m_hCommandingPlayer.Get() == pLocalNeoPlayer ? "Release" : "Command", pTargetPlayer->GetNeoPlayerName());
 					}
 					else
 					{
-						V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] request primary weapon", szUppercaseKeyBinding); // NEO TODO (Adam) network primary weapon so can print its name here?
+						V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] Request primary weapon", szUppercaseKeyBinding); // NEO TODO (Adam) network primary weapon so can print its name here?
 					}
 				}
 			}

--- a/src/game/client/neo/ui/neo_root_settings.cpp
+++ b/src/game/client/neo/ui/neo_root_settings.cpp
@@ -1677,7 +1677,7 @@ void NeoSettings_HUD(NeoSettings *ns)
 	NeoUI::RingBox(L"Extended killfeed", EXT_KILLFEED_LABELS, ARRAYSIZE(EXT_KILLFEED_LABELS), &pHud->iExtendedKillfeed);
 	NeoUI::RingBox(L"Scoreboard padding", NEOSCOREBOARDPADDING_LABELS, NEOSCOREBOARDPADDING__TOTAL, &pHud->iScoreboardPadding);
 
-	NeoUI::Divider(L"Contextual hints");
+	NeoUI::Divider(L"CONTEXTUAL HINTS");
 	NeoUI::RingBoxBool(L"Show HUD contextual hints", &pHud->bShowHudContextHints);
 	if (pHud->bShowHudContextHints)
 	{

--- a/src/game/shared/neo/neo_juggernaut.cpp
+++ b/src/game/shared/neo/neo_juggernaut.cpp
@@ -126,24 +126,6 @@ void CNEO_Juggernaut::Spawn(void)
 	UTIL_SetSize(this, VEC_HULL_MIN, VEC_HULL_MAX); // Needs to be equal or smaller than the player's girth to avoid getting stuck
 	SetFriction(100.0);
 	SetSoftCollision(false);
-
-	m_textParms.channel = 0;
-	m_textParms.x = 0.42;
-	m_textParms.y = 0.4;
-	m_textParms.effect = 0;
-	m_textParms.fadeinTime = 0;
-	m_textParms.fadeoutTime = 0;
-	m_textParms.holdTime = USE_DURATION;
-	m_textParms.fxTime = 0;
-
-	m_textParms.r1 = 200;
-	m_textParms.g1 = 200;
-	m_textParms.b1 = 200;
-	m_textParms.a1 = 100;
-	m_textParms.r2 = 200;
-	m_textParms.g2 = 200;
-	m_textParms.b2 = 200;
-	m_textParms.a2 = 100;
 	
 	CBaseEntity *pWeaponModel = CreateEntityByName("prop_dynamic");
 	if (pWeaponModel)
@@ -190,7 +172,6 @@ void CNEO_Juggernaut::Use(CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYP
 		SetNextThink(gpGlobals->curtime + 0.1f);
 		SetPlaybackRate(m_flWarpedPlaybackRate);
 		pNEOPlayer->AddFlag(FL_FROZEN);
-		UTIL_HudMessage(pNEOPlayer, m_textParms, "BOOTING JGR56"); // TODO localise this text
 		EmitSound("HUD.CPCharge");
 	}
 	else
@@ -221,7 +202,6 @@ void CNEO_Juggernaut::Think(void)
 		SetNextThink(TICK_NEVER_THINK);
 		StopSound("HUD.CPCharge");
 		EmitSound("HUD.CPCaptured");
-		UTIL_HudMessage(pNeoPlayer, m_textParms, ""); // Find a better way of hiding the text. This doesn't remove the old message from the user messages list and thus makes a weird overlapping visual bug
 
 		pNeoPlayer->RemoveFlag(FL_FROZEN);
 		pNeoPlayer->CreateRagdollEntity();
@@ -302,7 +282,6 @@ void CNEO_Juggernaut::HoldCancel(void)
 	if (pNeoPlayer)
 	{
 		pNeoPlayer->RemoveFlag(FL_FROZEN);
-		UTIL_HudMessage(pNeoPlayer, m_textParms, "");
 	}
 	SetNextThink(TICK_NEVER_THINK);
 	SetPlaybackRate(-m_flWarpedPlaybackRate);

--- a/src/game/shared/neo/neo_juggernaut.h
+++ b/src/game/shared/neo/neo_juggernaut.h
@@ -68,7 +68,6 @@ private:
 	float m_flHoldStartTime = 0.0f;
 	bool m_bActivationRemoval = false;
 
-	hudtextparms_t	m_textParms;
 	COutputEvent m_OnPlayerActivate;
 #endif
 };


### PR DESCRIPTION
## Description
Improves the capitalisation on the contextual hint strings and the menu divider. Removes the old juggernaut hint as I had originally intended to have it be replaced by the contextual hint.

## Toolchain
- Windows MSVC VS2022


