### PR TITLE
Show SourceTV separately on scoreboard

### DIFF
--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -723,7 +723,7 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 		// Output all the players in the server
 		for (int iCurTeam = TEAM_UNASSIGNED; iCurTeam < TEAM__TOTAL; ++iCurTeam)
 		{
-			if (iaTeamTally[iCurTeam] <= 0 && iCurTeam <= TEAM_SPECTATOR && !(iCurTeam == TEAM_SPECTATOR && !m_bSourceTVEnabled))
+			if (iaTeamTally[iCurTeam] <= 0 && iCurTeam <= TEAM_SPECTATOR)
 			{
 				continue;
 			}
@@ -802,14 +802,14 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 							}
 							if (bShowReadyUp)
 							{
-								V_swprintf_safe(wszText, L"%ls: %d (%d players - %d ready)",
-										wszTeamtag, pTeam->GetRoundsWon(), iaTeamTally[iCurTeam],
+								V_swprintf_safe(wszText, L"%ls: %d (%d player%s - %d ready)",
+										wszTeamtag, pTeam->GetRoundsWon(), iaTeamTally[iCurTeam], iaTeamTally[iCurTeam] == 1 ? "" : "s",
 										iaTeamReadyTally[iCurTeam]);
 							}
 							else
 							{
-								V_swprintf_safe(wszText, L"%ls: %d (%d players)",
-										wszTeamtag, pTeam->GetRoundsWon(), iaTeamTally[iCurTeam]);
+								V_swprintf_safe(wszText, L"%ls: %d (%d player%s)",
+										wszTeamtag, pTeam->GetRoundsWon(), iaTeamTally[iCurTeam], iaTeamTally[iCurTeam] == 1 ? "" : "s");
 							}
 						}
 					}
@@ -818,8 +818,9 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 						// DM - Print players total on the left side only
 						if (iCurTeam == TEAM_JINRAI)
 						{
-							V_swprintf_safe(wszText, L"Players: %d",
-									iaTeamTally[TEAM_JINRAI] + iaTeamTally[TEAM_NSF]);
+							const int total = iaTeamTally[TEAM_JINRAI] + iaTeamTally[TEAM_NSF];
+							V_swprintf_safe(wszText, L"Player%s: %d",
+									total == 1 ? "" : "s", total);
 						}
 						else
 						{
@@ -829,13 +830,14 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 				}
 				else
 				{
-					V_wcscpy_safe(wszText, SZWSZ_NEO_TEAM_STRS[iCurTeam].wszStr);
+					V_swprintf_safe(wszText, L"%ls (%d player%s)",
+							SZWSZ_NEO_TEAM_STRS[iCurTeam].wszStr, iaTeamTally[iCurTeam], iaTeamTally[iCurTeam] == 1 ? "" : "s");
 				}
 				NeoUI::Label(wszText, true);
 
 				if (TEAM_SPECTATOR == iCurTeam && m_bSourceTVEnabled)
 				{
-					V_swprintf_safe(wszText,L"SourceTV Enabled (%d Spectators)", m_HLTVSpectators);
+					V_swprintf_safe(wszText,L"SourceTV Enabled (%d watching)", m_HLTVSpectators);
 					int x = 0;
 					[[maybe_unused]] int y = 0;
 					vgui::surface()->GetTextSize(m_uiCtx.fonts[m_uiCtx.eFont].hdl, wszText, x, y);

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -345,10 +345,17 @@ void CNEOScoreBoard::Update()
 	m_iTotalPlayers = 0;
 	V_memset(m_playersInfo, 0, sizeof(m_playersInfo));
 
+	m_bSourceTVEnabled = false;
 	for (int i = 1; i <= gpGlobals->maxClients; ++i)
 	{
 		if (false == g_PR->IsConnected(i))
 		{
+			continue;
+		}
+
+		if (true == g_PR->IsHLTV(i))
+		{
+			m_bSourceTVEnabled = true;
 			continue;
 		}
 
@@ -716,7 +723,7 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 		// Output all the players in the server
 		for (int iCurTeam = TEAM_UNASSIGNED; iCurTeam < TEAM__TOTAL; ++iCurTeam)
 		{
-			if (iaTeamTally[iCurTeam] <= 0 && iCurTeam <= TEAM_SPECTATOR)
+			if (iaTeamTally[iCurTeam] <= 0 && iCurTeam <= TEAM_SPECTATOR && !(iCurTeam == TEAM_SPECTATOR && !m_bSourceTVEnabled))
 			{
 				continue;
 			}
@@ -820,16 +827,21 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 						}
 					}
 				}
