### PR TITLE
Differ killer/damage info console printout to single ConMsg

### DIFF
--- a/src/game/client/neo/c_neo_killer_damage_infos.cpp
+++ b/src/game/client/neo/c_neo_killer_damage_infos.cpp
@@ -15,6 +15,8 @@
 
 static inline AttackersTotals gTotals;
 static const char *BORDER = "==========================\n";
+static char gPrintBuffer[4096];
+static char gConcatBuffer[512];
 
 void NeoUserIDsLocalKilledClear()
 {
@@ -93,7 +95,8 @@ static ENEOCompactMsgFlag ReadDamageReport(bf_read &msg)
 			V_sprintf_safe(infoLine, "Damage dealt to %s [%s]: %d in %d hits\n",
 					   dmgerName, dmgerClass,
 					   pDmgReport->iDealtDmgs, pDmgReport->iDealtHits);
-			ConMsg("%s", infoLine);
+			V_sprintf_safe(gConcatBuffer, "%s", infoLine);
+			V_strcat_safe(gPrintBuffer, gConcatBuffer);
 			gTotals.iDealtDmgs += pDmgReport->iDealtDmgs;
 			gTotals.iDealtHits += pDmgReport->iDealtHits;
 		}
@@ -102,7 +105,8 @@ static ENEOCompactMsgFlag ReadDamageReport(bf_read &msg)
 			V_sprintf_safe(infoLine, "Damage taken from %s [%s]: %d in %d hits\n",
 					   dmgerName, dmgerClass,
 					   pDmgReport->iTakenDmgs, pDmgReport->iTakenHits);
-			ConMsg("%s", infoLine);
+			V_sprintf_safe(gConcatBuffer, "%s", infoLine);
+			V_strcat_safe(gPrintBuffer, gConcatBuffer);
 			gTotals.iTakenDmgs += pDmgReport->iTakenDmgs;
 			gTotals.iTakenHits += pDmgReport->iTakenHits;
 		}
@@ -115,10 +119,11 @@ static ENEOCompactMsgFlag ReadDamageReport(bf_read &msg)
 
 static void PrintTotalReport()
 {
-	ConMsg("Total damage dealt: %d in %d hits\nTotal damage received from players: %d in %d hits\n%s\n",
+	V_sprintf_safe(gConcatBuffer, "Total damage dealt: %d in %d hits\nTotal damage received from players: %d in %d hits\n%s\n",
 		gTotals.iDealtDmgs, gTotals.iDealtHits,
 		gTotals.iTakenDmgs, gTotals.iTakenHits,
 		BORDER);
+	V_strcat_safe(gPrintBuffer, gConcatBuffer);
 }
 
 // Console + activation of damage info
@@ -133,6 +138,8 @@ static void __MsgFunc_KillerDamageInfo(bf_read &msg)
 	{
 		return;
 	}
+
+	V_memset(gPrintBuffer, 0, sizeof(gPrintBuffer));
 
 	// Print damage stats into the console
 	// Print to console
@@ -203,7 +210,8 @@ static void __MsgFunc_KillerDamageInfo(bf_read &msg)
 		}
 	}
 
-	ConMsg("%sDamage infos (Round %d):\n%s\n", BORDER, NEORules()->roundNumber(), setKillByLine ? killByLine : "");
+	V_sprintf_safe(gConcatBuffer, "%sDamage infos (Round %d):\n%s\n", BORDER, NEORules()->roundNumber(), setKillByLine ? killByLine : "");
+	V_strcat_safe(gPrintBuffer, gConcatBuffer);
 
 	NeoDamageReportClear();
 	gTotals = {};
@@ -212,12 +220,15 @@ static void __MsgFunc_KillerDamageInfo(bf_read &msg)
 	{
 		PrintTotalReport();
 	}
+	ConMsg("%s", gPrintBuffer);
 }
 
 static void __MsgFunc_KillerDamageInfoExtra(bf_read &msg)
 {
+	V_memset(gPrintBuffer, 0, sizeof(gPrintBuffer));
 	ReadDamageReport(msg);
 	PrintTotalReport();
+	ConMsg("%s", gPrintBuffer);
 }
 
 USER_MESSAGE_REGISTER(KillerDamageInfo);


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Probably the workaround of ConMsg printing at random, instead of directly printing lines with ConMsg, the have a buffer string array to fill up then just print it all at once.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Arch/GCC 16

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

- fixes #
- related #
-->

