### PR TITLE
Carry over values from the damage report to show in the next round during freeze and pause

### DIFF
--- a/game/neo/resource/NeoModEvents.res
+++ b/game/neo/resource/NeoModEvents.res
@@ -107,6 +107,11 @@
 	
 	}
 	
+	"game_freezetime_end"
+	{
+	
+	}
+	
 	// inherited from NT
 	"game_round_end"
 	{

--- a/src/game/client/neo/c_neo_killer_damage_infos.cpp
+++ b/src/game/client/neo/c_neo_killer_damage_infos.cpp
@@ -203,7 +203,7 @@ static void __MsgFunc_KillerDamageInfo(bf_read &msg)
 
 	ConMsg("%sDamage infos (Round %d):\n%s\n", BORDER, NEORules()->roundNumber(), setKillByLine ? killByLine : "");
 
-	NeoDamageReportClear();
+	//NeoDamageReportClear();
 	gTotals = {};
 	const ENEOCompactMsgFlag flags = ReadDamageReport(msg);
 	if (!(flags & NEO_COMPACT_MSG_FLAG_EXTRA))

--- a/src/game/client/neo/c_neo_killer_damage_infos.cpp
+++ b/src/game/client/neo/c_neo_killer_damage_infos.cpp
@@ -203,7 +203,7 @@ static void __MsgFunc_KillerDamageInfo(bf_read &msg)
 
 	ConMsg("%sDamage infos (Round %d):\n%s\n", BORDER, NEORules()->roundNumber(), setKillByLine ? killByLine : "");
 
-	//NeoDamageReportClear();
+	NeoDamageReportClear();
 	gTotals = {};
 	const ENEOCompactMsgFlag flags = ReadDamageReport(msg);
 	if (!(flags & NEO_COMPACT_MSG_FLAG_EXTRA))

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -472,8 +472,13 @@ C_NEO_Player::C_NEO_Player()
 	m_flTocFactor = 0.15f;
 
 	memset(m_szNeoNameWDupeIdx, 0, sizeof(m_szNeoNameWDupeIdx));
-	ClearLocalPlayerDmgReports();
 	m_szNameDupePos = 0;
+
+	if (IsLocalPlayer())
+	{
+		ListenForGameEvent( "game_freezetime_end" );
+		ClearLocalPlayerDmgReports();
+	}
 }
 
 C_NEO_Player::~C_NEO_Player()
@@ -1186,8 +1191,6 @@ void C_NEO_Player::PreThink( void )
 			// so it could arrive too late.
 			CLocalPlayerFilter filter;
 			enginesound->SetPlayerDSP(filter, 0, true);
-
-			ClearLocalPlayerDmgReports();
 
 			// Reset the cache of other players crosshair data on spawning in
 			if (CHudCrosshair *crosshair = GET_HUDELEMENT(CHudCrosshair))
