### PR TITLE
Don't reset aimpunch after a shot if viewkick is disabled.

### DIFF
--- a/src/game/shared/neo/weapons/weapon_aa13.cpp
+++ b/src/game/shared/neo/weapons/weapon_aa13.cpp
@@ -120,7 +120,6 @@ void CWeaponAA13::PrimaryAttack(void)
 		pPlayer->SetSuitUpdate("!HEV_AMO0", FALSE, 0);
 	}
 
-	pPlayer->ViewPunchReset();
 	AddViewKick();
 }
 

--- a/src/game/shared/neo/weapons/weapon_balc.cpp
+++ b/src/game/shared/neo/weapons/weapon_balc.cpp
@@ -196,7 +196,6 @@ void CWeaponBALC::ShootGrenade(CNEO_Player *pPlayer)
 	// View kick
 	if (!pPlayer->IsBot())
 	{
-		pPlayer->ViewPunchReset();
 		AddViewKick();
 	}
 }

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -919,6 +919,8 @@ void CNEOBaseCombatWeapon::DryFire()
 	m_flNextPrimaryAttack = gpGlobals->curtime + GetFastestDryRefireTime(); // SequenceDuration();
 }
 
+extern ConVar sv_suppress_viewpunch;
+
 void CNEOBaseCombatWeapon::PrimaryAttack(void)
 {
 	if (ShootingIsPrevented())
@@ -1069,8 +1071,12 @@ void CNEOBaseCombatWeapon::PrimaryAttack(void)
 		m_flAccuracyPenalty + GetAccuracyPenalty() * sv_neo_accuracy_penalty_scale.GetFloat()
 	);
 
+	// TODO: Resetting viewpunch here doesn't just affect viewkick, but also aimpunch.
+	// This if-check is a temporary workaround until we can separate the two.
+	if (!sv_suppress_viewpunch.GetBool()) {
+		pOwner->ViewPunchReset();
+	}
 	//Add our view kick in
-	pOwner->ViewPunchReset();
 	AddViewKick();
 }
 

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -865,6 +865,8 @@ const Vector &CNEOBaseCombatWeapon::GetBulletSpread(void)
 	return cone;
 }
 
+extern ConVar sv_suppress_viewpunch;
+
 void CNEOBaseCombatWeapon::AddViewKick()
 {
 	auto owner = ToNEOPlayer(GetOwner());
@@ -872,6 +874,13 @@ void CNEOBaseCombatWeapon::AddViewKick()
 	if (!owner)
 	{
 		return;
+	}
+
+	// Reset any existing viewkick so it doesn't accumulate
+	// TODO: Resetting viewpunch here doesn't just affect viewkick, but also aimpunch.
+	// This if-check is a temporary workaround until we can separate the two.
+	if (!sv_suppress_viewpunch.GetBool()) {
+		owner->ViewPunchReset();
 	}
 
 	auto kickInfo = m_weaponHandling.kickInfo;
@@ -918,8 +927,6 @@ void CNEOBaseCombatWeapon::DryFire()
 	SendWeaponAnim(ACT_VM_DRYFIRE);
 	m_flNextPrimaryAttack = gpGlobals->curtime + GetFastestDryRefireTime(); // SequenceDuration();
 }
-
-extern ConVar sv_suppress_viewpunch;
 
 void CNEOBaseCombatWeapon::PrimaryAttack(void)
 {
@@ -1071,11 +1078,6 @@ void CNEOBaseCombatWeapon::PrimaryAttack(void)
 		m_flAccuracyPenalty + GetAccuracyPenalty() * sv_neo_accuracy_penalty_scale.GetFloat()
 	);
 
-	// TODO: Resetting viewpunch here doesn't just affect viewkick, but also aimpunch.
-	// This if-check is a temporary workaround until we can separate the two.
-	if (!sv_suppress_viewpunch.GetBool()) {
-		pOwner->ViewPunchReset();
-	}
 	//Add our view kick in
 	AddViewKick();
 }

--- a/src/game/shared/neo/weapons/weapon_supa7.cpp
+++ b/src/game/shared/neo/weapons/weapon_supa7.cpp
@@ -374,7 +374,6 @@ void CWeaponSupa7::PrimaryAttack(void)
 		pPlayer->SetSuitUpdate("!HEV_AMO0", FALSE, 0);
 	}
 
-	pPlayer->ViewPunchReset();
 	AddViewKick();
 }
 


### PR DESCRIPTION
## Description
This adds a check to avoid calling ViewPunchReset after a shot if viewkick is disabled. Ideally we'd separate viewkick and aimpunch so they can be controlled individually (and make viewkick visual only?). But this workaround will work for comp where viewkick usually is disabled.

## Toolchain
- Cachy OS - gcc version 16.1.1 20260728

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- related #2068

