### PR TITLE
Bots reload reliability when empty clip tweaks

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_behavior.cpp
@@ -675,9 +675,15 @@ QueryResultType CNEOBotMainAction::ShouldWalk(const CNEOBot *me, const QueryResu
 		}
 	}
 
-	// Walk if reloading or firing
+	// Walk if firing or aiming on target
 	CNEOBaseCombatWeapon *myWeapon = static_cast<CNEOBaseCombatWeapon*>(me->GetActiveWeapon());
-	if (myWeapon && (myWeapon->m_bInReload || me->m_bOnTarget || me->IsFiring()))
+	if (myWeapon && (me->m_bOnTarget || me->IsFiring()))
+	{
+		return ANSWER_YES;
+	}
+
+	// Walk until reload actually starts so sprint does not block the reload initiation
+	if (myWeapon && myWeapon->Clip1() <= 0 && !myWeapon->m_bInReload)
 	{
 		return ANSWER_YES;
 	}
@@ -693,7 +699,18 @@ QueryResultType CNEOBotMainAction::ShouldWalk(const CNEOBot *me, const QueryResu
 QueryResultType CNEOBotMainAction::ShouldAim(const CNEOBot *me, const bool bWepHasClip) const
 {
 	auto *pNeoWep = static_cast<CNEOBaseCombatWeapon *>(me->GetActiveWeapon());
-	if (!bWepHasClip || !pNeoWep)
+	
+	if (!pNeoWep)
+	{
+		return ANSWER_NO;
+	}
+
+	if (!bWepHasClip)
+	{
+		return ANSWER_NO;
+	}
+
+	if (pNeoWep->m_bInReload)
 	{
 		return ANSWER_NO;
 	}
@@ -749,6 +766,10 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 			{
 				if ( myWeapon->Clip1() < myWeapon->GetMaxClip1() )
 				{
+					if ( !myWeapon->m_bInReload )
+					{
+						me->ReloadIfLowClip(true);
+					}
 					return;
 				}
 
@@ -857,6 +878,27 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 		me->EquipBestWeaponForThreat(threat, false);
 	}
 
+	if ( myWeapon && me->IsCombatWeapon( myWeapon )
+		&& !( myWeapon->GetNeoWepBits() & NEO_WEP_BALC )
+		&& myWeapon->m_iClip1 <= 0 )
+	{
+		if (myWeapon->m_bInReload)
+		{
+			// passthrough: don't introduce decision jitter
+		}
+		else if (IsImmediateThreat(me->GetEntity(), threat) && !m_isWaitingForFullReload)
+		{
+			// intention is to swap to secondary if available
+			me->EquipBestWeaponForThreat(threat, bNotPrimary);
+		}
+		else
+		{
+			me->ReloadIfLowClip(true);
+			m_isWaitingForFullReload = true;
+		}
+		return;
+	}
+
 	float threatRange = ( threat->GetEntity()->GetAbsOrigin() - me->GetAbsOrigin() ).Length();
 
 	// actual head aiming is handled elsewhere, just check if we're on target
@@ -886,24 +928,6 @@ void CNEOBotMainAction::FireWeaponAtEnemy( CNEOBot *me )
 			if (myWeapon->GetNeoWepBits() & NEO_WEP_BALC)
 			{
 				FireBalcAtEnemy( me, myWeapon, threat, threatRange );
-				return;
-			}
-			else if (myWeapon->m_iClip1 <= 0)
-			{
-				if (m_isWaitingForFullReload)
-				{
-					// passthrough: don't introduce decision jitter
-				}
-				else if (IsImmediateThreat(me->GetEntity(), threat) && !m_isWaitingForFullReload)
-				{
-					// intention is to swap to secondary if available
-					me->EquipBestWeaponForThreat(threat, bNotPrimary);
-				}
-				else
-				{
-					me->ReloadIfLowClip(true);
-					m_isWaitingForFullReload = true;
-				}
 				return;
 			}
 


### PR DESCRIPTION
## Description
Improve bot reload reliability related to bot sprint state as well as enable reloading when not actively shooting at an enemy

## Toolchain
- Windows MSVC VS2022


