### PR TITLE
Hint controls for buttons

### DIFF
--- a/game/bin/rebuild.fgd
+++ b/game/bin/rebuild.fgd
@@ -467,3 +467,239 @@
 [
 	radius(float) : "Radius" : 12 : ""
 ]
+
+@SolidClass base(Targetname, Parentname, Origin, RenderFields,DamageFilter, Button) = func_button : 
+	"A brush entity that's designed to be used for a player-useable button. When used by the player, it moves to a pressed position."
+[
+	movedir(angle) : "Move Direction (Pitch Yaw Roll)" : "0 0 0" : "Specifies the direction of motion to move when the button is used."
+	speed(integer) : "Speed" : 5 : "The speed that the button moves, in inches per second."
+	health(integer) : "Health (Obsolete)" : 0 : "Legacy method of specifying whether or not the button can be shot to activate it. Use the 'Damage Activates' spawnflag instead."
+	lip(integer) : "Lip" : 0 : "The amount, in inches, of the button to leave sticking out of the wall it recedes into when pressed. Negative values make the button recede even further into the wall."
+	master(string) : "Master (Obsolete)" : : "Legacy support: The name of a master entity. If the master hasn't been activated, this button cannot be pressed."
+	sounds(choices) : "Sounds" : 0 = 
+	[
+		0: "None (Silent)"
+		1: "Big zap & Warmup"
+		2: "Access Denied"
+		3: "Access Granted"
+		4: "Quick Combolock"
+		5: "Power Deadbolt 1"
+		6: "Power Deadbolt 2"
+		7: "Plunger"
+		8: "Small zap"
+		9: "Keycard Sound"
+		10: "Buzz"
+		11: "Buzz Off"
+		12: "latch locked"
+		13: "Latch Unlocked"
+		14: "Lightswitch"
+		15: "small bleek"
+		16: "small deny"
+		17: "small doop"
+		18: "small tech deny"
+		19: "click and combine screen fuzz"
+		20: "roomy beep"
+		21: "lever or wheel: turn + move sqeek"
+		22: "lever or wheel: latch + release gas"
+		23: "lever or wheel: ratchet + sqeek"
+		24: "lever or wheel: large ratchet"
+		25: "lever or wheel: clanky + gas release"
+		26: "lever or wheel: latch + large metal thud"
+		27: "lever or wheel: smaller ratchet"
+		28: "lever or wheel: smaller lever move"
+		31: "shock buzz"
+		32: "clickbeep"
+		33: "tech blip"
+		34: "clickbeepbeep open"
+		35: "small high blip"
+		36: "small tech fuzz blip"
+		37: "small click bleep (change to lightswitch)"
+		40: "combine door lock - locked"
+		41: "combine blip growl"
+		42: "combine squick growl"
+		43: "combine whine purr"
+		44: "combine click talk"
+		45: "combine click growl fizz"
+		46: "combine click fizz (deny)"
+		47: "combine click talker"
+	]	
+	wait(integer) : "Delay Before Reset (-1 stay)" : 3 : "Amount of time, in seconds, after the button has been pressed before it returns to the starting position. Once it has returned, it can be used again. If the value is set to -1, the button never returns."
+	spawnflags(flags) =
+	[
+		1: "Don't move" : 0
+		32: "Toggle" : 0
+		256: "Touch Activates": 0
+		512: "Damage Activates": 0
+		1024: "Use Activates" : 1
+		2048: "Starts locked" : 0
+		4096: "Sparks" : 0
+	]
+	locked_sound(choices) : "Locked Sound" : 0 : "Sound played when the player tries to use the button, and fails because it's locked." = 
+	[
+		0: "None"
+		2: "Access Denied"
+		8: "Small zap"
+		10: "Buzz"
+		11: "Buzz Off"
+		12: "Latch Locked"
+	]
+	unlocked_sound(choices) : "Unlocked Sound" : 0 : "Sound played when the button is unlocked." = 
+	[
+		0: "None"
+		1: "Big zap & Warmup"
+		3: "Access Granted"
+		4: "Quick Combolock"
+		5: "Power Deadbolt 1"
+		6: "Power Deadbolt 2"
+		7: "Plunger"
+		8: "Small zap"
+		9: "Keycard Sound"
+		10: "Buzz"
+		13: "Latch Unlocked"
+		14: "Lightswitch"
+	]
+	locked_sentence(choices) : "Locked Sentence" : 0 : "A sentence played when the player tries to use the button, and fails because it's locked." = 
+	[
+		0: "None"
+		1: "Gen. Access Denied"
+		2: "Security Lockout"
+		3: "Blast Door"
+		4: "Fire Door"
+		5: "Chemical Door"
+		6: "Radiation Door"
+		7: "Gen. Containment"
+		8: "Maintenance Door"
+		9: "Broken Shut Door"
+	]
+	unlocked_sentence(choices) : "Unlocked Sentence" : 0 : "A sentence played when the button is unlocked." = 
+	[
+		0: "None"
+		1: "Gen. Access Granted"
+		2: "Security Disengaged"
+		3: "Blast Door"
+		4: "Fire Door"
+		5: "Chemical Door"
+		6: "Radiation Door"
+		7: "Gen. Containment"
+		8: "Maintenance area"
+	]
+	_minlight(string) : "Minimum Light Level" : : "The minimum level of ambient light that hits this brush."
+	
+	usehint(choices) : "Use Hint" : 1 : "Show a visual indicator for this button?" =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+	usehinttext(string) : "Use Hint Text" : "Text to display with the hint"
+]
+
+@SolidClass base(Targetname, Parentname, Origin, Angles, Global, Button, EnableDisable) = func_rot_button : 
+	"A brush entity that's designed to be used for a rotating player-useable button. When used by the player, it rotates to a pressed position."
+[
+	master(string) : "Master (Obsolete)" : : "Legacy support: The name of a master entity. If the master hasn't been activated, this button cannot be used."
+	speed(integer) : "Speed" : 50 : "The speed that the button rotates, in degrees per second."
+	health(integer) : "Health (Obsolete)" : 0 : "Legacy method of specifying whether or not the button can be shot to activate it. Use the 'Damage Activates' spawnflag instead."
+	sounds(choices) : "Sounds" : 21 = 
+	[
+		0: "None (Silent)"
+		21: "Squeaky"
+		22: "Squeaky Pneumatic"
+		23: "Ratchet Groan"
+		24: "Clean Ratchet"
+		25: "Gas Clunk"
+	]
+	wait(integer) : "Delay Before Reset (-1 stay)" : 3 : "Amount of time, in seconds, after the button has been pressed before it returns to the starting position. Once it has returned, it can be used again. If the value is set to -1, the button never returns."
+	distance(integer) : "Distance (deg)" : 90 : "The amount, in degrees, that the button should rotate when it's pressed."
+	// TODO: move spawnflags into Button base class?
+	spawnflags(flags) =
+	[
+		1 : "Not solid" : 0
+		2 : "Reverse Dir" : 0
+		32: "Toggle" : 0
+		64: "X Axis" : 0
+		128: "Y Axis" : 0
+		256: "Touch Activates": 0
+		512: "Damage Activates": 0
+		1024: "Use Activates": 0
+		2048: "Starts locked" : 0
+	]
+	_minlight(string) : "Minimum Light Level" : : "The minimum level of ambient light that hits this brush."
+	
+	usehint(choices) : "Use Hint" : 1 : "Show a visual indicator for this button?" =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+	usehinttext(string) : "Use Hint Text" : "Text to display with the hint"
+]
+
+@SolidClass base(Targetname, Parentname, Origin, Angles, RenderFields) = momentary_rot_button : 
+	"A brush entity that's designed to be used for rotating wheels, where the player can rotate them to arbitrary positions before stopping."
+[
+	speed(integer) : "Speed (deg/sec)" : 50 : "The amount, in degrees, that the wheel turns per second."
+	master(string) : "Master (Obsolete)" : : "Legacy support: The name of a master entity. If the master hasn't been activated, this button cannot be used."
+	sounds(choices) : "Sounds" : 0 = 
+	[
+		0: "None"
+		1: "Big zap & Warmup"
+		2: "Access Denied"
+		3: "Access Granted"
+		4: "Quick Combolock"
+		5: "Power Deadbolt 1"
+		6: "Power Deadbolt 2"
+		7: "Plunger"
+		8: "Small zap"
+		9: "Keycard Sound"
+		21: "Squeaky"
+		22: "Squeaky Pneumatic"
+		23: "Ratchet Groan"
+		24: "Clean Ratchet"
+		25: "Gas Clunk"
+	]
+	distance(integer) : "Distance" : 90 : "The maximum amount, in degrees, that the wheel is allowed to rotate."
+	returnspeed(integer) : "Auto-return speed" : 0 : "If the 'Toggle' spawnflag is not set, the speed at which the wheel auto-returns when left alone, in degrees per second."
+	spawnflags(flags) =
+	[
+		1: "Not Solid" : 1
+		32: "Toggle (Disable Auto Return)" : 1
+		64: "X Axis" : 0
+		128: "Y Axis" : 0
+		1024: "Use Activates" : 1
+		2048: "Starts locked" : 0
+		8192: "Jiggle when used while locked" : 0
+	]
+	_minlight(string) : "Minimum Light Level" : : "The minimum level of ambient light that hits this brush."
+	startposition(float) : "Start Position" : 0 : "Postion when spawned. The value is a range between 0.0 and 1.0, where 0 is the unrotated position and 1 is the rotated position + 'Distance'."
+	startdirection(choices) : "Start Direction" : "Forward" =
+	[
+		-1 : "Forward"		 // Reverses upon USE, so are
+		1 : "Backward"	 // reversed here.
+	]
+	solidbsp(choices) : "Solid BSP" : 0 =
+	[
+		0 : "No"
+		1 : "Yes"
+	]	
+
+	usehint(choices) : "Use Hint" : 1 : "Show a visual indicator for this button?" =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+	usehinttext(string) : "Use Hint Text" : "Text to display with the hint"
+
+	// Inputs
+	input Lock(void) : "Lock the button, preventing it from functioning."
+	input Unlock(void) : "Unlock the button, allowing it to function."
+	input SetPosition(string) : "Move to a position. The parameter must be a value between 0 and 1, where 0 is the unrotated position and 1 is the rotated position + 'Distance'."
+	input SetPositionImmediately(string) : "Immediately teleport to a position. The parameter must be a value between 0 and 1, where 0 is the unrotated position and 1 is the rotated position + 'Distance'."
+
+	// Outputs
+	output Position(integer)   : "Fired whenever the button moves. The output is the position of button from 0 to 1, where 0 is the unrotated position and 1 is the rotated position + 'Distance'."
+	output OnPressed(integer)  : "Fired when the button is first pressed."
+	output OnUnpressed(integer): "Fired when the button is first released from being pressed."
+	output OnFullyClosed(void) : "Fired when the button has reached position 1, the rotated position + 'Distance'."
+	output OnFullyOpen(void)   : "Fired when the button has reached position 0, the unrotated starting position."
+	output OnReachedPosition(void)   : "Fired whenever the button reaches a goal position: i.e. when it becomes open, becomes closed, or reaches the point specified by a 'SetPosition' input."
+]
+

