### PR TITLE
Fallback killer info + popup avatar, load on steam ID instead of paint

### DIFF
--- a/src/game/client/neo/ui/neo_hud_killer_info.cpp
+++ b/src/game/client/neo/ui/neo_hud_killer_info.cpp
@@ -37,6 +37,10 @@ CNEOHud_KillerInfo::CNEOHud_KillerInfo(const char *pszName, vgui::Panel *parent)
 	}
 	SetVisible(false);
 	CommonSetupHUD();
+
+	m_avatar32.SetAvatarSize(32, 32);
+	m_avatar64.SetAvatarSize(64, 64);
+	m_avatar184.SetAvatarSize(184, 184);
 }
 
 void CNEOHud_KillerInfo::ApplySchemeSettings(vgui::IScheme *pScheme)
@@ -75,11 +79,15 @@ void CNEOHud_KillerInfo::UpdateStateForNeoHudElementDraw()
 	const CSteamID steamID = GetSteamIDForPlayerIndex(g_neoKillerInfos.iEntIndex);
 	if (steamID.IsValid())
 	{
-		m_avatar.SetAvatarSteamID(steamID, k_EAvatarSize184x184);
+		m_avatar32.SetAvatarSteamID(steamID, k_EAvatarSize32x32);
+		m_avatar64.SetAvatarSteamID(steamID, k_EAvatarSize64x64);
+		m_avatar184.SetAvatarSteamID(steamID, k_EAvatarSize184x184);
 	}
 	else
 	{
-		m_avatar.ClearAvatarSteamID();
+		m_avatar32.ClearAvatarSteamID();
+		m_avatar64.ClearAvatarSteamID();
+		m_avatar184.ClearAvatarSteamID();
 	}
 }
 
@@ -109,8 +117,22 @@ void CNEOHud_KillerInfo::DrawNeoHudElement()
 	const bool bSuicideKill = (iKillerEntIndex == pLocalPlayer->entindex()) ||
 			(iKillerEntIndex == NEO_ENVIRON_KILLED);
 
-	CAvatarImage *pAvatarImg = (CNEOScoreBoard::ShowAvatars() && m_avatar.IsValid())
-			? &m_avatar : nullptr;
+	CAvatarImage *pAvatarImg = nullptr;
+	if (CNEOScoreBoard::ShowAvatars())
+	{
+		if (m_avatar184.IsValid())
+		{
+			pAvatarImg = &m_avatar184;
+		}
+		else if (m_avatar64.IsValid())
+		{
+			pAvatarImg = &m_avatar64;
+		}
+		else if (m_avatar32.IsValid())
+		{
+			pAvatarImg = &m_avatar32;
+		}
+	}
 
 	// NEO NOTE (nullsystem): Similar sizing to how the scoreboard popup card is
 	const int iMargin = wide / 384;

--- a/src/game/client/neo/ui/neo_hud_killer_info.h
+++ b/src/game/client/neo/ui/neo_hud_killer_info.h
@@ -28,6 +28,8 @@ private:
 
 	vgui::HFont m_hFontNormal;
 	vgui::HFont m_hFontTitle;
-	CAvatarImage m_avatar;
+	CAvatarImage m_avatar32;
+	CAvatarImage m_avatar64;
+	CAvatarImage m_avatar184;
 	bool m_bPlayerShownHud = false;
 };

--- a/src/game/client/neo/ui/neo_scoreboard.cpp
+++ b/src/game/client/neo/ui/neo_scoreboard.cpp
@@ -502,6 +502,10 @@ void CNEOScoreBoard::Update()
 				auto *pImage64 = new CAvatarImage;
 				auto *pImage184 = new CAvatarImage;
 
+				pImage32->SetAvatarSize(32, 32);
+				pImage64->SetAvatarSize(64, 64);
+				pImage184->SetAvatarSize(184, 184);
+
 				pImage32->SetAvatarSteamID(pPlayerInfo->steamID, k_EAvatarSize32x32);
 				pImage64->SetAvatarSteamID(pPlayerInfo->steamID, k_EAvatarSize64x64);
 				pImage184->SetAvatarSteamID(pPlayerInfo->steamID, k_EAvatarSize184x184);
