### PR TITLE
Add new damage modifier for explosives

### DIFF
--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -48,7 +48,9 @@ ConVar sv_neo_warmup_round_time("sv_neo_warmup_round_time", "45", FCVAR_REPLICAT
 ConVar sv_neo_preround_freeze_time("sv_neo_preround_freeze_time", "15", FCVAR_REPLICATED, "The pre-round freeze time, in seconds.", true, 0.0, false, 0);
 ConVar sv_neo_latespawn_max_time("sv_neo_latespawn_max_time", "15", FCVAR_REPLICATED, "How many seconds late are players still allowed to spawn.", true, 0.0, false, 0);
 
-ConVar sv_neo_wep_dmg_modifier("sv_neo_wep_dmg_modifier", "1.485", FCVAR_REPLICATED, "Temp global weapon damage modifier.", true, 0.0, true, 100.0);
+ConVar sv_neo_wep_dmg_modifier("sv_neo_wep_dmg_modifier", "1.485", FCVAR_REPLICATED, "Weapon damage modifier.", true, 0.0, true, 100.0);
+ConVar sv_neo_exp_dmg_modifier("sv_neo_exp_dmg_modifier", "1.485", FCVAR_REPLICATED, "Explosive damage modifier", true, 0.0, true, 100.0);
+
 ConVar sv_neo_player_restore("sv_neo_player_restore", "1", FCVAR_REPLICATED, "If enabled, the server will save players XP and deaths per match session and restore them if they reconnect.", true, 0.0f, true, 1.0f);
 
 ConVar sv_neo_spraydisable("sv_neo_spraydisable", "0", FCVAR_REPLICATED, "If enabled, disables the players ability to spray.", true, 0.0f, true, 1.0f);

--- a/src/game/shared/neo/weapons/weapon_detpack.cpp
+++ b/src/game/shared/neo/weapons/weapon_detpack.cpp
@@ -272,6 +272,7 @@ bool CWeaponDetpack::CanDrop()
 	return m_bThisDetpackHasBeenThrown && owner && !GetOwner()->IsAlive();
 }
 
+extern ConVar sv_neo_exp_dmg_modifier;
 void CWeaponDetpack::TossDetpack(CBasePlayer* pPlayer)
 {
 	Assert(HasPrimaryAmmo());
@@ -297,7 +298,7 @@ void CWeaponDetpack::TossDetpack(CBasePlayer* pPlayer)
 
 	if (m_pDetpack)
 	{
-		m_pDetpack->SetDamage(NEO_DETPACK_DAMAGE);
+		m_pDetpack->SetDamage(NEO_DETPACK_DAMAGE * sv_neo_exp_dmg_modifier.GetFloat());
 		m_pDetpack->SetDamageRadius(NEO_DETPACK_DAMAGE_RADIUS);
 	}
 	else

--- a/src/game/shared/neo/weapons/weapon_grenade.cpp
+++ b/src/game/shared/neo/weapons/weapon_grenade.cpp
@@ -218,6 +218,7 @@ void CWeaponGrenade::ItemPostFrame(void)
 	BaseClass::ItemPostFrame();
 }
 
+extern ConVar sv_neo_exp_dmg_modifier;
 void CWeaponGrenade::ThrowGrenade(CNEO_Player *pPlayer, bool isAlive, CBaseEntity *pAttacker)
 {
 	if (!sv_neo_infinite_frag_grenades.GetBool())
@@ -255,7 +256,7 @@ void CWeaponGrenade::ThrowGrenade(CNEO_Player *pPlayer, bool isAlive, CBaseEntit
 
 	if (pGrenade)
 	{
-		pGrenade->SetDamage(sv_neo_grenade_blast_damage.GetFloat());
+		pGrenade->SetDamage(sv_neo_grenade_blast_damage.GetFloat() * sv_neo_exp_dmg_modifier.GetFloat());
 		pGrenade->SetDamageRadius(sv_neo_grenade_blast_radius.GetFloat());
 		pGrenade->SetDetonateTimerLength(sv_neo_grenade_fuse_timer.GetFloat());
 	}


### PR DESCRIPTION
## Description
Adds a new damage modifier for explosives `sv_neo_exp_dmg_modifier` with the same default value as the weapon modifier (1.485, which is parity).

I made it a separate modifier because I can see scenarios where we want to reduce bullet damage without affecting the grenades. The modifier is applied pretty high up the chain, because `CGameRules::RadiusDamage` takes the damage info as a const, and we want the correct damage in the `WeaponHit` event.

Note that explosives can still do less damage than they would in OGNT if there's a prop between the player and the explosion. This is intentional (by Valve) and handled in `CGameRules::RadiusDamage`. I deemed it outside the scope of this issue.

## Toolchain
- Cachy OS - gcc version 16.2.1 20260810

## Linked Issues
- fixes #2076 

