### PR TITLE
Auto-fix lowercased engine binaries at launch

### DIFF
--- a/src/launcher_main/CMakeLists.txt
+++ b/src/launcher_main/CMakeLists.txt
@@ -11,6 +11,10 @@ if(OS_WINDOWS)
     list(APPEND LAUNCHER_SOURCES launcher_main_mod_neo.rc)
 endif()
 
+if(OS_LINUX)
+    list(APPEND LAUNCHER_SOURCES neo_case_heal.cpp neo_case_heal.h)
+endif()
+
 add_executable(launcher_main
     ${LAUNCHER_SOURCES}
 )

--- a/src/launcher_main/main.cpp
+++ b/src/launcher_main/main.cpp
@@ -704,6 +704,10 @@ static void WaitForDebuggerConnect( int argc, char *argv[], int time )
 #endif // !LINUX
 
 #ifdef NEO
+#if defined( LINUX )
+#include "neo_case_heal.h"
+#endif
+
 // The engine resolves |appid_243750| gameinfo mounts by opening the SDK Base
 // 2013 Multiplayer install path with the final word of the folder name
 // lowercased ("...2013 multiplayer"). On case-sensitive filesystems that path
@@ -812,6 +816,12 @@ int main( int argc, char *argv[] )
 	{
 		fprintf( stderr, "[NT;RE launcher] Warning: chdir(%s) failed: %s\n", pRootDir, strerror( errno ) );
 	}
+
+#if defined( LINUX )
+	// Must run before any engine library is opened. Runs on both sides of
+	// the bootstrap re-exec below; the second pass is a no-op.
+	NEO_HealBinaryCasing( pRootDir );
+#endif
 
 	// The dynamic linker only reads LD_LIBRARY_PATH at process start, and
 	// launcher.so's dependencies resolve through it, so prepend our bin dir

--- a/src/launcher_main/neo_case_heal.cpp
+++ b/src/launcher_main/neo_case_heal.cpp
@@ -1,0 +1,99 @@
+#include "neo_case_heal.h"
+
+#include <ctype.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+// Heal hack :: fix poisoned installations
+
+// Binaries the engine loads by exact mixed-case name. 
+// Keep this list in sync with src/devtools/check_depot_casing.sh. 
+// It's hacky but it works, and should be harmless to leave in 
+// clearly marked, use `git blame` to find the commit to revert. 
+static const char *k_pszCanonicalBinaryPaths[] =
+{
+	"bin/GameUI.so",
+	"bin/ServerBrowser.so",
+	"bin/libMiles.so",
+	"bin/libTelemetryX64.so",
+	"bin/libTelemetryX86.so",
+	"bin/linux64/GameUI.so",
+	"bin/linux64/ServerBrowser.so",
+};
+
+int NEO_HealBinaryCasing( const char *pszRootDir )
+{
+	int nRepairs = 0;
+	const size_t nRootLen = strlen( pszRootDir );
+
+	for ( size_t i = 0; i < sizeof( k_pszCanonicalBinaryPaths ) / sizeof( k_pszCanonicalBinaryPaths[0] ); ++i )
+	{
+		const char *pszCanonical = k_pszCanonicalBinaryPaths[i];
+
+		char szCanonicalPath[PATH_MAX];
+		char szLowerPath[PATH_MAX];
+		int nLen = snprintf( szCanonicalPath, sizeof( szCanonicalPath ), "%s/%s", pszRootDir, pszCanonical );
+		if ( nLen <= 0 || nLen >= (int)sizeof( szCanonicalPath ) )
+		{
+			continue;
+		}
+
+		// The miscased variant is always the fully lower cased relative
+		// path. The directory parts are already lowercase, so
+		// lower casing the whole relative path is A-OK.
+
+		memcpy( szLowerPath, szCanonicalPath, nLen + 1 );
+		for ( char *pch = szLowerPath + nRootLen + 1; *pch; ++pch )
+		{
+			*pch = (char)tolower( (unsigned char)*pch );
+		}
+
+		if ( strcmp( szLowerPath, szCanonicalPath ) == 0 )
+		{
+			continue;
+		}
+
+		// `lstat` instead of `stat`: a twin left as a symlink should be
+		// handled as the link itself, not its target.
+		// see: `man lstat`
+		struct stat lowerStat;
+		if ( lstat( szLowerPath, &lowerStat ) != 0 )
+		{
+			continue;
+		}
+
+		struct stat canonStat;
+		const bool bHaveCanonical = ( lstat( szCanonicalPath, &canonStat ) == 0 );
+
+		bool bRepaired;
+		if ( !bHaveCanonical || lowerStat.st_mtime > canonStat.st_mtime )
+		{
+			// Either its just the lowercased file exists, or both exist and
+			// the lowercased one is newer. Newer means Steam wrote it
+			// last, so it carries the current depot content. rename()
+			// replaces any stale canonical file atomically.
+
+			bRepaired = ( rename( szLowerPath, szCanonicalPath ) == 0 );
+		}
+		else
+		{
+			// Both exist and the canonical file is current. Drop the twin.
+			bRepaired = ( unlink( szLowerPath ) == 0 );
+		}
+
+		if ( bRepaired )
+		{
+			fprintf( stderr, "[NT;RE launcher] Repaired file name casing: %s\n", pszCanonical );
+			++nRepairs;
+		}
+		else
+		{
+			fprintf( stderr, "[NT;RE launcher] Warning: could not repair file name casing of %s. The engine may fail to load it.\n", pszCanonical );
+		}
+	}
+
+	return nRepairs;
+}

