### PR TITLE
Reduce smoke opacity in thermal vision.

### DIFF
--- a/src/game/client/c_particle_smokegrenade.cpp
+++ b/src/game/client/c_particle_smokegrenade.cpp
@@ -684,7 +684,7 @@ inline void C_ParticleSmokeGrenade::ApplyDynamicLight( const Vector &vParticlePo
 	}
 }
 
-
+ConVar r_neo_thermal_smoke_alpha("r_neo_thermal_smoke_alpha", "0.03", FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY, "Smoke grenade transparency in thermal vision",true, 0.0f, true, 1.0f);
 void C_ParticleSmokeGrenade::RenderParticles( CParticleRenderIterator *pIterator )
 {
 	const SmokeGrenadeParticle* pParticle = (const SmokeGrenadeParticle*)pIterator->GetFirst();
@@ -739,8 +739,7 @@ void C_ParticleSmokeGrenade::RenderParticles( CParticleRenderIterator *pIterator
 
 			if (CanSeeThroughSmokeGrenades())
 			{
-				constexpr float THERMAL_VISION_ALPHA_MULTIPLIER = 0.1f;
-				alpha *= THERMAL_VISION_ALPHA_MULTIPLIER;
+				alpha *= r_neo_thermal_smoke_alpha.GetFloat();
 			}
 
 			// TODO: optimize this whole routine!


### PR DESCRIPTION
## Description
Reduces smoke opacity while in thermal vision. This isn't a strict attempt at parity because the color of the smokes also play a role in how visible they are and I didn't want to make smokes completely invisible. I basically went as low as I could while still maintaining awareness of the smoke without having to turn off motion vision. In the end the alpha value went from the old 0.1 to 0.03.

Since this is highly subjective I made it a convar (flagged development only) to more easily tweak it in the future if necessary.

OGNT:
<img width="2050" height="1238" alt="d1_ognt" src="https://github.com/user-attachments/assets/f6ec5e20-f6d7-4632-bae1-d142b5214c46" />

NT;RE @ 0.03:
<img width="2050" height="1238" alt="d1_ntre0 03" src="https://github.com/user-attachments/assets/5b50a783-6b8a-42f1-a269-4f73d4725386" />

## Toolchain
- Linux GCC Distro Native - CachyOS - gcc version 16.1.1 20260728

## Linked Issues
- fixes #2062 

