### PR TITLE
Fixup usage of char str on swprintf

### DIFF
--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -803,14 +803,16 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 							}
 							if (bShowReadyUp)
 							{
-								V_swprintf_safe(wszText, L"%ls: %d (%d player%s - %d ready)",
-										wszTeamtag, pTeam->GetRoundsWon(), iaTeamTally[iCurTeam], iaTeamTally[iCurTeam] == 1 ? "" : "s",
+								V_swprintf_safe(wszText, L"%ls: %d (%d player%ls - %d ready)",
+										wszTeamtag, pTeam->GetRoundsWon(), iaTeamTally[iCurTeam],
+										iaTeamTally[iCurTeam] == 1 ? L"" : L"s",
 										iaTeamReadyTally[iCurTeam]);
 							}
 							else
 							{
-								V_swprintf_safe(wszText, L"%ls: %d (%d player%s)",
-										wszTeamtag, pTeam->GetRoundsWon(), iaTeamTally[iCurTeam], iaTeamTally[iCurTeam] == 1 ? "" : "s");
+								V_swprintf_safe(wszText, L"%ls: %d (%d player%ls)",
+										wszTeamtag, pTeam->GetRoundsWon(), iaTeamTally[iCurTeam],
+										iaTeamTally[iCurTeam] == 1 ? L"" : L"s");
 							}
 						}
 					}
@@ -820,8 +822,8 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 						if (iCurTeam == TEAM_JINRAI)
 						{
 							const int total = iaTeamTally[TEAM_JINRAI] + iaTeamTally[TEAM_NSF];
-							V_swprintf_safe(wszText, L"Player%s: %d",
-									total == 1 ? "" : "s", total);
+							V_swprintf_safe(wszText, L"Player%ls: %d",
+									total == 1 ? L"" : L"s", total);
 						}
 						else
 						{
@@ -831,8 +833,9 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 				}
 				else
 				{
-					V_swprintf_safe(wszText, L"%ls (%d player%s)",
-							SZWSZ_NEO_TEAM_STRS[iCurTeam].wszStr, iaTeamTally[iCurTeam], iaTeamTally[iCurTeam] == 1 ? "" : "s");
+					V_swprintf_safe(wszText, L"%ls (%d player%ls)",
+							SZWSZ_NEO_TEAM_STRS[iCurTeam].wszStr, iaTeamTally[iCurTeam],
+							iaTeamTally[iCurTeam] == 1 ? L"" : L"s");
 				}
 				NeoUI::Label(wszText, true);
 


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Windows screws up when using string "%s" in wide-char swprintf

<!--
## Toolchain

If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
- Linux GCC Distro Native [Specify distro + GCC version]
- Linux GCC 10 Sniper 3.0
-->

<!--
## Linked Issues

Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

- fixes #
- related #
-->