--- a/src/game/client/c_buttons.cpp
+++ b/src/game/client/c_buttons.cpp
@@ -8,6 +8,8 @@ LINK_ENTITY_TO_CLASS(func_button, C_BaseButton);
 
 IMPLEMENT_CLIENTCLASS_DT( C_BaseButton, DT_BaseButton, CBaseButton )
 	RecvPropInt( RECVINFO(m_spawnflags) ),
+	RecvPropString( RECVINFO(m_szUseHintText) ),
+	RecvPropBool( RECVINFO(m_bUseHint) )
 END_RECV_TABLE()
 
 int C_BaseButton::ObjectCaps(void) {

--- a/src/game/client/c_buttons.h
+++ b/src/game/client/c_buttons.h
@@ -9,6 +9,8 @@ public:
 	DECLARE_CLIENTCLASS();
 
 	int m_spawnflags;
+	char m_szUseHintText[64];
+	bool m_bUseHint;
 	
 	virtual int	ObjectCaps(void) override;
 };

--- a/src/game/client/neo/ui/neo_hud_context_hint.cpp
+++ b/src/game/client/neo/ui/neo_hud_context_hint.cpp
@@ -13,6 +13,7 @@
 #include "neo_root_settings.h"
 #include "glow_outline_effect.h"
 #include "smoke_fog_overlay.h"
