### PR TITLE
Fix bogus ghost angles on ghoster disconnect

### DIFF
--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -4408,13 +4408,8 @@ void CNEORules::ClientDisconnected(edict_t* pClient)
 		auto ghost = GetNeoWepWithBits(pNeoPlayer, NEO_WEP_GHOST);
 		if (ghost)
 		{
-			// NEO JANK (nullsystem): Teleport so that disconnected player don't noclips the ghost?
-			Vector stillVec{0.0f, 0.0f, 0.0f};
-			ghost->Drop(stillVec);
+			ghost->Drop(vec3_origin);
 			pNeoPlayer->Weapon_Detach(ghost);
-			Vector origin = ghost->GetAbsOrigin();
-			ghost->Teleport(&origin, nullptr, NULL);
-			ghost->SetMoveType(MOVETYPE_FLYGRAVITY);
 		}
 		pNeoPlayer->RemoveAllWeapons();
 

--- a/src/game/shared/neo/neo_gamerules.cpp
+++ b/src/game/shared/neo/neo_gamerules.cpp
@@ -4410,11 +4410,10 @@ void CNEORules::ClientDisconnected(edict_t* pClient)
 		{
 			// NEO JANK (nullsystem): Teleport so that disconnected player don't noclips the ghost?
 			Vector stillVec{0.0f, 0.0f, 0.0f};
-			QAngle angles;
 			ghost->Drop(stillVec);
 			pNeoPlayer->Weapon_Detach(ghost);
 			Vector origin = ghost->GetAbsOrigin();
-			ghost->Teleport(&origin, &angles, NULL);
+			ghost->Teleport(&origin, nullptr, NULL);
 			ghost->SetMoveType(MOVETYPE_FLYGRAVITY);
 		}
 		pNeoPlayer->RemoveAllWeapons();

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -350,6 +350,19 @@ void CNEOBaseCombatWeapon::Activate(void)
 #endif
 }
 
+void CNEOBaseCombatWeapon::Detach()
+{
+	BaseClass::Detach();
+
+	RemoveEffects(EF_BONEMERGE | EF_BONEMERGE_FASTCULL);
+	SetParent(nullptr);
+	SetOwnerEntity(nullptr);
+	SetAbsAngles(vec3_angle);
+	SetMoveType(MOVETYPE_VPHYSICS);
+	RemoveSolidFlags(FSOLID_NOT_SOLID);
+	SetCollisionGroup(COLLISION_GROUP_WEAPON);
+}
+
 #ifdef CLIENT_DLL
 void CNEOBaseCombatWeapon::ClientThink()
 {

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.h
@@ -135,6 +135,7 @@ public:
 	virtual void Precache() override;
 	virtual void Spawn() override;
 	virtual void Activate() override;
+	virtual void Detach() override;
 
 #ifdef CLIENT_DLL
 	virtual void ClientThink() override;


### PR DESCRIPTION
## Description
Fix a problem with the ghost being set to uninitialized QAngles if the ghoster disconnects mid-round.

81834151 fixes the bad angles case, but I decided to follow it up with 9c95ac29 to simplify the code path.

Also should be careful not to regress #502 with this; I briefly tested the 3 cases of:

* spawned/respawned ghost not floating in the air
* ghost detaching to world properly when the ghoster:
  * dies
  * disconnects/is kicked

## Steps to reproduce

* For c6ff0807 (HEAD before this PR), set breakpoint at line: https://github.com/NeotokyoRebuild/neo/blob/c6ff080778e1d19dda672b6f551b9df91de41d08/src/game/shared/neo/neo_gamerules.cpp#L4414
* Launch a CTG map with bots
* Wait for any bot to pick up the ghost
* Use `neo_bot_kick all;` to kick the bot currently holding the ghost
* Observe `QAngle angles` local variable value as the breakpoint is hit

### What happens

* The `QAngle angles` local variable's value is uninitialized (or NaN if `VECTOR_PARANOIA`)
* The `Teleport` call trashes ghost angles with the bad `angles` value
* Furthermore, after continuing execution after the breakpoint, `IsEntityQAngleReasonable` may or may not fail (depending on what the `angles` ended up being), at: https://github.com/NeotokyoRebuild/neo/blob/c6ff080778e1d19dda672b6f551b9df91de41d08/src/game/server/baseentity.cpp#L6819-L6827

### What should happen

* Ghost angles are not trashed when the ghoster disconnects

## Toolchain
- Windows MSVC VS2022

## Linked Issues