--- a/src/launcher_main/neo_case_heal.h
+++ b/src/launcher_main/neo_case_heal.h
@@ -1,0 +1,20 @@
+#ifndef NEO_CASE_HEAL_H
+#define NEO_CASE_HEAL_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+// Heal hack :: fix poisoned installations
+
+// Repairs engine binaries whose ondisk file names are fully lowercased.
+// The engine loads these binaries by exact mixed case name, and Steam
+// matches depot file names case-insensitively. Steam never renames files on
+// disk. 
+// 
+// A lowercased copy is unreachable on a case sensitive filesystem. 
+// Renames each affected file under `pszRootDir` back to its conventional casing. 
+// When both casings exist, the newest file wins and ends up under the 
+// canonical name. Returns the number of repairs made.
+int NEO_HealBinaryCasing( const char *pszRootDir );
+
+#endif // NEO_CASE_HEAL_H

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -28,10 +28,23 @@ add_executable(test_neo_serial
     ${CMAKE_SOURCE_DIR}/game/shared/neo/neo_serial.h
 )
 
+if (OS_LINUX)
+    add_executable(test_neo_case_heal
+        test_neo_case_heal.cpp
+        test_util.h
+        ${CMAKE_SOURCE_DIR}/launcher_main/neo_case_heal.cpp
+        ${CMAKE_SOURCE_DIR}/launcher_main/neo_case_heal.h
+    )
+endif ()
+
 set(TEST_EXE_LIST
     test_neo_crosshair
     test_neo_serial
 )
