### PR TITLE
Fix death icon logic again

### DIFF
--- a/src/game/client/neo/ui/neo_hud_spectator_overlay.cpp
+++ b/src/game/client/neo/ui/neo_hud_spectator_overlay.cpp
@@ -368,7 +368,7 @@ void CNEOHud_SpectatorOverlay::UpdateStateForNeoHudElementDraw()
 						}
 
 						// Icons are really only 1 character long
-						Q_UTF8ToUnicode(pNeoWep->GetDeathIcon(DEATHICONTYPE_IDX),
+						Q_UTF8ToUnicode(CNEOBaseCombatWeapon::GetDeathIcon(pNeoWep, DEATHICONTYPE_IDX),
 								wszWeaponIcon, sizeof(wszWeaponIcon));
 						pCard->wcaWeaponIcons[pCard->iTotalWeaponIcons++] = wszWeaponIcon[0];
 					}

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -4351,9 +4351,9 @@ void CNEORules::DeathNotice(CBasePlayer* pVictim, const CTakeDamageInfo& info)
 		event->SetInt("priority", 7);
 		event->SetBool("headshot", pVictim->LastHitGroup() == HITGROUP_HEAD);
 		event->SetBool("suicide", pKiller == pVictim || !pKiller->IsPlayer());
-		event->SetString("deathIcon", neoWep
-				? neoWep->GetDeathIcon(DEATHICONTYPE_BOOLS, isGrenade, isRemoteDetpack)
-				: "");
+		event->SetString("deathIcon",
+				CNEOBaseCombatWeapon::GetDeathIcon(
+					neoWep, DEATHICONTYPE_BOOLS, isGrenade, isRemoteDetpack));
 		event->SetBool("explosive", isGrenade || isRemoteDetpack);
 		event->SetBool("ghoster", m_iGhosterPlayer == pVictim->entindex());
 

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -1407,13 +1407,13 @@ void CNEOBaseCombatWeapon::Use(CBaseEntity* pActivator, CBaseEntity* pCaller, US
 }
 #endif
 
-const char *CNEOBaseCombatWeapon::GetDeathIcon(const EDeathIconType eType,
-		bool isGrenade, bool isRemoteDetpack) const
+const char *CNEOBaseCombatWeapon::GetDeathIcon(const CNEOBaseCombatWeapon *pNeoWep,
+		const EDeathIconType eType, bool isGrenade, bool isRemoteDetpack)
 {
-	if (eType == DEATHICONTYPE_IDX)
+	if (eType == DEATHICONTYPE_IDX && pNeoWep)
 	{
-		isGrenade = WeaponIndex() == NEO_WIDX_FRAG_GRENADE;
-		isRemoteDetpack = WeaponIndex() == NEO_WIDX_DETPACK;
+		isGrenade = pNeoWep->WeaponIndex() == NEO_WIDX_FRAG_GRENADE;
+		isRemoteDetpack = pNeoWep->WeaponIndex() == NEO_WIDX_DETPACK;
 	}
 
 	if (isGrenade)
@@ -1424,6 +1424,10 @@ const char *CNEOBaseCombatWeapon::GetDeathIcon(const EDeathIconType eType,
 	{
 		return "A";
 	}
-	return GetNEOWpnData().szDeathIcon;
+	else if (pNeoWep)
+	{
+		return pNeoWep->GetNEOWpnData().szDeathIcon;
+	}
+	return "";
 }
 

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -266,8 +266,9 @@ public:
 	int m_spawnflags;
 #endif // CLIENT_DLL
 	
-	const char *GetDeathIcon(const EDeathIconType eType,
-			bool isGrenade = false, bool isRemoteDetpack = false) const;
+	static const char *GetDeathIcon(const CNEOBaseCombatWeapon *pNeoWep,
+			const EDeathIconType eType,
+			bool isGrenade = false, bool isRemoteDetpack = false);
 
 protected:
 	WeaponHandlingInfo_t m_weaponHandling;


### PR DESCRIPTION


<!--
Before submitting a pull request, ensure the following has been done:
* The branch has been tested with the latest master changes rebased in
* Fill in the descriptions, link the issues, and put in tags appropriate to the PR
* Update any documentation and comments if needed
* For WIP/Work in Progress PRs, use the Draft PR feature
-->

## Description
Nade kill post-death won't have active weapon so weapon pointer check cannot be first but rather after grenade kills.

## Toolchain
<!--
If this is documentation only update, just remove the whole Toolchain section
NOTE: It's not needed for all to be filled in, just keep the toolchain/OS lines this PR been worked on
- Windows MSVC VS2022
-->
- Linux GCC Distro Native Arch/GCC 16