+#include "c_buttons.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -218,6 +219,31 @@ void CNEOHud_ContextHint::UpdateStateForNeoHudElementDraw()
 				else
 				{
 					V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"Hold [%hs] Boot into JGR56", szUppercaseKeyBinding);
+				}
+			}
+			// Buttons
+			else if (C_BaseButton* pButton = dynamic_cast<C_BaseButton*>(pUseEntity))
+			{
+				if (pButton->m_bUseHint)
+				{
+					if (pButton->m_szUseHintText[0] != '\0')
+					{
+						V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] %hs", szUppercaseKeyBinding, pButton->m_szUseHintText);
+						m_flDisplayEndTime = gpGlobals->curtime + 1.f;
+					}
+					else
+					{
+						V_snwprintf(m_wszHintText, ARRAYSIZE(m_wszHintText), L"[%hs] Use", szUppercaseKeyBinding);
+						m_flDisplayEndTime = gpGlobals->curtime + 1.f;
+					}
+				}
+				else
+				{
+					m_flDisplayEndTime = gpGlobals->curtime;
+					g_GlowObjectManager.ClearUseItem();
+					m_hUseEntity = INVALID_EHANDLE;
+					ClearUseEntityListEntry();
+					return;
 				}
 			}
 			// Some other useable entity