-				else if (TEAM_SPECTATOR == iCurTeam && m_HLTVSpectators > 0)
-				{
-					V_swprintf_safe(wszText, L"%ls + %d HLTV spectators",
-							SZWSZ_NEO_TEAM_STRS[iCurTeam].wszStr, m_HLTVSpectators);
-				}
 				else
 				{
 					V_wcscpy_safe(wszText, SZWSZ_NEO_TEAM_STRS[iCurTeam].wszStr);
 				}
 				NeoUI::Label(wszText, true);
+
+				if (TEAM_SPECTATOR == iCurTeam && m_bSourceTVEnabled)
+				{
+					V_swprintf_safe(wszText,L"SourceTV Enabled (%d Spectators)", m_HLTVSpectators);
+					int x = 0;
+					[[maybe_unused]] int y = 0;
+					vgui::surface()->GetTextSize(m_uiCtx.fonts[m_uiCtx.eFont].hdl, wszText, x, y);
+					vgui::surface()->DrawSetTextPos(m_uiCtx.rWidgetArea.x0 + m_uiCtx.dPanel.wide - x - m_uiCtx.iMarginX, m_uiCtx.rWidgetArea.y0 + m_uiCtx.fonts[m_uiCtx.eFont].iYFontOffset);
+					vgui::surface()->DrawPrintText(wszText, V_wcslen(wszText));
+				}
 
 				NeoUI::Pad(); // Avatar/Dead-indicator
 				NeoUI::Pad(); // Name column

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -353,7 +353,7 @@ void CNEOScoreBoard::Update()
 			continue;
 		}
 
-		if (true == g_PR->IsHLTV(i))
+		if (g_PR->IsHLTV(i))
 		{
 			m_bSourceTVEnabled = true;
 			continue;
@@ -723,10 +723,15 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 		// Output all the players in the server
 		for (int iCurTeam = TEAM_UNASSIGNED; iCurTeam < TEAM__TOTAL; ++iCurTeam)
 		{
-			if (iaTeamTally[iCurTeam] <= 0 && iCurTeam <= TEAM_SPECTATOR)
+			if (iCurTeam == TEAM_UNASSIGNED && iaTeamTally[iCurTeam] <= 0)
 			{
 				continue;
 			}
+			else if (iCurTeam == TEAM_SPECTATOR && iaTeamTally[iCurTeam] <= 0 && !m_bSourceTVEnabled)
+			{
+				continue;
+			}
+
 			m_uiCtx.dPanel.wide = (iCurTeam <= TEAM_SPECTATOR)
 					? iRootSubPanelWide
 					: iRootSubPanelWide / 2;
@@ -837,7 +842,7 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 
 				if (TEAM_SPECTATOR == iCurTeam && m_bSourceTVEnabled)
 				{
-					V_swprintf_safe(wszText,L"SourceTV Enabled (%d watching)", m_HLTVSpectators);
+					V_swprintf_safe(wszText, L"SourceTV Enabled (%d watching)", m_HLTVSpectators);
 					int x = 0;
 					[[maybe_unused]] int y = 0;
 					vgui::surface()->GetTextSize(m_uiCtx.fonts[m_uiCtx.eFont].hdl, wszText, x, y);

--- a/src/game/client/neo/ui/neo_scoreboard.h
+++ b/src/game/client/neo/ui/neo_scoreboard.h
@@ -96,7 +96,7 @@ public:
 
 	NeoUI::Context m_uiCtx;
 
-	bool m_bSourceTVEnabled = 0;
+	bool m_bSourceTVEnabled = false;
 	int	m_HLTVSpectators = 0;
 
 	int m_iTotalPlayers = 0;

--- a/src/game/client/neo/ui/neo_scoreboard.h
+++ b/src/game/client/neo/ui/neo_scoreboard.h
@@ -96,7 +96,9 @@ public:
 
 	NeoUI::Context m_uiCtx;
 
+	bool m_bSourceTVEnabled = 0;
 	int	m_HLTVSpectators = 0;
+
 	int m_iTotalPlayers = 0;
 	CNEOScoreBoardPlayer m_playersInfo[MAX_PLAYERS_ARRAY_SAFE] = {};
 	CNEOScoreBoardPlayer m_playerPopup = {};


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Instead of showing the SourceTV bot in the scoreboard, draw some text informing the player that SourceTV is enabled

SourceTV enabled plus spectator in the game
<img width="1277" height="183" alt="image" src="https://github.com/user-attachments/assets/c420f904-1b2d-411d-b2b4-364a6f1dff2b" />

SourceTV enabled, no spectators in the game
<img width="1269" height="161" alt="image" src="https://github.com/user-attachments/assets/79752414-b286-43a4-b52c-e08ae7d4725f" />

SourceTV disabled, no spectators in the game
<img width="1273" height="128" alt="image" src="https://github.com/user-attachments/assets/80bb3704-31b1-41fb-a260-473d398a4601" />

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #