### PR TITLE
Reset the player animation state when the model changes

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -1853,6 +1853,29 @@ void CHL2MP_Player::DoAnimationEvent( PlayerAnimEvent_t event, int nData )
 	TE_PlayerAnimEvent( this, event, nData );	// Send to any clients who can see this guy.
 }
 
+#ifdef NEO
+//-----------------------------------------------------------------------------
+// Purpose: Server-side mirror of C_HL2MP_Player::OnNewModel. The animation state
+//			caches per-model data (pose parameters, gesture slots, the aim-layer
+//			sequence transitioner), all of which is invalid once the model changes -
+//			CNEO_Player::SetPlayerTeamModel swaps models on spawn, class change and
+//			round restart. Only the client had this hook, so the server kept animating
+//			the new model against the old model's state.
+//-----------------------------------------------------------------------------
+CStudioHdr *CHL2MP_Player::OnNewModel( void )
+{
+	CStudioHdr *hdr = BaseClass::OnNewModel();
+
+	// Reset the players animation states, gestures
+	if ( m_PlayerAnimState )
+	{
+		m_PlayerAnimState->OnNewModel();
+	}
+
+	return hdr;
+}
+#endif
+
 //-----------------------------------------------------------------------------
 // Purpose: Override setup bones so that is uses the render angles from
 //			the HL2MP animation state to setup the hitboxes.

--- a/src/game/server/hl2mp/hl2mp_player.h
+++ b/src/game/server/hl2mp/hl2mp_player.h
@@ -64,6 +64,12 @@ public:
 	void			SetupBones( matrix3x4_t *pBoneToWorld, int boneMask );
 	// TODO (nullsystem): 2025-02-18 SOURCE SDK 2013 CHECK - END
 
+#ifdef NEO
+	// Mirrors C_HL2MP_Player::OnNewModel: the animation state must drop its per-model
+	// cache when the model changes, on the server as well as the client.
+	virtual CStudioHdr *OnNewModel( void ) OVERRIDE;
+#endif
+
 	DECLARE_ENT_SCRIPTDESC();
 
 	virtual void Precache( void );

--- a/src/game/shared/Multiplayer/multiplayer_animstate.cpp
+++ b/src/game/shared/Multiplayer/multiplayer_animstate.cpp
@@ -2619,5 +2619,14 @@ void CMultiPlayerAnimState::OnNewModel( void )
 {
 	m_bPoseParameterInit = false;
 	m_PoseParameterData.Init();
+#ifdef NEO
+	// NEO: a sequence index is only meaningful for the model it was computed against.
+	// The aim-layer transitioner keeps the previous sequence in its animation queue so
+	// it can blend out of it; after a model swap that index addresses a foreign sequence
+	// table, and CheckForSequenceChange() hands it straight to CStudioHdr::pSeqdesc().
+	// Drop the queue along with the model - an empty queue simply snaps, which is what
+	// the transitioner already does for STUDIO_SNAP sequences.
+	m_IdleSequenceTransitioner.RemoveAll();
+#endif
 	ClearAnimationState();
 }


### PR DESCRIPTION
### Description
Aims to fix two asserts:
- `studio.cpp (941) : Assertion Failed: ( i >= 0 && i < GetNumSeq() ) || ( i == 1 && GetNumSeq() <= 1 )`
- `studio.h (1787) : Assertion Failed: 0`.

Player models are swapped on spawn, class change, team change, JGR takeover and round restart, but the animation state's aim-layer sequence transitioner keeps the sequence index it was blending from, and sequence indices are per-model.  On the next update that stale index is looked up in the new model's sequence table and lands out of range.

`CMultiPlayerAnimState::OnNewModel()` predates that transitioner and never cleared it, and the server had no `OnNewModel` override at all, so on the server the reset never ran. This clears the transitioner in `OnNewModel()` and adds the server-side `CHL2MP_Player::OnNewModel` mirroring the existing client one. An empty queue snaps instead of blending, which is what the transitioner already does for `STUDIO_SNAP` sequences and what `C_BaseAnimating::OnNewModel` already does with its own transitioner.

This is also likely behind the JGR takeover asserts, since `BecomeJuggernaut` changes the player's class and `SetPlayerTeamModel` picks the model from the class. This may lead to the same stale index surviving the same kind of swap, hence why #1381 is tagged as related.

### Toolchain
Windows MSVC VS2022

### Linked Issues
- fixes #1381