--- a/src/game/server/buttons.cpp
+++ b/src/game/server/buttons.cpp
@@ -47,6 +47,11 @@ BEGIN_DATADESC( CBaseButton )
 	DEFINE_FIELD( m_bSolidBsp, FIELD_BOOLEAN ),
 	
 	DEFINE_KEYFIELD( m_sounds, FIELD_INTEGER, "sounds" ),
+
+#ifdef NEO
+	DEFINE_KEYFIELD( m_szUseHintText, FIELD_STRING, "usehinttext" ),
+	DEFINE_KEYFIELD( m_bUseHint, FIELD_BOOLEAN, "usehint" ),
+#endif
 	
 //	DEFINE_FIELD( m_ls, FIELD_SOUNDNAME ),   // This is restored in Precache()
 //  DEFINE_FIELD( m_nState, FIELD_INTEGER ),
@@ -80,8 +85,16 @@ LINK_ENTITY_TO_CLASS( func_button, CBaseButton );
 
 #ifdef NEO
 IMPLEMENT_SERVERCLASS_ST( CBaseButton, DT_BaseButton )
-	SendPropInt( SENDINFO(m_spawnflags), 14, SPROP_UNSIGNED )
+	SendPropInt( SENDINFO(m_spawnflags), 14, SPROP_UNSIGNED ),
+	SendPropString( SENDINFO( m_szUseHintText ) ),
+	SendPropBool( SENDINFO( m_bUseHint ) )
 END_SEND_TABLE()
+
+
+CBaseButton::CBaseButton()
+{
+	m_bUseHint = true;
+}
 #endif // NEO
 
 
@@ -162,6 +175,13 @@ bool CBaseButton::KeyValue( const char *szKeyName, const char *szValue )
 	{
 		m_bUnlockedSentence = atof(szValue);
 	}
+#ifdef NEO
+	else if (FStrEq(szKeyName, "usehinttext"))
+	{
+		V_strncpy( m_szUseHintText.GetForModify(), szValue, sizeof( m_szUseHintText ) );
+		return true;
+	}
+#endif
 	else
 	{
 		return BaseClass::KeyValue( szKeyName, szValue );

--- a/src/game/server/buttons.h
+++ b/src/game/server/buttons.h
@@ -18,6 +18,8 @@ public:
 	DECLARE_CLASS( CBaseButton, CBaseToggle );
 #ifdef NEO
 	DECLARE_SERVERCLASS();
+
+	CBaseButton();
 #endif // NEO
 
 	void Spawn( void );
@@ -80,6 +82,11 @@ protected:
 	bool	m_bSolidBsp;
 
 	string_t	m_sNoise;			// The actual WAV file name of the sound.
+
+#ifdef NEO
+	CNetworkString( m_szUseHintText, 64 );
+	CNetworkVar( bool, m_bUseHint );
+#endif
 
 	COutputEvent m_OnDamaged;
 	COutputEvent m_OnPressed;


### PR DESCRIPTION
## Description
Set custom hint messages or disable contextual hints for buttons in maps. Hints are enabled by default if the KV is not set for compatibility with legacy maps

## Toolchain
- Windows MSVC VS2022

## Linked Issues
- related #1944 

