### PR TITLE
Bots won't ping and only see own pings in non-teamplay modes

### DIFF
--- a/src/game/client/neo/ui/neo_hud_player_ping.cpp
+++ b/src/game/client/neo/ui/neo_hud_player_ping.cpp
@@ -117,16 +117,16 @@ void CNEOHud_PlayerPing::FireGameEvent(IGameEvent* event)
 			return;
 		}
 
-		const int localTeam = GetLocalPlayerTeam();
-		const int playerTeam = event->GetInt("playerteam");
-		if (localTeam != TEAM_SPECTATOR && playerTeam != localTeam)
+		const int userID = event->GetInt("userid");
+		const int playerIndex = engine->GetPlayerForUserID(userID);
+		if (GetClientVoiceMgr()->IsPlayerBlocked(playerIndex) || (!NEORules()->IsTeamplay() && playerIndex != GetLocalPlayerIndex()))
 		{
 			return;
 		}
 
-		const int userID = event->GetInt("userid");
-		const int playerIndex = engine->GetPlayerForUserID(userID);
-		if (GetClientVoiceMgr()->IsPlayerBlocked(playerIndex))
+		const int localTeam = GetLocalPlayerTeam();
+		const int playerTeam = event->GetInt("playerteam");
+		if (localTeam != TEAM_SPECTATOR && playerTeam != localTeam)
 		{
 			return;
 		}
@@ -167,7 +167,7 @@ enum NeoPlayerPingsInSpectate
 ConVar cl_neo_player_pings_in_spectate("cl_neo_player_pings_in_spectate", "1", FCVAR_ARCHIVE, "See pings of players playing the game. 0 = disabled, 1 = spectate target team, 2 = all", true, NEO_SPECTATE_PINGS_DISABLED, true, NEO_SPECTATE_PINGS_LAST_VALUE);
 void CNEOHud_PlayerPing::DrawNeoHudElement()
 {
-	if (!ShouldDraw() || !NEORules()->IsTeamplay())
+	if (!ShouldDraw())
 	{
 		return;
 	}

--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -902,7 +902,10 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 
 	if (bOnTarget)
 	{
-		me->PressSpecialFireButton(); // place a player ping to alert friends
+		if (NEORules()->IsTeamplay())
+		{
+			me->PressSpecialFireButton(); // place a player ping to alert friends
+		}
 
 		if (bThreatIsGhoster)
 		{


### PR DESCRIPTION
## Description
In DM, change behaviours so that pings are blocked entirely, not just prevented from drawing. Brings them back for the local player. Stops bots from pinging.

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- fixes #2031 