@@ -2144,6 +2147,15 @@ void C_NEO_Player::PlayerUse()
 void C_NEO_Player::ClearLocalPlayerDmgReports()
 {
 	if (IsLocalPlayer())
+	{
+		NeoAllKDReportsClear();
+	}
+}
+
+void C_NEO_Player::FireGameEvent(IGameEvent* event)
+{
+	auto eventName = event->GetName();
+	if (!Q_stricmp(eventName, "game_freezetime_end"))
 	{
 		NeoAllKDReportsClear();
 	}

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -1186,6 +1186,11 @@ void C_NEO_Player::PreThink( void )
 			// Toggle keys can be toggled while the player is dead, reset again on spawn
 			LiftAllToggleKeys();
 
+			if (NEORules()->CanRespawnAnyTime())
+			{
+				ClearLocalPlayerDmgReports();
+			}
+
 			// Reset any player explosion/shock effects
 			// NEO NOTE (Rain): The game already does this at CBasePlayer::Spawn, but that one's server-side,
 			// so it could arrive too late.

--- a/src/game/client/neo/c_neo_player.h
+++ b/src/game/client/neo/c_neo_player.h
@@ -47,6 +47,7 @@ public:
 	virtual void AddPoints(int score, bool bAllowNegativeScore, bool bIgnorePlayerTakeover = false);
 
 	virtual void PreDataUpdate(DataUpdateType_t updateType) OVERRIDE;
+	virtual void FireGameEvent( IGameEvent * event ) override;
 
 	// Should this object cast shadows?
 	virtual ShadowType_t		ShadowCastType( void );

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -337,8 +337,11 @@ void CNEOScoreBoard::Update()
 	const bool bLocalPlaying = (TEAM_JINRAI == iLocalPlayerTeam || TEAM_NSF == iLocalPlayerTeam);
 	const bool bIsTeamplay = NEORules()->IsTeamplay();
 
-	const bool bShowDamageInfo = (pLocalPlayer->IsPlayerDead() && NEORules()->IsRoundOn()) || (NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze || NEORules()->GetRoundStatus() == NeoRoundStatus::Pause)
-			&& bLocalPlaying;
+	const bool bShowDamageInfo =
+			   bLocalPlaying
+			&& ((pLocalPlayer->IsPlayerDead() && NEORules()->IsRoundOn())
+				|| (NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze
+					|| NEORules()->GetRoundStatus() == NeoRoundStatus::Pause));
 
 	// Zero array every update
 	m_iTotalPlayers = 0;
@@ -433,7 +436,8 @@ void CNEOScoreBoard::Update()
 				|| (bIsTeamplay && iLocalPlayerTeam == pPlayerInfo->iTeam) // Team - See own team's classes
 				|| (bShowDamageInfo
 						&& ((pPlayerInfo->iDealtDmgs > 0 && pPlayerInfo->iDealtHits > 0)
-							|| (pPlayerInfo->iTakenDmgs > 0 && pPlayerInfo->iTakenHits > 0))); // Dead and have damage dealt/taken
+							|| (pPlayerInfo->iTakenDmgs > 0 && pPlayerInfo->iTakenHits > 0)) // Dead and have damage dealt/taken
+						&& !(NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze || NEORules()->GetRoundStatus() == NeoRoundStatus::Pause));
 		if (bShowClass)
 		{
 			pPlayerInfo->iClass = (bIsImpersonating)
@@ -584,9 +588,11 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 	const bool bIsTeamplay = NEORules()->IsTeamplay();
 	const bool bShowReadyUp = sv_neo_readyup_lobby.GetBool()
 			&& NEORules()->m_nRoundStatus == NeoRoundStatus::Idle;
-	const bool bShowDamageInfo = (pLocalPlayer->IsPlayerDead() && NEORules()->IsRoundOn()) || (NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze || NEORules()->GetRoundStatus() == NeoRoundStatus::Pause)
-			&& g_neoKillerInfos.bHasDmgInfos
-			&& (pLocalPlayer->GetTeamNumber() == TEAM_JINRAI || pLocalPlayer->GetTeamNumber() == TEAM_NSF);
+	const bool bShowDamageInfo =
+			   g_neoKillerInfos.bHasDmgInfos
+			&& (pLocalPlayer->GetTeamNumber() == TEAM_JINRAI || pLocalPlayer->GetTeamNumber() == TEAM_NSF)
+			&& ((pLocalPlayer->IsPlayerDead() && NEORules()->IsRoundOn())
+				|| (NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze || NEORules()->GetRoundStatus() == NeoRoundStatus::Pause));
 	static CrosshairInfo staticXhairInfo = {};
 
 	bool bHasRanklessDog = false;

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -337,8 +337,7 @@ void CNEOScoreBoard::Update()
 	const bool bLocalPlaying = (TEAM_JINRAI == iLocalPlayerTeam || TEAM_NSF == iLocalPlayerTeam);
 	const bool bIsTeamplay = NEORules()->IsTeamplay();
 
-	const bool bShowDamageInfo = pLocalPlayer->IsPlayerDead()
-			&& NEORules()->InRoundState()
+	const bool bShowDamageInfo = (pLocalPlayer->IsPlayerDead() && NEORules()->IsRoundOn()) || (NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze || NEORules()->GetRoundStatus() == NeoRoundStatus::Pause)
 			&& bLocalPlaying;
 
 	// Zero array every update
@@ -585,11 +584,9 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 	const bool bIsTeamplay = NEORules()->IsTeamplay();
 	const bool bShowReadyUp = sv_neo_readyup_lobby.GetBool()
 			&& NEORules()->m_nRoundStatus == NeoRoundStatus::Idle;
-	const bool bShowDamageInfo = pLocalPlayer->IsPlayerDead()
-			&& NEORules()->InRoundState()
+	const bool bShowDamageInfo = (pLocalPlayer->IsPlayerDead() && NEORules()->IsRoundOn()) || (NEORules()->GetRoundStatus() == NeoRoundStatus::PreRoundFreeze || NEORules()->GetRoundStatus() == NeoRoundStatus::Pause)
 			&& g_neoKillerInfos.bHasDmgInfos
-			&& (pLocalPlayer->GetTeamNumber() == TEAM_JINRAI
-					|| pLocalPlayer->GetTeamNumber() == TEAM_NSF);
+			&& (pLocalPlayer->GetTeamNumber() == TEAM_JINRAI || pLocalPlayer->GetTeamNumber() == TEAM_NSF);
 	static CrosshairInfo staticXhairInfo = {};
 
 	bool bHasRanklessDog = false;

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -4577,6 +4577,11 @@ void CNEORules::SetRoundStatus(NeoRoundStatus status)
 			{
 				pEntGameCfg->m_OnRoundStart.FireOutput(nullptr, pEntGameCfg);
 			}
+			
+			if (IGameEvent* event = gameeventmanager->CreateEvent("game_freezetime_end"))
+			{
+				gameeventmanager->FireEvent(event);
+			}
 		}
 #endif
 	}


### PR DESCRIPTION
<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
<!--
Put in description here...
-->

Show damage report in freeze and pause

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
-->
- Windows MSVC VS2022

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
