### PR TITLE
`sv_neo_wep_xp_override` cheat, includes fix for detpack loadout grant 

### DIFF
--- a/src/game/client/neo/game_controls/neo_loadoutmenu.cpp
+++ b/src/game/client/neo/game_controls/neo_loadoutmenu.cpp
@@ -190,7 +190,6 @@ void CNeoLoadoutMenu::OnMousePressed(vgui::MouseCode code)
 
 extern ConCommand loadoutmenu;
 
-extern ConVar sv_neo_ignore_wep_xp_limit;
 extern ConVar sv_neo_dev_loadout;
 
 void CNeoLoadoutMenu::OnClose()

--- a/src/game/client/neo/game_controls/neo_loadoutmenu.cpp
+++ b/src/game/client/neo/game_controls/neo_loadoutmenu.cpp
@@ -227,7 +227,7 @@ void CNeoLoadoutMenu::OnCommand(const char* command)
 		auto localPlayer = C_NEO_Player::GetLocalNEOPlayer();
 		if (!localPlayer) { return; }
 
-		int currentXP = localPlayer->m_iXP.Get();
+		int currentXP = CNEOWeaponLoadout::GetEffectiveXP(localPlayer->m_iXP.Get());
 		int currentClass = localPlayer->m_iNextSpawnClassChoice.Get() != NEO_CLASS_RANDOM ? localPlayer->m_iNextSpawnClassChoice.Get() : localPlayer->m_iNeoClass.Get();
 		int numWeapons = CNEOWeaponLoadout::GetNumberOfLoadoutWeapons(currentXP,
 				sv_neo_dev_loadout.GetBool() ? NEO_LOADOUT_DEV : currentClass);
@@ -295,7 +295,7 @@ void CNeoLoadoutMenu::ApplySchemeSettings(vgui::IScheme *pScheme)
 	auto localPlayer = C_NEO_Player::GetLocalNEOPlayer();
 	if (!localPlayer) { return; }
 
