### PR TITLE
Avoid recomputing long/static paths on short timers

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_capture.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_capture.cpp
@@ -60,7 +60,7 @@ ActionResult<CNEOBot> CNEOBotCtgCapture::Update( CNEOBot *me, float interval )
 			// Transition to search around the ghost behavior to avoid cycle of ghost search failure and retry attempts
 			return ChangeTo( new CNEOBotCtgLoneWolf(), "Unable to find a path to the ghost capture target, searching around nearest areas" );
 		}
-		m_repathTimer.Start( RandomFloat( 0.3f, 0.6f ) );
+		m_repathTimer.Start( RandomFloat( 1.0f, 2.0f ) );
 	}
 	m_path.Update( me );
 

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_carrier.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_carrier.cpp
@@ -356,7 +356,6 @@ ActionResult< CNEOBot >	CNEOBotCtgCarrier::OnStart( CNEOBot *me, Action< CNEOBot
 {
 	m_chasePath.Invalidate();
 	m_aloneTimer.Invalidate();
-	m_repathTimer.Invalidate();
 	m_path.SetMinLookAheadDistance( me->GetDesiredPathLookAheadRange() );
 
 	m_teammates.RemoveAll();
@@ -542,12 +541,11 @@ void CNEOBotCtgCarrier::UpdateFollowPath( CNEOBot *me, const CUtlVector<CNEO_Pla
 			{
 				m_chasePath.Invalidate();
 
-				if ( !m_path.IsValid() || !m_repathTimer.HasStarted() || m_repathTimer.IsElapsed() )
+				if ( !m_path.IsValid() )
 				{
 					CNEOBotPathCompute( me, m_path, vecGoalPos, FASTEST_ROUTE );
-					m_repathTimer.Start( RandomFloat( 0.3f, 0.5f ) );
 				}
-				
+                
 				m_path.Update( me );
 				return;
 			}
@@ -633,10 +631,9 @@ void CNEOBotCtgCarrier::UpdateFollowPath( CNEOBot *me, const CUtlVector<CNEO_Pla
 
 	if ( bFoundGoal )
 	{
-		if ( !m_path.IsValid() || !m_repathTimer.HasStarted() || m_repathTimer.IsElapsed() )
+		if ( !m_path.IsValid() )
 		{
 			CNEOBotPathCompute( me, m_path, vecGoalPos, SAFEST_ROUTE );
-			m_repathTimer.Start( RandomFloat( 0.5f, 1.0f ) );
 		}
 		m_path.Update( me );
 	}
@@ -656,7 +653,6 @@ ActionResult< CNEOBot > CNEOBotCtgCarrier::OnResume( CNEOBot *me, Action< CNEOBo
 	// Re-evaluate nearest cap point on resume (in case we moved significantly while interrupted)
 	m_closestCapturePoint = GetNearestCapPoint( me );
 
-	m_repathTimer.Invalidate();
 	UpdateFollowPath( me, m_teammates );
 	return Continue();
 }
@@ -664,6 +660,7 @@ ActionResult< CNEOBot > CNEOBotCtgCarrier::OnResume( CNEOBot *me, Action< CNEOBo
 //---------------------------------------------------------------------------------------------
 EventDesiredResult< CNEOBot > CNEOBotCtgCarrier::OnStuck( CNEOBot *me )
 {
+	m_path.Invalidate();
 	m_teammates.RemoveAll();
 	CollectPlayers( me, &m_teammates );
 	UpdateFollowPath( me, m_teammates );
@@ -679,5 +676,6 @@ EventDesiredResult< CNEOBot > CNEOBotCtgCarrier::OnMoveToSuccess( CNEOBot *me, c
 //---------------------------------------------------------------------------------------------
 EventDesiredResult< CNEOBot > CNEOBotCtgCarrier::OnMoveToFailure( CNEOBot *me, const Path *path, MoveToFailureType reason )
 {
+	m_path.Invalidate();
 	return TryContinue();
 }

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_carrier.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_carrier.h
@@ -45,7 +45,6 @@ private:
 	PathFollower m_path;
 	ChasePath m_chasePath;
 	CountdownTimer m_aloneTimer;
-	CountdownTimer m_repathTimer;
 	
 	CNEOBotGhostEquipmentHandler m_ghostEquipmentHandler;
 	

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_escort.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_escort.cpp
@@ -195,7 +195,8 @@ ActionResult< CNEOBot >	CNEOBotCtgEscort::Update( CNEOBot *me, float interval )
 		{
 			m_chasePath.Invalidate();
 
-			CNEOBotPathCompute( me, m_path, vecMoveTarget, SAFEST_ROUTE );
+			// when using m_repathTimer approach, use FASTEST_ROUTE for path consistency
+			CNEOBotPathCompute( me, m_path, vecMoveTarget, FASTEST_ROUTE );
 			m_repathTimer.Start( RandomFloat( 1.0f, 2.0f ) );
 		}
 		m_path.Update( me );

--- a/src/game/server/neo/bot/behavior/neo_bot_grenade_throw.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_grenade_throw.cpp
@@ -385,7 +385,7 @@ ActionResult< CNEOBot >	CNEOBotGrenadeThrow::Update( CNEOBot *me, float interval
 
 				if ( m_repathTimer.IsElapsed() )
 				{
-					m_repathTimer.Start( RandomFloat( 0.3f, 0.5f ) );
+					m_repathTimer.Start( RandomFloat( 1.0f, 2.0f ) );
 					CNEOBotPathCompute( me, m_PathFollower, m_vecTarget, FASTEST_ROUTE );
 				}
 			}
@@ -412,7 +412,7 @@ ActionResult< CNEOBot >	CNEOBotGrenadeThrow::Update( CNEOBot *me, float interval
 
 		if ( m_repathTimer.IsElapsed() )
 		{
-			m_repathTimer.Start( RandomFloat( 0.3f, 0.5f ) );
+			m_repathTimer.Start( RandomFloat( 1.0f, 2.0f ) );
 
 			if ( !m_vantageArea && !m_bVantagePointBlocked )
 			{

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_from_grenade.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_from_grenade.cpp
@@ -232,10 +232,10 @@ ActionResult< CNEOBot >	CNEOBotRetreatFromGrenade::Update( CNEOBot *me, float in
 	if ( me->GetLastKnownArea() != m_coverArea || !bIsExposed )
 	{
 		// not in cover yet
-		if (m_repathTimer.IsElapsed())
+		if ( m_repathTimer.IsElapsed() || !m_path.IsValid() )
 		{
-			CNEOBotPathCompute(me, m_path, m_coverArea->GetCenter(), FASTEST_ROUTE);
-			m_repathTimer.Start(0.2f); // Recompute path every 0.2 seconds
+			CNEOBotPathCompute( me, m_path, m_coverArea->GetCenter(), FASTEST_ROUTE );
+			m_repathTimer.Start( 1.0f );
 		}
 		m_path.Update( me );
 	}
@@ -247,6 +247,8 @@ ActionResult< CNEOBot >	CNEOBotRetreatFromGrenade::Update( CNEOBot *me, float in
 //---------------------------------------------------------------------------------------------
 EventDesiredResult< CNEOBot > CNEOBotRetreatFromGrenade::OnStuck( CNEOBot *me )
 {
+	m_path.Invalidate();
+	m_repathTimer.Invalidate();
 	return TryContinue();
 }
 
@@ -261,6 +263,8 @@ EventDesiredResult< CNEOBot > CNEOBotRetreatFromGrenade::OnMoveToSuccess( CNEOBo
 //---------------------------------------------------------------------------------------------
 EventDesiredResult< CNEOBot > CNEOBotRetreatFromGrenade::OnMoveToFailure( CNEOBot *me, const Path *path, MoveToFailureType reason )
 {
+	m_path.Invalidate();
+	m_repathTimer.Invalidate();
 	return TryContinue();
 }
 

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
@@ -309,10 +309,8 @@ ActionResult< CNEOBot >	CNEOBotRetreatToCover::Update( CNEOBot *me, float interv
 
 		m_waitInCoverTimer.Reset();
 
-		if ( m_repathTimer.IsElapsed() )
+		if ( !m_path.IsValid() )
 		{
-			m_repathTimer.Start( RandomFloat( 0.3f, 0.5f ) );
-
 			CNEOBotPathCompute( me, m_path, m_coverArea->GetCenter(), RETREAT_ROUTE );
 		}
 
@@ -326,6 +324,7 @@ ActionResult< CNEOBot >	CNEOBotRetreatToCover::Update( CNEOBot *me, float interv
 //---------------------------------------------------------------------------------------------
 EventDesiredResult< CNEOBot > CNEOBotRetreatToCover::OnStuck( CNEOBot *me )
 {
+	m_path.Invalidate();
 	return TryContinue();
 }
 
@@ -340,6 +339,7 @@ EventDesiredResult< CNEOBot > CNEOBotRetreatToCover::OnMoveToSuccess( CNEOBot *m
 //---------------------------------------------------------------------------------------------
 EventDesiredResult< CNEOBot > CNEOBotRetreatToCover::OnMoveToFailure( CNEOBot *me, const Path *path, MoveToFailureType reason )
 {
+	m_path.Invalidate();
 	return TryContinue();
 }
 

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.h
@@ -22,7 +22,6 @@ private:
 	Action< CNEOBot > *m_actionToChangeToOnceCoverReached;
 
 	PathFollower m_path;
-	CountdownTimer m_repathTimer;
 
 	CNavArea *m_coverArea;
 	CountdownTimer m_grenadeCheckTimer;

--- a/src/game/server/neo/bot/behavior/neo_bot_seek_weapon.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_seek_weapon.cpp
@@ -280,7 +280,7 @@ ActionResult< CNEOBot >	CNEOBotSeekWeapon::Update( CNEOBot *me, float interval )
 		{
 			return Done("Unable to find a path to the nearest primary weapon");
 		}
-		m_repathTimer.Start( RandomFloat( 0.3f, 0.6f ) );
+		m_repathTimer.Start( RandomFloat( 1.0f, 2.0f ) );
 	}
 
 	if (!m_path.IsValid())


### PR DESCRIPTION
## Description
Only follow short timer recompute pattern with paths that are short and without additional path requirements.
Because there are now complex criteria in the path costs, triggering an early recompute was causing bots to jitter between different alternative paths, which caused indecisive repathing in competing directions at times.
By limiting the recompute on short timers in the case where paths are intended to be short or straightforward, we can avoid these path jitter events.

## Toolchain
- Windows MSVC VS2022
