### PR TITLE
Fix NPCs not showing in thermals

### DIFF
--- a/src/game/client/proxyplayer.cpp
+++ b/src/game/client/proxyplayer.cpp
@@ -318,7 +318,7 @@ void CBaseAnimatingTemperature::OnBind(void* pC_BaseEntity)
 	{
 		m_pResult->SetFloatValue(0);
 	}
-	else if (pEntity->IsPlayer())
+	else if (pEntity->IsBaseCombatCharacter())
 	{
 		m_pResult->SetFloatValue(THERMALS_OBJECT_MAX_TEMPERATURE);
 	}


### PR DESCRIPTION
## Description
This fixes npcs not showing in thermals

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1751

