### PR TITLE
Bots seek enemy after capturing ghost

### DIFF
--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_carrier.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_carrier.cpp
@@ -381,6 +381,11 @@ ActionResult< CNEOBot >	CNEOBotCtgCarrier::Update( CNEOBot *me, float interval )
 		return Done( "No longer carrying the ghost" );
 	}
 	
+	if ( NEORules()->IsRoundOver() )
+	{
+		return Done( "Round Over: no CTG objectives to reach" );
+	}
+
 	m_teammates.RemoveAll();
 	CollectPlayers( me, &m_teammates );
 

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_escort.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_escort.cpp
@@ -54,6 +54,11 @@ ActionResult< CNEOBot >	CNEOBotCtgEscort::Update( CNEOBot *me, float interval )
 		return Done( "Ghost carrier is not a teammate anymore" );
 	}
 	
+	if ( NEORules()->IsRoundOver() )
+	{
+		return Done( "Round Over: seek enemies instead of escorting CTG carrier" );
+	}
+
 	if ( m_repathTimer.IsElapsed() )
 	{
 		UpdateGoalPosition( me, pGhostCarrier );

--- a/src/game/server/neo/bot/behavior/neo_bot_ctg_seek.cpp
+++ b/src/game/server/neo/bot/behavior/neo_bot_ctg_seek.cpp
@@ -19,6 +19,11 @@ ActionResult< CNEOBot > CNEOBotCtgSeek::Update( CNEOBot *me, float interval )
 		return Done( "Game mode is no longer CTG" );
 	}
 
+	if (NEORules()->IsRoundOver())
+	{
+		return Done( "Round Over: CTG objective no longer relevant" );
+	}
+
 	ActionResult< CNEOBot > result = UpdateCommon( me, interval );
 	if ( result.IsRequestingChange() || result.IsDone() )
 	{


### PR DESCRIPTION
## Description
After a team captures the objective in CTG mode, they can get into a buggy state where they are trying to pursue the objective, but there are no relevant objectives between round end and the next round start.  This behavior end for the related CTG behaviors allows the bots to look for enemies between that time period, which can help bots score some interim points.

## Toolchain
- Windows MSVC VS2022