-	const int currentXP = localPlayer->m_iXP.Get();
+	const int currentXP = CNEOWeaponLoadout::GetEffectiveXP(localPlayer->m_iXP.Get());
 	const int currentClass = localPlayer->m_iNextSpawnClassChoice.Get() != NEO_CLASS_RANDOM ? localPlayer->m_iNextSpawnClassChoice.Get() : localPlayer->m_iNeoClass.Get();
 
 	int iLoadout = sv_neo_dev_loadout.GetBool() ? NEO_LOADOUT_DEV : currentClass;

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -643,7 +643,8 @@ void CNEOBot::Spawn()
 
 int CNEOBot::ChooseRandomWeaponIndex() const
 {
-    const ENeoRank eRank = static_cast<ENeoRank>(GetRank(m_iXP) - 1);
+    const int iEffectiveXP = CNEOWeaponLoadout::GetEffectiveXP(m_iXP);
+    const ENeoRank eRank = static_cast<ENeoRank>(GetRank(iEffectiveXP) - 1);
     if (eRank == NEO_RANK_RANKLESS_DOG || (false == IN_BETWEEN_EQ(NEO_CLASS_RECON, m_iNeoClass, NEO_CLASS_VIP)))
     {
         return 0;
@@ -665,7 +666,7 @@ int CNEOBot::ChooseRandomWeaponIndex() const
 		// Generally shouldn't happen, but if so, just pick from any under the XP limit
         for (int i = 0; i < MAX_WEAPON_LOADOUTS; ++i)
         {
-            if (CNEOWeaponLoadout::s_LoadoutWeapons[m_iNeoClass][i].m_iWeaponPrice > m_iXP)
+            if (CNEOWeaponLoadout::s_LoadoutWeapons[m_iNeoClass][i].m_iWeaponPrice > iEffectiveXP)
             {
                 break;
             }

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -144,6 +144,7 @@ extern CBaseEntity *g_pLastSpawn;
 extern ConVar sv_neo_bot_cmdr_enable;
 extern ConVar sv_neo_ignore_wep_xp_limit;
 extern ConVar sv_neo_clantag_allow;
+extern ConVar sv_neo_detpack_xp_limit;
 extern ConVar sv_neo_dev_test_clantag;
 extern ConVar sv_stickysprint;
 extern ConVar sv_neo_dev_loadout;
@@ -3475,6 +3476,15 @@ CBaseEntity* CNEO_Player::GiveNamedItem(const char* szName, int iSubType)
 
 void GiveDet(CNEO_Player* pPlayer)
 {
+	// Cost of -1 XP means no XP cost. Checked before creating the weapon
+	// entity so ineligible players don't pay a create/destroy cycle.
+	const int detXpCost = sv_neo_detpack_xp_limit.GetInt();
+	const bool canHaveDet = (detXpCost < 0 || CNEOWeaponLoadout::GetEffectiveXP(pPlayer->m_iXP) >= detXpCost);
+	if (!canHaveDet)
+	{
+		return;
+	}
+
 	constexpr const char* detpackClassname = "weapon_remotedet";
 	if (!pPlayer->Weapon_OwnsThisType(detpackClassname))
 	{
@@ -3492,23 +3502,12 @@ void GiveDet(CNEO_Player* pPlayer)
 			auto pWeapon = assert_cast<CNEOBaseCombatWeapon*>((CBaseEntity*)pent);
 			if (pWeapon)
 			{
-				const int detXpCost = pWeapon->GetNeoWepXPCost(pPlayer->GetClass());
-				// Cost of -1 XP means no XP cost.
-				const bool canHaveDet = (detXpCost < 0 || pPlayer->m_iXP >= detXpCost);
-
 				pWeapon->SetSubType(0);
-				if (canHaveDet)
-				{
-					DispatchSpawn(pent);
+				DispatchSpawn(pent);
 
-					if (pent != NULL && !(pent->IsMarkedForDeletion()))
-					{
-						pent->Touch(pPlayer);
-					}
-				}
-				else
+				if (pent != NULL && !(pent->IsMarkedForDeletion()))
 				{
-					UTIL_Remove(pWeapon);
+					pent->Touch(pPlayer);
 				}
 			}
 		}
@@ -3522,7 +3521,7 @@ void CNEO_Player::GiveDefaultItems(void)
 	case NEO_CLASS_RECON:
 		GiveNamedItem("weapon_knife");
 		GiveNamedItem("weapon_milso");
-		if (this->m_iXP >= 4) { GiveDet(this); }
+		GiveDet(this);
 		Weapon_Switch(Weapon_OwnsThisType("weapon_milso"));
 		break;
 	case NEO_CLASS_ASSAULT:

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -390,7 +390,7 @@ bool CNEO_Player::RequestSetLoadout(int loadoutNumber)
 	}
 
 	if (!sv_neo_ignore_wep_xp_limit.GetBool() &&
-			loadoutNumber+1 > CNEOWeaponLoadout::GetNumberOfLoadoutWeapons(m_iXP,
+			loadoutNumber+1 > CNEOWeaponLoadout::GetNumberOfLoadoutWeapons(CNEOWeaponLoadout::GetEffectiveXP(m_iXP),
 				sv_neo_dev_loadout.GetBool() ? NEO_LOADOUT_DEV : classChosen))
 	{
 		DevMsg("Insufficient XP for %s\n", pszWepName);
@@ -3597,7 +3597,7 @@ void CNEO_Player::GiveLoadoutWeapon(void)
 	if (pNeoWeapon)
 	{
 		if (sv_neo_ignore_wep_xp_limit.GetBool() ||
-				m_iLoadoutWepChoice+1 <= CNEOWeaponLoadout::GetNumberOfLoadoutWeapons(m_iXP,
+				m_iLoadoutWepChoice+1 <= CNEOWeaponLoadout::GetNumberOfLoadoutWeapons(CNEOWeaponLoadout::GetEffectiveXP(m_iXP),
 					sv_neo_dev_loadout.GetBool() ? NEO_LOADOUT_DEV : m_iNeoClass.Get()))
 		{
 			pNeoWeapon->SetSubType(wepSubType);

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -142,7 +142,6 @@ CNEOGameRulesProxy* neoGameRules;
 extern CBaseEntity *g_pLastSpawn;
 
 extern ConVar sv_neo_bot_cmdr_enable;
-extern ConVar sv_neo_ignore_wep_xp_limit;
 extern ConVar sv_neo_clantag_allow;
 extern ConVar sv_neo_detpack_xp_limit;
 extern ConVar sv_neo_dev_test_clantag;
@@ -390,9 +389,8 @@ bool CNEO_Player::RequestSetLoadout(int loadoutNumber)
 		result = false;
 	}
 
-	if (!sv_neo_ignore_wep_xp_limit.GetBool() &&
-			loadoutNumber+1 > CNEOWeaponLoadout::GetNumberOfLoadoutWeapons(CNEOWeaponLoadout::GetEffectiveXP(m_iXP),
-				sv_neo_dev_loadout.GetBool() ? NEO_LOADOUT_DEV : classChosen))
+	if (loadoutNumber+1 > CNEOWeaponLoadout::GetNumberOfLoadoutWeapons(CNEOWeaponLoadout::GetEffectiveXP(m_iXP),
+			sv_neo_dev_loadout.GetBool() ? NEO_LOADOUT_DEV : classChosen))
 	{
 		DevMsg("Insufficient XP for %s\n", pszWepName);
 		result = RequestSetLoadout(0);
@@ -3595,9 +3593,8 @@ void CNEO_Player::GiveLoadoutWeapon(void)
 	CNEOBaseCombatWeapon *pNeoWeapon = assert_cast<CNEOBaseCombatWeapon*>((CBaseEntity*)pEnt);
 	if (pNeoWeapon)
 	{
-		if (sv_neo_ignore_wep_xp_limit.GetBool() ||
-				m_iLoadoutWepChoice+1 <= CNEOWeaponLoadout::GetNumberOfLoadoutWeapons(CNEOWeaponLoadout::GetEffectiveXP(m_iXP),
-					sv_neo_dev_loadout.GetBool() ? NEO_LOADOUT_DEV : m_iNeoClass.Get()))
+		if (m_iLoadoutWepChoice+1 <= CNEOWeaponLoadout::GetNumberOfLoadoutWeapons(CNEOWeaponLoadout::GetEffectiveXP(m_iXP),
+				sv_neo_dev_loadout.GetBool() ? NEO_LOADOUT_DEV : m_iNeoClass.Get()))
 		{
 			pNeoWeapon->SetSubType(wepSubType);
 

--- a/src/game/shared/neo/neo_weapon_loadout.cpp
+++ b/src/game/shared/neo/neo_weapon_loadout.cpp
@@ -5,6 +5,8 @@
 #include "convar.h"
 #include "neo_misc.h"
 
+extern ConVar sv_neo_ignore_wep_xp_limit;
+
 namespace CNEOWeaponLoadout {
 
 #define WEAPON_DEF(M_BITWNAME, M_NAME, M_DISPLAY_NAME, ...) \
@@ -111,6 +113,11 @@ ConVar sv_neo_wep_xp_override("sv_neo_wep_xp_override", "-1", FCVAR_CHEAT | FCVA
 
 int GetEffectiveXP(const int actualXP)
 {
+	if (sv_neo_ignore_wep_xp_limit.GetBool())
+	{
+		// Treat as max rank so every XP-gated weapon is eligible
+		return XP_LIEUTENANT;
+	}
 	const int iOverride = sv_neo_wep_xp_override.GetInt();
 	return (iOverride >= 0) ? iOverride : actualXP;
 }

--- a/src/game/shared/neo/neo_weapon_loadout.cpp
+++ b/src/game/shared/neo/neo_weapon_loadout.cpp
@@ -2,6 +2,7 @@
 
 #include "tier0/dbg.h"
 #include "tier0/commonmacros.h"
+#include "convar.h"
 #include "neo_misc.h"
 
 namespace CNEOWeaponLoadout {
@@ -103,6 +104,15 @@ int GetNumberOfLoadoutWeapons(const int rank, const int classType)
 		Assert(false);
 	}
 	return amount;
+}
+
+ConVar sv_neo_wep_xp_override("sv_neo_wep_xp_override", "-1", FCVAR_CHEAT | FCVAR_REPLICATED,
+	"Override the effective XP used for weapon eligibility checks, or -1 to disable.", true, -1.0f, false, 0.0f);
+
+int GetEffectiveXP(const int actualXP)
+{
+	const int iOverride = sv_neo_wep_xp_override.GetInt();
+	return (iOverride >= 0) ? iOverride : actualXP;
 }
 
 } // namespace CNEOWeaponLoadout

--- a/src/game/shared/neo/neo_weapon_loadout.h
+++ b/src/game/shared/neo/neo_weapon_loadout.h
@@ -44,5 +44,9 @@ namespace CNEOWeaponLoadout
 	extern const CLoadoutWeapon s_LoadoutWeapons[NEO_LOADOUT__COUNT][MAX_WEAPON_LOADOUTS];
 
 	int GetNumberOfLoadoutWeapons(const int rank, const int classType);
+
+	// The XP value to use for weapon eligibility checks. Returns actualXP unless
+	// sv_neo_wep_xp_override is set (>= 0), in which case the override wins.
+	int GetEffectiveXP(const int actualXP);
 } // namespace CNEOWeaponLoadout
 


### PR DESCRIPTION
## Description

The commits in order:

1. Adds a debugging cheat cvar `sv_neo_wep_xp_override` for testing XP-gated weapon behavior without grinding XP. 
2. Fixes the detpack loadout grant ignoring its existing convar. 
3. Consolidates `sv_neo_ignore_wep_xp_limit` into the same mechanism.

> [!NOTE] 
> Follow-up: [sunmachine/ntre-dev // Check loadout XP eligibility before creating weapon entities - #3](https://github.com/sunmachine/ntre-dev/pull/3)

**The new cheat `sv_neo_wep_xp_override`** is bidirectional (a value below your real XP locks weapons, useful for testing the locked path), never mutates `m_iXP`, and leaves scoreboard/rank display untouched. It is consolidated with `sv_neo_ignore_wep_xp_limit`.

**Detpack consistency fix:** the recon path hardcoded `m_iXP >= 4` before calling `GiveDet`, so `sv_neo_detpack_xp_limit` had no effect the detpack being granted. The convar is now the single source of truth, checked at the top of `GiveDet` before the weapon entity is created, preserving the old gate's property that ineligible spawns never pay an entity create/destroy cycle.

**`sv_neo_ignore_wep_xp_limit` consolidation:** This commit is separable if the wider scope is unwanted, but I'll argue it's consistency without breaking existing workflows.

### Testing
```
sv_cheats 1; sv_neo_wep_xp_override 20; bot_class 0
```

All loadout tiers unlock from round one and Recon bots spawn with detpacks. Values apply on next spawn (loadouts and bot weapon choices are decided at spawn time); reopen the loadout menu after changing the value to refresh button states. Verified in-game on the toolchain below.

## Toolchain
- Linux GCC 10 Sniper 3.0

## Linked Issues
- related #1795 in that I wrote this to make testing it easier. :joy: 
- follow-up [Check loadout XP eligibility before creating weapon entities - #3](https://github.com/sunmachine/ntre-dev/pull/3)