@@ -1109,9 +1113,20 @@ void CNEOScoreBoard::OnMainLoop(const NeoUI::Mode eMode)
 		if (NeoUI::BeginPopup(NEOSCOREBOARDPOPUP_CARD))
 		{
 			CAvatarImage *pAvatarImg = nullptr;
-			if (ShowAvatars() && m_playerPopup.avatar.i184Idx >= 0)
+			if (ShowAvatars())
 			{
-				pAvatarImg = (CAvatarImage *)(m_pImageList->GetImage(m_playerPopup.avatar.i184Idx));
+				if (m_playerPopup.avatar.i184Idx >= 0)
+				{
+					pAvatarImg = (CAvatarImage *)(m_pImageList->GetImage(m_playerPopup.avatar.i184Idx));
+				}
+				if ((!pAvatarImg || !pAvatarImg->IsValid()) && m_playerPopup.avatar.i64Idx >= 0)
+				{
+					pAvatarImg = (CAvatarImage *)(m_pImageList->GetImage(m_playerPopup.avatar.i64Idx));
+				}
+				if ((!pAvatarImg || !pAvatarImg->IsValid()) && m_playerPopup.avatar.i32Idx >= 0)
+				{
+					pAvatarImg = (CAvatarImage *)(m_pImageList->GetImage(m_playerPopup.avatar.i32Idx));
+				}
 			}
 			if (pAvatarImg)
 			{

--- a/src/game/client/vgui_avatarimage.cpp
+++ b/src/game/client/vgui_avatarimage.cpp
@@ -92,6 +92,13 @@ void CAvatarImage::ClearAvatarSteamID( void )
 //-----------------------------------------------------------------------------
 bool CAvatarImage::SetAvatarSteamID( CSteamID steamIDUser, EAvatarSize avatarSize /*= k_EAvatarSize32x32 */ )
 {
+#ifdef NEO
+	// NEO NOTE (nullsystem): avatarSize is unused, so just check on steamIDUser
+	if (m_SteamID == steamIDUser)
+	{
+		return m_bValid;
+	}
+#endif // NEO
 	ClearAvatarSteamID();
 
 	m_SteamID = steamIDUser;
@@ -179,12 +186,16 @@ void CAvatarImage::LoadAvatarImage()
 				uint32 wide = 0, tall = 0;
 				if ( steamapicontext->SteamUtils()->GetImageSize( iAvatar, &wide, &tall ) && wide > 0 && tall > 0 )
 				{
+#ifdef NEO
+					// NEO NOTE (nullsystem): Moved off GetImageRGBA to inside InitFromRGBA
+					InitFromRGBA( iAvatar, nullptr, wide, tall );
+#else
 					int destBufferSize = wide * tall * 4;
 					byte *rgbDest = (byte*)stackalloc( destBufferSize );
 					if ( steamapicontext->SteamUtils()->GetImageRGBA( iAvatar, rgbDest, destBufferSize ) )
 						InitFromRGBA( iAvatar, rgbDest, wide, tall );
-
 					stackfree( rgbDest );
+#endif // NEO
 				}
 			}
 		}
@@ -223,10 +234,24 @@ void CAvatarImage::InitFromRGBA( int iAvatar, const byte *rgba, int width, int h
 	int iTexIndex = s_AvatarImageCache.Find( AvatarImagePair_t( m_SteamID, iAvatar ) );
 	if ( iTexIndex == s_AvatarImageCache.InvalidIndex() )
 	{
+#ifdef NEO
+		(void)(rgba); // unused
+		int destBufferSize = width * height * 4;
+		byte *rgbDest = (byte*)stackalloc( destBufferSize );
+		if ( steamapicontext->SteamUtils()->GetImageRGBA( iAvatar, rgbDest, destBufferSize ) )
+		{
+			m_iTextureID = vgui::surface()->CreateNewTextureID( true );
+			g_pMatSystemSurface->DrawSetTextureRGBAEx2( m_iTextureID, rgbDest, width, height, IMAGE_FORMAT_RGBA8888, true );
+			iTexIndex = s_AvatarImageCache.Insert( AvatarImagePair_t( m_SteamID, iAvatar ) );
+			s_AvatarImageCache[ iTexIndex ] = m_iTextureID;
+		}
+		stackfree( rgbDest );
+#else
 		m_iTextureID = vgui::surface()->CreateNewTextureID( true );
 		g_pMatSystemSurface->DrawSetTextureRGBAEx2( m_iTextureID, rgba, width, height, IMAGE_FORMAT_RGBA8888, true );
 		iTexIndex = s_AvatarImageCache.Insert( AvatarImagePair_t( m_SteamID, iAvatar ) );
 		s_AvatarImageCache[ iTexIndex ] = m_iTextureID;
+#endif // NEO
 	}
 	else
 		m_iTextureID = s_AvatarImageCache[ iTexIndex ];


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
CAvatarImage wasn't used "properly" so avatar can seem to loadup for way too long.
32px/64px what was thought was was loaded up as 184px.

Add 64px and 32px as fallback avatars for the killer info + scoreboard's right-click popup avatars. Altered CAvatarImage so SteamID just skip over if already using same ID and also moved off GetImageRGBA from steam from outside to inside when the cache haven't found the image.

Also SetAvatarSteamID's avatarSize parameter is actually unused, so it never did anything the whole time. So instead used SetAvatarSize to get the actual desired size.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on

- Windows MSVC VS2022
-->
- Linux GCC Distro Native Arch/GCC 16

## Linked Issues
<!--
Applying issues here will auto-link the PR to its related issues if starting with "resolves".
If there's a related PR but don't want to resolve/close the issue, mark them with "related".

See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- fixes #
- related #

