### PR TITLE
More !IsTeamplay fixes for DM

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_grenade_dispatch.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_grenade_dispatch.cpp
@@ -86,7 +86,7 @@ Action< CNEOBot > *CNEOBotGrenadeDispatch::ChooseGrenadeThrowBehavior( const CNE
 				continue;
 			}
 
-			if ( pPlayer->InSameTeam( me ) ) 
+			if ( !me->IsEnemy( pPlayer ) )
 			{
 				if ( !pPlayer->IsBot() && pPlayer->GetClass() != NEO_CLASS_SUPPORT )
 				{

--- a/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.cpp
@@ -351,9 +351,21 @@ ActionResult< CNEOBot > CNEOBotSeekAndDestroy::UpdateCommon( CNEOBot *me, float 
 
 	if ( !m_path.IsValid() )
 	{
-		m_repathTimer.Start( 45.0f );
+		if ( !m_repathFailTimer.HasStarted() || m_repathFailTimer.IsElapsed() )
+		{
+			m_repathTimer.Start( 45.0f );
 
-		RecomputeSeekPath( me );
+			RecomputeSeekPath( me );
+
+			if ( m_path.IsValid() )
+			{
+				m_repathFailTimer.Invalidate();
+			}
+			else
+			{
+				m_repathFailTimer.Start( 1.0f );
+			}
+		}
 	}
 	else if ( m_bInvestigateGunfire && (!m_soundSearchTimer.HasStarted() || m_soundSearchTimer.IsElapsed()) )
 	{

--- a/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.h
+++ b/src/game/server/neo/bot/behavior/neo_bot_seek_and_destroy.h
@@ -42,6 +42,7 @@ protected:
 
 	PathFollower m_path;
 	CountdownTimer m_repathTimer;
+	CountdownTimer m_repathFailTimer;
 	CountdownTimer m_soundSearchTimer;
 	CountdownTimer m_itemStolenTimer;
 	EHANDLE m_hTargetEntity;

--- a/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_tactical_monitor.cpp
@@ -212,6 +212,11 @@ void CNEOBotTacticalMonitor::AvoidBumpingFriends( CNEOBot *me )
 {
 	const float avoidRange = 32.0f;
 
+	if ( !NEORules()->IsTeamplay() )
+	{
+		return;
+	}
+
 	CUtlVector< CNEO_Player * > friendVector;
 	CollectPlayers( &friendVector, me->GetTeamNumber(), COLLECT_ONLY_LIVING_PLAYERS );
 

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -1310,6 +1310,8 @@ public:
 	{
 		m_vantageArea = NULL;
 
+		m_enemies.EnsureCapacity(gpGlobals->maxClients - 1);
+
 		for (int i = 1; i <= gpGlobals->maxClients; ++i)
 		{
 			CNEO_Player* enemy = ToNEOPlayer(UTIL_PlayerByIndex(i));
@@ -1330,7 +1332,7 @@ public:
 
 		for (int i = 0; i < m_enemies.Count(); ++i)
 		{
-			CNavArea* enemyArea = (CNavArea*)m_enemies[i]->GetLastKnownArea();
+			CNavArea* enemyArea = m_enemies[i]->GetLastKnownArea();
 			if (enemyArea->IsCompletelyVisible(area))
 			{
 				// nearby area from which we can see an enemy

--- a/src/game/server/neo/bot/neo_bot.cpp
+++ b/src/game/server/neo/bot/neo_bot.cpp
@@ -1306,28 +1306,34 @@ void CNEOBot::UpdateLookingAroundForEnemies(void)
 class CFindVantagePoint : public ISearchSurroundingAreasFunctor
 {
 public:
-	CFindVantagePoint(int enemyTeamIndex)
+	CFindVantagePoint(const CNEOBot* me)
 	{
-		m_enemyTeamIndex = enemyTeamIndex;
 		m_vantageArea = NULL;
+
+		for (int i = 1; i <= gpGlobals->maxClients; ++i)
+		{
+			CNEO_Player* enemy = ToNEOPlayer(UTIL_PlayerByIndex(i));
+
+			if (!enemy || !me->IsEnemy(enemy))
+				continue;
+
+			if (!enemy->IsAlive() || !enemy->GetLastKnownArea())
+				continue;
+
+			m_enemies.AddToTail(enemy);
+		}
 	}
 
 	virtual bool operator() (CNavArea* baseArea, CNavArea* priorArea, float travelDistanceSoFar)
 	{
 		CNavArea* area = (CNavArea*)baseArea;
 
-		CTeam* enemyTeam = GetGlobalTeam(m_enemyTeamIndex);
-		for (int i = 0; i < enemyTeam->GetNumPlayers(); ++i)
+		for (int i = 0; i < m_enemies.Count(); ++i)
 		{
-			CNEO_Player* enemy = (CNEO_Player*)enemyTeam->GetPlayer(i);
-
-			if (!enemy->IsAlive() || !enemy->GetLastKnownArea())
-				continue;
-
-			CNavArea* enemyArea = (CNavArea*)enemy->GetLastKnownArea();
+			CNavArea* enemyArea = (CNavArea*)m_enemies[i]->GetLastKnownArea();
 			if (enemyArea->IsCompletelyVisible(area))
 			{
-				// nearby area from which we can see the enemy team
+				// nearby area from which we can see an enemy
 				m_vantageArea = area;
 				return false;
 			}
@@ -1336,16 +1342,16 @@ public:
 		return true;
 	}
 
-	int m_enemyTeamIndex;
+	CUtlVector< CNEO_Player* > m_enemies;
 	CNavArea* m_vantageArea;
 };
 
 
 //-----------------------------------------------------------------------------------------------------
-// Return a nearby area where we can see a member of the enemy team
+// Return a nearby area where we can see an enemy
 CNavArea* CNEOBot::FindVantagePoint(float maxTravelDistance) const
 {
-	CFindVantagePoint find(GetTeamNumber() == TEAM_JINRAI ? TEAM_NSF : TEAM_JINRAI);
+	CFindVantagePoint find(this);
 	SearchSurroundingAreas(GetLastKnownArea(), find, maxTravelDistance);
 	return find.m_vantageArea;
 }

--- a/src/game/server/neo/neo_player.cpp
+++ b/src/game/server/neo/neo_player.cpp
@@ -1340,9 +1340,10 @@ bool CNEO_Player::IsHiddenByFog(CBaseEntity* target) const
 		return false; // Not a player that is affected by cloaking/etc
 	}
 
-	if (GetTeamNumber() == targetPlayer->GetTeamNumber())
+	if (NEORules()->IsTeamplay() && GetTeamNumber() == targetPlayer->GetTeamNumber())
 	{
-		return false; // Teammates are always labeled with IFF
+		// Teammates are always labeled with IFF, unless in DM
+		return false;
 	}
 
 	// Check visibility cache for this player
@@ -3413,8 +3414,8 @@ int	CNEO_Player::OnTakeDamage_Alive(const CTakeDamageInfo& info)
 				flDmgAccumlator -= 1.0f;
 			}
 
-			// Mirror team-damage
-			const bool bIsTeamDmg = (attackerIdx != entindex() && attacker->GetTeamNumber() == GetTeamNumber());
+			// Mirror team-damage (unless in DM)
+			const bool bIsTeamDmg = (NEORules()->IsTeamplay() && attackerIdx != entindex() && attacker->GetTeamNumber() == GetTeamNumber());
 			if (bIsTeamDmg)
 			{
 				const float flMirrorMult = NEORules()->MirrorDamageMultiplier();
@@ -3458,7 +3459,7 @@ int	CNEO_Player::OnTakeDamage_Alive(const CTakeDamageInfo& info)
 					++m_iBotDetectableBleedingInjuryEvents;
 				}
 
-				if (bIsTeamDmg && NEORules()->IsTeamplay() && attacker->IsBot() && (info.GetDamageType() & botDamageTypes))
+				if (bIsTeamDmg && attacker->IsBot() && (info.GetDamageType() & botDamageTypes))
 				{
 					attacker->m_botPauseFiringTimer.Start(1.0f);
 				}

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -953,7 +953,7 @@ void CNEORules::GetDMHighestScorers(
 		return;
 	}
 
-	for (int i = 0; i < (MAX_PLAYERS + 1); ++i)
+	for (int i = 1; i < (MAX_PLAYERS + 1); ++i)
 #endif
 	{
 		int iXP = 0;
@@ -964,27 +964,31 @@ void CNEORules::GetDMHighestScorers(
 		{
 			continue;
 		}
+		if (pCmpPlayer->GetTeamNumber() < FIRST_GAME_TEAM)
+		{
+			continue;
+		}
 		iXP = pCmpPlayer->m_iXP;
 #else
-		if (!g_PR->IsConnected(i))
+		if (!g_PR->IsConnected(i) || g_PR->GetTeam(i) < FIRST_GAME_TEAM)
 		{
 			continue;
 		}
 		iXP = g_PR->GetXP(i);
 #endif
 
-		if (iXP == *iHighestXP)
+		if (*iHighestPlayersTotal == 0 || iXP > *iHighestXP)
 		{
+			*iHighestPlayersTotal = 0;
+			*iHighestXP = iXP;
 #ifdef GAME_DLL
 			(*pHighestPlayers)[(*iHighestPlayersTotal)++] = pCmpPlayer;
 #else
 			(*iHighestPlayersTotal)++;
 #endif
 		}
-		else if (iXP > *iHighestXP)
+		else if (iXP == *iHighestXP)
 		{
-			*iHighestPlayersTotal = 0;
-			*iHighestXP = iXP;
 #ifdef GAME_DLL
 			(*pHighestPlayers)[(*iHighestPlayersTotal)++] = pCmpPlayer;
 #else
@@ -1419,6 +1423,10 @@ void CNEORules::Think(void)
 				return;
 			}
 			// Otherwise go into overtime
+			if (m_nRoundStatus == NeoRoundStatus::RoundLive)
+			{
+				m_nRoundStatus = NeoRoundStatus::Overtime;
+			}
 		}
 		else if (GetGameType() == NEO_GAME_TYPE_JGR)
 		{
@@ -2682,8 +2690,12 @@ void CNEORules::StartNextRound()
 	const int iThres = sv_neo_readyup_teamplayersthres.GetInt();
 	const bool bEqualThres = (iThres == GetGlobalTeam(TEAM_JINRAI)->GetNumPlayers()) && (iThres == GetGlobalTeam(TEAM_NSF)->GetNumPlayers());
 	const auto readyPlayers = FetchReadyPlayers();
+	// Handle case where everyone joins same team in DM
+	const bool bTooFewToStart = IsTeamplay()
+			? (GetGlobalTeam(TEAM_JINRAI)->GetNumPlayers() == 0 || GetGlobalTeam(TEAM_NSF)->GetNumPlayers() == 0)
+			: ((GetGlobalTeam(TEAM_JINRAI)->GetNumPlayers() + GetGlobalTeam(TEAM_NSF)->GetNumPlayers()) < 2);
 	// Do not start if: Non-ready-up mode, no players in either teams
-	if ((!bLobby && (GetGlobalTeam(TEAM_JINRAI)->GetNumPlayers() == 0 || GetGlobalTeam(TEAM_NSF)->GetNumPlayers() == 0))
+	if ((!bLobby && bTooFewToStart)
 			// If ready-up mode and doesn't exactly match the threshold on ready-up or players
 			|| (bLobby && !m_bIgnoreOverThreshold && (!bEqualThres || (readyPlayers.array[TEAM_JINRAI] != iThres || readyPlayers.array[TEAM_NSF] != iThres)))
 			// If ready-up mode, allows over threshold and is lower than threshold or not equal teams
@@ -3666,6 +3678,11 @@ bool CNEORules::RoundIsInSuddenDeath() const
 #ifdef CLIENT_DLL
 	return m_bIsInSuddenDeath;
 #else
+	if (!GetTeamPlayEnabled())
+	{
+		return false;
+	}
+
 	auto teamJinrai = GetGlobalTeam(TEAM_JINRAI);
 	auto teamNSF = GetGlobalTeam(TEAM_NSF);
 	if (teamJinrai && teamNSF)
@@ -3681,6 +3698,11 @@ bool CNEORules::RoundIsMatchPoint() const
 #ifdef CLIENT_DLL
 	return m_bIsMatchPoint;
 #else
+	if (!GetTeamPlayEnabled())
+	{
+		return false;
+	}
+
 	auto teamJinrai = GetGlobalTeam(TEAM_JINRAI);
 	auto teamNSF = GetGlobalTeam(TEAM_NSF);
 	if (teamJinrai && teamNSF && GetRoundLimit() != 0)
@@ -3700,6 +3722,11 @@ bool CNEORules::RoundIsDoOrDie() const
 #ifdef CLIENT_DLL
 	return m_bIsDoOrDie;
 #else
+	if (!GetTeamPlayEnabled())
+	{
+		return false;
+	}
+
 	auto teamJinrai = GetGlobalTeam(TEAM_JINRAI);
 	auto teamNSF = GetGlobalTeam(TEAM_NSF);
 	if (teamJinrai && teamNSF && GetRoundLimit() != 0)
@@ -3990,6 +4017,12 @@ static CNEO_Player* FetchAssists(CNEO_Player* attacker, CNEO_Player* victim)
 			continue;
 		}
 
+		// Never credit the victim with assisting their own death
+		if (assistIdx == victim->entindex())
+		{
+			continue;
+		}
+
 		const int assistDmg = victim->m_riAttackersScores[assistIdx];
 		static const float MIN_DMG_QUALIFY_ASSIST = 0.5f;
 		if ((float)assistDmg / victim->GetMaxHealth() >= MIN_DMG_QUALIFY_ASSIST)
@@ -4145,7 +4178,7 @@ void CNEORules::PlayerKilled(CBasePlayer *pVictim, const CTakeDamageInfo &info)
 	if (auto *assister = FetchAssists(attacker, victim))
 	{
 		// Team kill assist
-		if (assister->GetTeamNumber() == victim->GetTeamNumber())
+		if (IsTeamplay() && assister->GetTeamNumber() == victim->GetTeamNumber())
 		{
 			if (sv_neo_teamdamage_assists.GetBool())
 			{

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -977,8 +977,9 @@ void CNEORules::GetDMHighestScorers(
 		iXP = g_PR->GetXP(i);
 #endif
 
-		if (*iHighestPlayersTotal == 0 || iXP > *iHighestXP)
+		if (iXP > *iHighestXP)
 		{
+			// Higher top score found, clear previous count based on lower top score threshold
 			*iHighestPlayersTotal = 0;
 			*iHighestXP = iXP;
 #ifdef GAME_DLL


### PR DESCRIPTION
## Description
* Fixed the client deathmatch scorer scanning invalid player slot 0.
* Fixed deathmatch timelimit handling so stopped matches correctly enter overtime status.
* Fixed deathmatch round startup when all players choose the same cosmetic team.
* Disabled team-based match-point, sudden-death, and do-or-die checks in free-for-all modes.
* Fixed deathmatch assists being incorrectly treated as team damage.
* Fixed `FetchAssists` from counting the victim as their own assister and from missing valid assisters.
* Fixed friendly-fire, mirrored damage, auto-kick tracking, and spawn immunity incorrectly applying between deathmatch opponents.
* Fixed bots incorrectly seeing same-team deathmatch opponents through thermoptic camo.
* Fixed bot vantage-point searches from excluding opponents who share the bot's cosmetic team.
* Fixed bots unnecessarily avoiding collisions with deathmatch opponents.
* Fixed smoke-grenade behavior from treating same-team deathmatch opponents as allies.
* Optimized bot vantage-point searches by collecting the enemy list once instead of rescanning players for every candidate nav area.
* Fixed bots repeatedly retrying failed seek-and-destroy pathfinding every tick by adding a one-second retry backoff after failed searches.
* Added regression coverage confirming deathmatch scoring and match flow, including ties, and single-team cosmetic selections.
* Added CTG regression coverage for shared teamplay logic, including round transitions, assists, damage handling, and bot behavior.

## Toolchain
- Windows MSVC VS2022


