### PR TITLE
Add (git tag) version to integrity fail message and neo_version

### DIFF
--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -1049,7 +1049,7 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 	InitializeNeoClRenderer();
 	InitializeClNeoCrosshair();
 #ifdef DEBUG
-	InitializeDbgNeoClGitHashEdit();
+	InitializeDbgNeoClGitHashTagEdit();
 #endif // DEBUG
 #endif // NEO
 

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -3435,6 +3435,7 @@ bool CNEORules::ClientConnected(edict_t *pEntity, const char *pszName, const cha
 	if (sv_neo_build_integrity_check.GetBool())
 	{
 		const char *clientGitHash = engine->GetClientConVarValue(engine->IndexOfEdict(pEntity), "__cl_neo_git_hash");
+		const char *clientGitTag = engine->GetClientConVarValue(engine->IndexOfEdict(pEntity), "__cl_neo_version_tag");
 		const bool dbgBuildSkip = (sv_neo_build_integrity_check_allow_debug.GetBool()) ? (clientGitHash[0] & 0b1000'0000) : false;
 		if (dbgBuildSkip)
 		{
@@ -3448,9 +3449,11 @@ bool CNEORules::ClientConnected(edict_t *pEntity, const char *pszName, const cha
 		{
 			// Truncate the git hash so it's short hash and doesn't make message too long
 			static constexpr int MAX_GITHASH_SHOW = 7;
-			V_snprintf(reject, maxrejectlen, "Build integrity failed! Client vs server mis-match: Check your neo_version. "
-											 "Client: %.*s | Server: %.*s",
-					   MAX_GITHASH_SHOW, cmpClientGitHash, MAX_GITHASH_SHOW, GIT_LONGHASH);
+			static constexpr int MAX_GITTAG_SHOW = 12;
+			V_snprintf(reject, maxrejectlen, "Build integrity failed! Client-server mismatch: Check neo_version. "
+											 "Client: %.*s %.*s | Server: %.*s %.*s",
+					   MAX_GITHASH_SHOW, cmpClientGitHash, MAX_GITTAG_SHOW, clientGitTag,
+					   MAX_GITHASH_SHOW, GIT_LONGHASH, MAX_GITTAG_SHOW, GIT_LATESTTAG);
 			return false;
 		}
 	}

--- a/src/game/shared/neo/neo_version.cpp
+++ b/src/game/shared/neo/neo_version.cpp
@@ -22,7 +22,7 @@ void NeoVersionPrint()
 #endif
 
 	Msg("%s\n"
-		"Build version: %s_%s\n"
+		"Build version: %s (%s_%s)\n"
 		"Build date: %s\n"
 		"Git hash: %s\n"
 		"OS: %s\n"
@@ -31,7 +31,7 @@ void NeoVersionPrint()
 		"Renderer: %s\n"
 #endif
 		, HEADER,
-		BUILD_DATE_SHORT, GIT_HASH,
+		GIT_LATESTTAG, BUILD_DATE_SHORT, GIT_HASH,
 		BUILD_DATE_LONG,
 		GIT_LONGHASH,
 		OS_BUILD,
@@ -63,6 +63,15 @@ ConCommand neo_version("neo_version", NeoVersionPrint, "Print out client/server'
 
 #ifdef CLIENT_DLL
 ConVar __cl_neo_git_hash("__cl_neo_git_hash", GIT_LONGHASH,
+						 FCVAR_USERINFO | FCVAR_HIDDEN | FCVAR_DONTRECORD | FCVAR_NOT_CONNECTED
+#ifndef DEBUG
+						 | FCVAR_PRINTABLEONLY
+#endif
+						 );
+#endif
+
+#ifdef CLIENT_DLL
+ConVar __cl_neo_version_tag("__cl_neo_version_tag", GIT_LATESTTAG,
 						 FCVAR_USERINFO | FCVAR_HIDDEN | FCVAR_DONTRECORD | FCVAR_NOT_CONNECTED
 #ifndef DEBUG
 						 | FCVAR_PRINTABLEONLY
@@ -109,7 +118,7 @@ void InitializeNeoClRenderer()
 }
 
 #ifdef DEBUG
-void InitializeDbgNeoClGitHashEdit()
+void InitializeDbgNeoClGitHashTagEdit()
 {
 	static char static_dbgHash[GIT_LONGHASH_SIZE];
 	V_strcpy_safe(static_dbgHash, GIT_LONGHASH);
@@ -117,6 +126,7 @@ void InitializeDbgNeoClGitHashEdit()
 	__cl_neo_git_hash.SetDefault(static_dbgHash);
 	__cl_neo_git_hash.Revert(); // It just sets to the default
 	__cl_neo_git_hash.InstallChangeCallback(NeoConVarEnforceDefault);
+	__cl_neo_version_tag.InstallChangeCallback(NeoConVarEnforceDefault);
 }
 #endif // DEBUG
 #endif // CLIENT_DLL

--- a/src/game/shared/neo/neo_version.h
+++ b/src/game/shared/neo/neo_version.h
@@ -5,7 +5,7 @@ void NeoVersionPrint();
 #ifdef CLIENT_DLL
 void InitializeNeoClRenderer();
 #ifdef DEBUG
-void InitializeDbgNeoClGitHashEdit();
+void InitializeDbgNeoClGitHashTagEdit();
 #endif // DEBUG
 #endif // CLIENT_DLL
 


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
This is mainly descriptive and not checked as the git hash the one to check. Should at least give more clear indication of the player or server running outdated builds. neo_version also changed to show the git tag version. Also made wording more concise.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Arch/GCC 16

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

- fixes #
- related #
-->

