### PR TITLE
Change cap zone distance to account for the cap radius

### DIFF
--- a/src/game/client/neo/ui/neo_hud_ghost_cap_point.cpp
+++ b/src/game/client/neo/ui/neo_hud_ghost_cap_point.cpp
@@ -73,7 +73,7 @@ void CNEOHud_GhostCapPoint::UpdateStateForNeoHudElementDraw()
 	auto *player = C_NEO_Player::GetLocalNEOPlayer();
 	if (!player) return;
 
-	m_flDistance = METERS_PER_INCH * player->GetAbsOrigin().DistTo(m_vecMyPos);
+	m_flDistance = METERS_PER_INCH * Max(0.0f, (player->GetAbsOrigin().DistTo(m_vecMyPos) - m_flMyRadius));
 	if (cl_neo_hud_worldpos_verbose.GetBool())
 	{
 		V_snwprintf(m_wszMarkerTextUnicode, ARRAYSIZE(m_wszMarkerTextUnicode), L"RETRIEVAL ZONE DISTANCE: %.0f m", m_flDistance);


### PR DESCRIPTION
## Description
The distance from the cap zone now shows the distance from the cap radius rather than the origin. Currently in gameplay, players are not given any information about how large the radius is, which can lead to frustration from missed or unexpected caps. I think this would be a minimal but effective change that reduces cases like this.

This is a diversion from parity, so feel free to debate this change

## Toolchain
- Windows MSVC VS2022