+
+if (OS_LINUX)
+    list(APPEND TEST_EXE_LIST test_neo_case_heal)
+endif ()
 
 foreach (TEST_EXE ${TEST_EXE_LIST})
     add_test(NAME ${TEST_EXE}

--- a/src/tests/test_neo_case_heal.cpp
+++ b/src/tests/test_neo_case_heal.cpp
@@ -1,0 +1,152 @@
+#include "test_util.h"
+#include "../launcher_main/neo_case_heal.h"
+
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+// Each test builds a throwaway install root under /tmp with mkdtemp and
+// runs the heal against it. Helpers below keep the fixtures short.
+
+static char g_szRoot[256];
+
+static void MakeRoot()
+{
+	V_strcpy_safe( g_szRoot, "/tmp/neo_case_heal_XXXXXX" );
+	TEST_VERIFY( mkdtemp( g_szRoot ) != nullptr );
+	char szDir[512];
+	V_sprintf_safe( szDir, "%s/bin", g_szRoot );
+	TEST_VERIFY( mkdir( szDir, 0755 ) == 0 );
+	V_sprintf_safe( szDir, "%s/bin/linux64", g_szRoot );
+	TEST_VERIFY( mkdir( szDir, 0755 ) == 0 );
+}
+
+static void WriteFileContent( const char *pszRelPath, const char *pszContent )
+{
+	char szPath[512];
+	V_sprintf_safe( szPath, "%s/%s", g_szRoot, pszRelPath );
+	FILE *pFile = fopen( szPath, "w" );
+	TEST_VERIFY( pFile != nullptr );
+	if ( pFile )
+	{
+		fputs( pszContent, pFile );
+		fclose( pFile );
+	}
+}
+
+static void SetMTime( const char *pszRelPath, time_t iSeconds )
+{
+	char szPath[512];
+	V_sprintf_safe( szPath, "%s/%s", g_szRoot, pszRelPath );
+	struct timeval times[2] = { { iSeconds, 0 }, { iSeconds, 0 } };
+	TEST_VERIFY( utimes( szPath, times ) == 0 );
+}
+
+static bool RelExists( const char *pszRelPath )
+{
+	char szPath[512];
+	V_sprintf_safe( szPath, "%s/%s", g_szRoot, pszRelPath );
+	struct stat st;
+	return lstat( szPath, &st ) == 0;
+}
+
+static void ReadFileContent( const char *pszRelPath, char *pszOut, int nOutSize )
+{
+	pszOut[0] = '\0';
+	char szPath[512];
+	V_sprintf_safe( szPath, "%s/%s", g_szRoot, pszRelPath );
+	FILE *pFile = fopen( szPath, "r" );
+	TEST_VERIFY( pFile != nullptr );
+	if ( pFile )
+	{
+		size_t nRead = fread( pszOut, 1, nOutSize - 1, pFile );
+		pszOut[nRead] = '\0';
+		fclose( pFile );
+	}
+}
+
+void TestLowercaseOnlyGetsRenamed()
+{
+	MakeRoot();
+	WriteFileContent( "bin/gameui.so", "engine bits" );
+	WriteFileContent( "bin/linux64/gameui.so", "engine bits 64" );
+	TEST_COMPARE_INT( 2, NEO_HealBinaryCasing( g_szRoot ) );
+	TEST_VERIFY( RelExists( "bin/GameUI.so" ) );
+	TEST_VERIFY( RelExists( "bin/linux64/GameUI.so" ) );
+	TEST_VERIFY( !RelExists( "bin/gameui.so" ) );
+	TEST_VERIFY( !RelExists( "bin/linux64/gameui.so" ) );
+}
+
+void TestBothExistLowercaseNewerWins()
+{
+	MakeRoot();
+	WriteFileContent( "bin/GameUI.so", "stale" );
+	WriteFileContent( "bin/gameui.so", "current" );
+	SetMTime( "bin/GameUI.so", 1000000 );
+	SetMTime( "bin/gameui.so", 2000000 );
+	TEST_COMPARE_INT( 1, NEO_HealBinaryCasing( g_szRoot ) );
+	TEST_VERIFY( RelExists( "bin/GameUI.so" ) );
+	TEST_VERIFY( !RelExists( "bin/gameui.so" ) );
+	char szContent[64];
+	ReadFileContent( "bin/GameUI.so", szContent, sizeof( szContent ) );
+	TEST_COMPARE_STR( szContent, "current" );
+}
+
+void TestBothExistCanonicalNewerKept()
+{
+	MakeRoot();
+	WriteFileContent( "bin/GameUI.so", "current" );
+	WriteFileContent( "bin/gameui.so", "stale" );
+	SetMTime( "bin/GameUI.so", 2000000 );
+	SetMTime( "bin/gameui.so", 1000000 );
+	TEST_COMPARE_INT( 1, NEO_HealBinaryCasing( g_szRoot ) );
+	TEST_VERIFY( RelExists( "bin/GameUI.so" ) );
+	TEST_VERIFY( !RelExists( "bin/gameui.so" ) );
+	char szContent[64];
+	ReadFileContent( "bin/GameUI.so", szContent, sizeof( szContent ) );
+	TEST_COMPARE_STR( szContent, "current" );
+}
+
+void TestCanonicalOnlyIsNoop()
+{
+	MakeRoot();
+	WriteFileContent( "bin/GameUI.so", "engine bits" );
+	TEST_COMPARE_INT( 0, NEO_HealBinaryCasing( g_szRoot ) );
+	TEST_VERIFY( RelExists( "bin/GameUI.so" ) );
+}
+
+void TestEmptyRootIsNoop()
+{
+	MakeRoot();
+	TEST_COMPARE_INT( 0, NEO_HealBinaryCasing( g_szRoot ) );
+}
+
+void TestAllSevenEntriesCovered()
+{
+	MakeRoot();
+	WriteFileContent( "bin/gameui.so", "a" );
+	WriteFileContent( "bin/serverbrowser.so", "b" );
+	WriteFileContent( "bin/libmiles.so", "c" );
+	WriteFileContent( "bin/libtelemetryx64.so", "d" );
+	WriteFileContent( "bin/libtelemetryx86.so", "e" );
+	WriteFileContent( "bin/linux64/gameui.so", "f" );
+	WriteFileContent( "bin/linux64/serverbrowser.so", "g" );
+	TEST_COMPARE_INT( 7, NEO_HealBinaryCasing( g_szRoot ) );
+	TEST_VERIFY( RelExists( "bin/GameUI.so" ) );
+	TEST_VERIFY( RelExists( "bin/ServerBrowser.so" ) );
+	TEST_VERIFY( RelExists( "bin/libMiles.so" ) );
+	TEST_VERIFY( RelExists( "bin/libTelemetryX64.so" ) );
+	TEST_VERIFY( RelExists( "bin/libTelemetryX86.so" ) );
+	TEST_VERIFY( RelExists( "bin/linux64/GameUI.so" ) );
+	TEST_VERIFY( RelExists( "bin/linux64/ServerBrowser.so" ) );
+}
+
+TEST_INIT()
+TEST_RUN( TestLowercaseOnlyGetsRenamed )
+TEST_RUN( TestBothExistLowercaseNewerWins )
+TEST_RUN( TestBothExistCanonicalNewerKept )
+TEST_RUN( TestCanonicalOnlyIsNoop )
+TEST_RUN( TestEmptyRootIsNoop )
+TEST_RUN( TestAllSevenEntriesCovered )
+TEST_END()


### PR DESCRIPTION
## Description

> [!WARNING]
> 
> This just "fixes" poisoned installs. That's why it's hacky. The real fix will require verifying the depot files' names at deploytime fixing the filenames in the depot.

The depot ships 7 `bin/` binaries fully lowercased, but the engine `dlopen`s them by exact mixed-case name (`GameUI.so` etc.) and Steam never repairs casing on disk. Linux installs created since the casing change fail at startup with "Engine Error: Could not load: GameUI"; older installs keep working, and verify/reinstall can't fix it. Follow-up to the depot notes in #2019.

- Launcher renames the seven binaries to canonical casing at startup, before anything is `dlopen`ed. Newest file wins if both casings exist; failures warn, never block launch.
- Unit tests cover the four disk states. Linux-only; no CI changes.

Verified on Linux: `ctest` green in sniper, and a real install with both `GameUI.so` lowercased (error dialog on the stock launcher) reaches the menu with this launcher.

## Testing on Linux

From `src/` in a sniper environment:

```
cmake --preset linux-release
cmake --build build/linux-release --target launcher_main test_neo_case_heal
ctest --test-dir build/linux-release/tests/ -R test_neo_case_heal
```

From the install root:

```
mv bin/GameUI.so bin/gameui.so
mv bin/linux64/GameUI.so bin/linux64/gameui.so
```

Launch stock: "Engine Error: Could not load: GameUI". Then:

```
cp <repo>/src/build/linux-release/launcher_main/neo_linux64 .
```

Launch again: reaches the menu, only `GameUI.so` left on disk.

## Depot Changes

- Re-stage `bin/` with canonical filename casing (the seven files); ship together with this launcher so new installs stop being born broken.

## Toolchain
- Linux GCC 10 Sniper 3.0
