### PR TITLE
Invalidate stale cover paths when retreat destination changes

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_from_grenade.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_from_grenade.cpp
@@ -221,7 +221,15 @@ ActionResult< CNEOBot >	CNEOBotRetreatFromGrenade::Update( CNEOBot *me, float in
 	// track projectile and relation to escape destination every update
 	if ( !m_coverArea || ( grenadeArea && grenadeArea->IsPotentiallyVisible( m_coverArea ) ) )
 	{
+		CNavArea *pPrevCoverArea = m_coverArea;
 		m_coverArea = FindCoverArea( me );
+
+		// cover destination changed, stop following the path to the old spot
+		if ( m_coverArea != pPrevCoverArea )
+		{
+			m_path.Invalidate();
+			m_repathTimer.Invalidate();
+		}
 	}
 
 	if (!m_coverArea)

--- a/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_retreat_to_cover.cpp
@@ -273,11 +273,18 @@ ActionResult< CNEOBot >	CNEOBotRetreatToCover::Update( CNEOBot *me, float interv
 		if ( threat )
 		{
 			// threats are still visible - find new cover
+			CNavArea *pPrevCoverArea = m_coverArea;
 			m_coverArea = FindCoverArea( me );
 
 			if ( m_coverArea == NULL )
 			{
 				return Done( "My cover is exposed, and there is no other cover available!" );
+			}
+
+			// cover destination changed, stop following the path to the old spot
+			if ( m_coverArea != pPrevCoverArea )
+			{
+				m_path.Invalidate();
 			}
 		}
 		else


### PR DESCRIPTION
## Retreat to cover...
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/dbf1652e-058b-4db5-81a7-431a69b9c1ec" />

## Shitty example 
#### Courtesy of Don Claudio

<img width="681" height="364" alt="Screenshot 2026-08-20 at 22 46 24" src="https://github.com/user-attachments/assets/771ea153-db39-4c44-8da4-9d58a2365171" />

## Description
Follow-up to #2065. 

When `FindCoverArea` picks a different cover area mid-retreat, the old path stayed valid and kept steering the bot toward the abandoned, exposed cover: 
- until the 1.0s repath timer elapsed in the grenade retreat, 
- and until the old path completed on its own in retreat-to-cover (where the timer was removed and `!m_path.IsValid()` is the only recompute trigger).

Invalidate the path (and repath timer, where one exists) whenever the chosen cover area changes, matching the existing `OnStuck`/`OnMoveToFailure` handling. No change when the re-pick returns the same area.

## Toolchain
- Linux GCC 10 Sniper 3.0

